### PR TITLE
[forked -> master -> v0.9.0] Retrieved the LocalMode config in VSL from the input config map of plugin init function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,16 +140,13 @@ astrolabe: build-dirs copy-pkgs build-image
 		-w /go/src/$(ASTROLABE) \
 		$(BUILDER_IMAGE) \
 		make
-VDDK_FILES_TO_COPY = libdiskLibPlugin.so libgvmomi.so libssoclient.so libvim-types.so libvixDiskLib.so libvixDiskLib.so.6 \
-libvixDiskLib.so.6.7.0 libvixDiskLibVim.so libvixDiskLibVim.so.6 libvixDiskLibVim.so.6.7.0 libvixMntapi.so libvixMntapi.so.1 \
-libvixMntapi.so.1.1.0 libvmacore.so libvmomi.so
 
 container-name:
 	@echo "container: $(IMAGE):$(VERSION)"
 
 copy-vix-libs:
 	mkdir -p _output/bin/$(GOOS)/$(GOARCH)/lib/vmware-vix-disklib/lib64
-	for lib in $(VDDK_FILES_TO_COPY); do cp -f $(VDDK_LIBS)/$$lib _output/bin/$(GOOS)/$(GOARCH)/lib/vmware-vix-disklib/lib64; done
+	cp -R $(VDDK_LIBS)/* _output/bin/$(GOOS)/$(GOARCH)/lib/vmware-vix-disklib/lib64
 
 copy-install-script:
 	cp $$(pwd)/scripts/install.sh _output/bin/$(GOOS)/$(GOARCH)

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -181,7 +181,9 @@ func newServer(f client.Factory, config serverConfig, logger *logrus.Logger) (*s
 		return nil, err
 	}
 
-	snapshotmgr, err := snapshotmgr.NewSnapshotManagerFromCluster(logger)
+	snapshotMgrConfig := make(map[string]string)
+	snapshotMgrConfig[utils.VolumeSnapshotterManagerLocation] = utils.VolumeSnapshotterDataServer
+	snapshotmgr, err := snapshotmgr.NewSnapshotManagerFromCluster(snapshotMgrConfig, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/plugin/volume_snapshotter_plugin.go
+++ b/pkg/plugin/volume_snapshotter_plugin.go
@@ -17,6 +17,7 @@
 package plugin
 
 import (
+	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/utils"
 	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -67,8 +68,12 @@ func (p *NewVolumeSnapshotter) Init(config map[string]string) error {
 
 	// Initializing snapshot manager
 	p.Infof("Initializing snapshot manager")
+	if config == nil {
+		config = make(map[string]string)
+	}
+	config[utils.VolumeSnapshotterManagerLocation] = utils.VolumeSnapshotterPlugin
 	var err error
-	p.snapMgr, err = snapshotmgr.NewSnapshotManagerFromCluster(p.FieldLogger)
+	p.snapMgr, err = snapshotmgr.NewSnapshotManagerFromCluster(config, p.FieldLogger)
 	if err != nil {
 		p.Errorf("Failed at calling snapshotmgr.NewSnapshotManagerFromConfigFile with error message: %v", err)
 		return err

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -17,3 +17,15 @@ const (
 	// Duration after which Reflector resyncs CRs and calls UpdateFunc on each of the existing CRs.
 	ResyncPeriod = 30 * time.Second
 )
+
+// configuration constants for the volume snapshot plugin
+const (
+	// The key of SnapshotManager mode for data movement. Specifically, boolean string values are expected.
+	// By default, it is "false". No data movement from local to remote storage if "true" is set.
+	VolumeSnapshotterLocalMode = "LocalMode"
+	// The key of SnapshotManager location
+	VolumeSnapshotterManagerLocation = "SnapshotManagerLocation"
+	// Valid values for the config with the VolumeSnapshotterManagerLocation key
+	VolumeSnapshotterPlugin = "Plugin"
+	VolumeSnapshotterDataServer = "DataServer"
+)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,32 +1,23 @@
 package utils
 
 import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	"github.com/vmware-tanzu/astrolabe/pkg/ivd"
+	"github.com/vmware-tanzu/astrolabe/pkg/s3repository"
+	v1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"net/url"
+	"os"
+	"strconv"
 	"strings"
 	"github.com/vmware-tanzu/velero/pkg/generated/clientset/versioned"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
-
-func RetrieveBackupStorageLocation(params map[string]interface{}, logger logrus.FieldLogger) error {
-	config, err := rest.InClusterConfig()
-	if err != nil {
-		return err
-	}
-
-	veleroClient, err := versioned.NewForConfig(config)
-	if err != nil {
-		return err
-	}
-	defaultBackupLocation := "default"
-	backupStorageLocation, err := veleroClient.VeleroV1().BackupStorageLocations("velero").
-		Get(defaultBackupLocation, metav1.GetOptions{})
-	params["region"] = backupStorageLocation.Spec.Config["region"]
-	params["bucket"] = backupStorageLocation.Spec.ObjectStorage.Bucket
-
-	return nil
-}
 
 /*
  * In the CSI setup, VC credential is stored as a secret
@@ -66,15 +57,148 @@ func RetrieveVcConfigSecret(params map[string]interface{}, logger logrus.FieldLo
 			params[key] = value[1 : len(value)-1]
 		}
 	}
+
 	return nil
 }
 
+/*
+ * Retrieve the Volume Snapshot Location(VSL) as the remote storage location
+ * for the data manager component in plugin from the Backup Storage Locations(BSLs)
+ * of Velero. It will always pick up the first available one.
+ */
+func RetrieveVSLFromVeleroBSLs(params map[string]interface{}, logger logrus.FieldLogger) error {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return err
+	}
 
-func RetrieveVcConfigSecretByHardCoding(params map[string]interface{}, logger logrus.FieldLogger) error {
-	params["VirtualCenter"] = "10.193.45.3"
-	params["port"] = "443"
-	params["user"] = "Administrator@vsphere.local"
-	params["password"] = "Admin!23"
-	params["insecure-flag"] = "true"
+	veleroClient, err := versioned.NewForConfig(config)
+	if err != nil {
+		return err
+	}
+
+	veleroNs, exist := os.LookupEnv("VELERO_NAMESPACE")
+	if !exist {
+		logger.Errorf("RetrieveVSLFromVeleroBSLs: Failed to lookup the env variable for velero namespace")
+		return err
+	}
+
+	defaultBackupLocation := "default"
+	var backupStorageLocation *v1.BackupStorageLocation
+	backupStorageLocation, err = veleroClient.VeleroV1().BackupStorageLocations(veleroNs).
+		Get(defaultBackupLocation, metav1.GetOptions{})
+
+	if err != nil {
+		logger.Infof("RetrieveVSLFromVeleroBSLs: Failed to get Velero default backup storage location with error message: %v", err)
+		backupStorageLocationList, err := veleroClient.VeleroV1().BackupStorageLocations(veleroNs).List(metav1.ListOptions{})
+		if err != nil || len(backupStorageLocationList.Items) <= 0 {
+			logger.Errorf("RetrieveVSLFromVeleroBSLs: Failed to list Velero default backup storage location with error message: %v", err)
+			return err
+		}
+		// Select the first valid BackupStorageLocation from the list if there is no default BackupStorageLocation.
+		logger.Infof("RetrieveVSLFromVeleroBSLs: Picked up the first valid BackupStorageLocation from the BackupStorageLocationList")
+		for _, item := range backupStorageLocationList.Items {
+			backupStorageLocation = &item
+			provider := strings.ToLower(item.Spec.Provider)
+			if provider != "aws" {
+				logger.Warnf("RetrieveVSLFromVeleroBSLs: Object store providers, %v, other than AWS are not supported for the moment", provider)
+				continue
+			}
+			region := backupStorageLocation.Spec.Config["region"]
+			if region == "" {
+				logger.Warnf("RetrieveVSLFromVeleroBSLs: The region field is missing in the Backup Storage Location. Skiping.")
+				continue
+			}
+		}
+	}
+
+	if backupStorageLocation == nil {
+		return errors.New("RetrieveVSLFromVeleroBSLs: No valid Backup Storage Location can be retrieved")
+	}
+
+	params["region"] = backupStorageLocation.Spec.Config["region"]
+	params["bucket"] = backupStorageLocation.Spec.ObjectStorage.Bucket
+
 	return nil
+}
+
+func GetIVDPETMFromParamsMap(params map[string]interface{}, logger logrus.FieldLogger) (*ivd.IVDProtectedEntityTypeManager, error) {
+	var vcUrl url.URL
+	vcUrl.Scheme = "https"
+	vcHostStr, ok := params["VirtualCenter"].(string)
+	if !ok {
+		return nil, errors.New("Missing vcHost param, cannot initialize IVD PETM")
+	}
+	vcHostPortStr, ok := params["port"].(string)
+	if !ok {
+		return nil, errors.New("Missing port param, cannot initialize IVD PETM")
+	}
+
+	vcUrl.Host = fmt.Sprintf("%s:%s", vcHostStr, vcHostPortStr)
+
+	vcUser, ok := params["user"].(string)
+	if !ok {
+		return nil, errors.New("Missing vcUser param, cannot initialize IVD PETM")
+	}
+	vcPassword, ok := params["password"].(string)
+	if !ok {
+		return nil, errors.New("Missing vcPassword param, cannot initialize IVD PETM")
+	}
+	vcUrl.User = url.UserPassword(vcUser, vcPassword)
+	vcUrl.Path = "/sdk"
+
+	insecure := false
+	insecureStr, ok := params["insecure-flag"].(string)
+	if ok && (insecureStr == "TRUE" || insecureStr == "true") {
+		insecure = true
+	}
+
+	s3URLBase := "VOID_URL"
+
+	ivdPETM, err := ivd.NewIVDProtectedEntityTypeManagerFromURL(&vcUrl, s3URLBase, insecure, logger)
+	if err != nil {
+		logger.Errorf("Error at creating new IVD PETM")
+		return nil, err
+	}
+
+	return ivdPETM, nil
+}
+
+func GetS3PETMFromParamsMap(params map[string]interface{}, logger logrus.FieldLogger) (*s3repository.ProtectedEntityTypeManager, error) {
+	serviceType := "ivd"
+	region, ok := params["region"].(string)
+	if !ok {
+		return nil, errors.New("Missing region param, cannot initialize S3 PETM")
+	}
+
+	bucket, ok := params["bucket"].(string)
+	if !ok {
+		return nil, errors.New("Missing bucket param, cannot initialize S3 PETM")
+	}
+
+	sess := session.Must(session.NewSession(&aws.Config{
+		Region: aws.String(region),
+	}))
+
+	s3PETM, err := s3repository.NewS3RepositoryProtectedEntityTypeManager(serviceType, *sess, bucket, logger)
+	if err != nil {
+		logger.Errorf("Error at creating new S3 PETM")
+		return nil, err
+	}
+
+	return s3PETM, nil
+}
+
+func GetBool(str string, defValue bool) bool {
+	if str == "" {
+		return defValue
+	}
+
+	res, err := strconv.ParseBool(str)
+	if err != nil {
+		res = defValue
+		err = nil
+	}
+
+	return res
 }


### PR DESCRIPTION
Retrieved the LocalMode config in Velero VolumeSnapshotLocation(VSL) from the input config map of plugin init function. With this change, users don't have to always specify the default VSL as the command argument of velero pod container. Meanwhile, Modified the Makefile to include all VDDK libs to avoid the potential runtime error. 

The PR is expected to be merged to v0.9.0 branch via master branch.