### PR TITLE
Fix deleting forever issue bug number 2481590.

### DIFF
--- a/pkg/controller/upload_controller.go
+++ b/pkg/controller/upload_controller.go
@@ -276,7 +276,7 @@ func (c *uploadController) processUpload(req *pluginv1api.Upload) error {
 	}
 
 	// Call snapshot manager API to cleanup the local snapshot
-	err = c.snapMgr.DeleteProtectedEntitySnapshot(peID, false)
+	err = c.snapMgr.DeleteLocalSnapshot(peID)
 	if err != nil {
 		errMsg := fmt.Sprintf("Failed to clean up local snapshot after uploading snapshot, %v. %v", peID.String(), errors.WithStack(err))
 		// TODO: Change the upload CRD definition to add one more phase, such as, UploadPhaseFailedLocalCleanup


### PR DESCRIPTION
Fix backup delete status is "Deleting" forever issue, when the backup doesn't exist in S3 repo. 

Test:
1.Create a backup, failed copy to S3:
```
time="2020-03-24T12:27:19Z" level=error msg="Failed to upload snapshot, ivd:87cfc633-dde3-4751-8a22-8dd4fe9955cb:7b5d98bb-d9f7-429e-bee1-e2072fe5eecf, to durable object storage. Prepare for access failed. The error code is 20005. with error code: 20005" controller=upload generation=11 logSource="/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/controller/upload_controller.go:274" name=upload-7b5d98bb-d9f7-429e-bee1-e2072fe5eecf namespace=velero phase=UploadError
```
2.Delete this backup, can be deleted successfully.
```
time="2020-03-24T12:21:57Z" level=info msg="Step 2: Deleting the durable snapshot from s3" backup=demo-app-0324-8 cmd=/plugins/velero-plugin-for-vsphere controller=backup-deletion logSource="/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/snapshotmgr/snapshot_manager.go:198" name=demo-app-0324-8-85b2q namespace=velero peID="ivd:87cfc633-dde3-4751-8a22-8dd4fe9955cb:7b5d98bb-d9f7-429e-bee1-e2072fe5eecf" pluginName=velero-plugin-for-vsphere
time="2020-03-24T12:21:58Z" level=error msg="Failed to get the ProtectedEntity from peID ivd:87cfc633-dde3-4751-8a22-8dd4fe9955cb:7b5d98bb-d9f7-429e-bee1-e2072fe5eecf" backup=demo-app-0324-8 cmd=/plugins/velero-plugin-for-vsphere controller=backup-deletion error="GetObject failed for bucket velero-plugin-for-vsphere-test, key backups/vsphere-volumes-repo/ivd/peinfo/ivd:87cfc633-dde3-4751-8a22-8dd4fe9955cb:7b5d98bb-d9f7-429e-bee1-e2072fe5eecf: NoSuchKey: The specified key does not exist.\n\tstatus code: 404, request id: 218B35EBE431698B, host id: cQ0/eXek2CLarSTlbco4Fhy/U0kOA/X4nFkLBHP3ALt3vzlhsK7aKR5EkIzqWbuNtytnxZI4zOQ=" error.file="/go/pkg/mod/github.com/vmware-tanzu/astrolabe@v0.0.0-20200324021554-865a01d86207/pkg/s3repository/repository_protected_entity_type_manager.go:170" error.function="github.com/vmware-tanzu/astrolabe/pkg/s3repository.(*ProtectedEntityTypeManager).GetProtectedEntity" logSource="/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/snapshotmgr/snapshot_manager.go:229" name=demo-app-0324-8-85b2q namespace=velero pluginName=velero-plugin-for-vsphere
time="2020-03-24T12:21:58Z" level=info msg="Deleted the durable snapshot from the durable repository" backup=demo-app-0324-8 cmd=/plugins/velero-plugin-for-vsphere controller=backup-deletion logSource="/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/snapshotmgr/snapshot_manager.go:204" name=demo-app-0324-8-85b2q namespace=velero peID="ivd:87cfc633-dde3-4751-8a22-8dd4fe9955cb:7b5d98bb-d9f7-429e-bee1-e2072fe5eecf" pluginName=velero-plugin-for-vsphere
```