### PR TITLE
Picked up the astrolabe change about changing to 7.0 VDDK libs from 6.7.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,9 @@ jobs:
       - name: Download essential GVDDK libraries
         run: |
           cd src/github.com/vmware-tanzu/astrolabe/vendor/github.com/vmware/gvddk
-          wget --quiet https://gvddk-libs.s3-us-west-1.amazonaws.com/VMware-vix-disklib-6.7.3-14389676.x86_64.tar.gz
-          tar xzf VMware-vix-disklib-6.7.3-14389676.x86_64.tar.gz
+          wget --quiet https://gvddk-libs.s3-us-west-1.amazonaws.com/VMware-vix-disklib-7.0.0-15832853.x86_64.tar.gz
+          tar xzf VMware-vix-disklib-7.0.0-15832853.x86_64.tar.gz
+          chmod 644 $(find vmware-vix-disklib-distrib/lib64/ -type f)
       - name: Set env
         run: echo "::set-env name=GOPATH::$GITHUB_WORKSPACE"
       - name: Make CI

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5
-	github.com/vmware-tanzu/astrolabe v0.0.0-20200403054520-e267eec94c48
+	github.com/vmware-tanzu/astrolabe v0.0.0-20200407045744-c3977b641329
 	github.com/vmware-tanzu/velero v1.3.0
 	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.17.3

--- a/go.sum
+++ b/go.sum
@@ -431,10 +431,8 @@ github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijb
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
-github.com/vmware-tanzu/astrolabe v0.0.0-20200402033148-2fc624d929b9 h1:mL4v0oEQ8wU9T80Ju9EFZCDTxh7t4RK7SrWzyF+fOdY=
-github.com/vmware-tanzu/astrolabe v0.0.0-20200402033148-2fc624d929b9/go.mod h1:SChYb3UPGc4UpCOs/9IhPb5Fpxd+8C9blc0RG5KfxtY=
-github.com/vmware-tanzu/astrolabe v0.0.0-20200403054520-e267eec94c48 h1:yJFFec8wYmlD0uVp4LEFxf2OIDKapQfAIWhVQ65Y6CY=
-github.com/vmware-tanzu/astrolabe v0.0.0-20200403054520-e267eec94c48/go.mod h1:SChYb3UPGc4UpCOs/9IhPb5Fpxd+8C9blc0RG5KfxtY=
+github.com/vmware-tanzu/astrolabe v0.0.0-20200407045744-c3977b641329 h1:SUOCa1bRSJyMRCFxrB4Kmp2WzAxsUpL2xeeWB+KViOU=
+github.com/vmware-tanzu/astrolabe v0.0.0-20200407045744-c3977b641329/go.mod h1:SChYb3UPGc4UpCOs/9IhPb5Fpxd+8C9blc0RG5KfxtY=
 github.com/vmware-tanzu/velero v1.3.0 h1:SyYQST2FQvFV8uhXJ3/iiYoq8KWqp8APV+VshaG4LAo=
 github.com/vmware-tanzu/velero v1.3.0/go.mod h1:s+8IqUKWcprcMVOfZKNC+jFY3tr/ElJfaMCcAfhThts=
 github.com/vmware/govmomi v0.22.2-0.20200329013745-f2eef8fc745f h1:6LIYlihC1/LDUhZ7zYVp1WOEY5owzsvogiaHBqvBzPU=


### PR DESCRIPTION
The follow changes are included in this commit.
1. Changed the go.mod to pick up the latest astrolabe change
2. Changed Action YAML accordingly to make sure the images built from github action CI contains 7.0 VDDK libs.

Testing
1. Basic End-to-end testing of backup & restore using velero plugin.
2. Precheckin: https://container-dp.svc.eng.vmware.com/job/Container_Precheck_Velero/52/