### PR TITLE
Checked the real status of download request by retrieving k8s api server for the truth

### DIFF
--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -266,8 +266,6 @@ func (s *server) runControllers() error {
 		s.pluginInformerFactory.Veleroplugin().V1().Uploads(),
 		s.pluginClient.VeleropluginV1(),
 		s.kubeClient,
-		s.kubeInformerFactory.Core().V1().PersistentVolumeClaims(),
-		s.kubeInformerFactory.Core().V1().PersistentVolumes(),
 		s.dataMover,
 		s.snapManager,
 		os.Getenv("NODE_NAME"),


### PR DESCRIPTION
This change resolves the similar window locking issue as the one previously resolved in upload_controller.go. Similarly, we need to do the same thing in download controller as well. Otherwise, the same download request might be repeatedly handled for multiple times due to the inconsistency between local cache and remote source of truth in k8s api server. Below is a list of changes made in this PR.

1. Checked the real status of download request by retrieving k8s api server for the truth. (only in download_controller.go)
2. Refactored code in upload_controller.go to keep naming convention aligned in both upload and download controller. (only in upload_controller.go)
3. Removed unused fields in upload controller (in upload_controller.go and server.go)

Signed-off-by: Lintong Jiang <lintongj@vmware.com>