### PR TITLE
Add velero version check when installing datamgr

### DIFF
--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -67,3 +67,8 @@ const (
 const (
 	DefaultS3RepoPrefix = "backups/vsphere-volumes-repo"
 )
+
+// Minimum velero version number to meet velero plugin requirement
+const (
+	VeleroMinVersion = "v1.3.0"
+)


### PR DESCRIPTION
Check installed velero version when installing datamgr. If velero version is prior to v1.3.0, give a warning message.

https://jira.eng.vmware.com/browse/DPCP-110

Test:
Velero v1.2.0 installed. After adding plugin image, check the log:
```
kubectl -n velero logs deploy/velero -c velero-plugin-for-vsphere
```
```
velero is running in the namespace, velero
WARNING: Velero version v1.2.0 is prior to v1.3.0. Velero-plugin-for-vsphere requires velero version to be v1.3.0 or above.The Image LocalMode: false
```