### PR TITLE
Fixes PR 2542384

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/vmware-tanzu/astrolabe v0.0.0-20200403054520-e267eec94c48
 	github.com/vmware-tanzu/velero v1.3.0
+	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.17.3
 	k8s.io/apiextensions-apiserver v0.17.3
 	k8s.io/apimachinery v0.17.3


### PR DESCRIPTION
SnapshotManager.CreateVolumeFromSnapshot created a download record with a name of format download-<snapshot ID>-<uuid>
however, when it went to check the status of the record it searched for download-<snapshot ID> and did not find it.  The
error from Get() was being ignored.  The record returned was empty and the code checks for phase == completed or
failed and continues to wait if the phase is neither of those.

Changed to generate 1 string for the name of the record and use it in both places.  Added error checking and logging to
monitor polling of the record.

Additionally, if the PollImmediateInfinite returned an error the error was ignored and we attempted to create a new ID
from download.Status.VolumeID.  Since this was an empty string, the create failed but the error message we would see in the logs
was incorrect.  Fixed to check for the error from PollImmediateInfinite.

Signed-off-by: Dave Smith-Uchida <dsmithuchida@vmware.com>