### PR TITLE
Check VDDK directory before build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,12 @@ BUILDER_IMAGE := vsphere-plugin-builder
 PLUGIN_DOCKERFILE ?= Dockerfile-plugin
 DATAMGR_DOCKERFILE ?= Dockerfile-datamgr
 
-all: plugin
+all: dep plugin
+
+dep:
+ifeq (,$(wildcard $(VDDK_LIBS)))
+	$(error "$(VDDK_LIBS) cannot find vddk libs in path, please reference to: https://github.com/vmware-tanzu/astrolabe/tree/master/vendor/github.com/vmware/gvddk#dependency")
+endif
 
 plugin: datamgr
 	@echo "making: $@"


### PR DESCRIPTION
Comparing to erroring out `/usr/bin/ld: cannot find-lvixDiskLib`
in build, add dependency check for VDDK enhances build flow.

Signed-off-by: Chin-Ya Huang <chin-ya.huang@suse.com>