### PR TITLE
[Forked --> master] Filtered upload requests by node VM to which the PV is attached to

### DIFF
--- a/pkg/controller/upload_controller.go
+++ b/pkg/controller/upload_controller.go
@@ -180,6 +180,23 @@ func (c *uploadController) pvbHandler(obj interface{}) {
 		return
 	}
 
+	log.Info("Filtering out the upload requests come from different node")
+	peID, err := astrolabe.NewProtectedEntityIDFromString(req.Spec.SnapshotID)
+	if err != nil {
+		log.WithError(err).Error("error extract volume ID from snapshot ID")
+		return
+	}
+
+	uploadNodeName, err := utils.RetrievePodNodesByVolumeId(peID.GetID())
+	if err != nil {
+		log.WithError(err).Error("error retrieve pod nodes from volume ID")
+		return
+	}
+
+	if c.nodeName != uploadNodeName {
+		return
+	}
+
 	log.Debug("Enqueueing Upload")
 	c.enqueue(obj)
 }


### PR DESCRIPTION
workaround the VDDK PrepareForAccess API that disable VMotion per VM rather than per FCD.

It is a commit to master branch only. NOT for 0.9.0 branch.

Signed-off-by: Lintong Jiang <lintongj@vmware.com>