### PR TITLE
Fix datamgr daemonset

### DIFF
--- a/pkg/install/daemonset.go
+++ b/pkg/install/daemonset.go
@@ -114,7 +114,7 @@ func DaemonSet(namespace string, opts ...podTemplateOption) *appsv1.DaemonSet {
 					Annotations: c.annotations,
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: "velero",
+					ServiceAccountName: "velero-server",
 					SecurityContext: &corev1.PodSecurityContext{
 						RunAsUser: &userID,
 					},
@@ -195,7 +195,7 @@ func DaemonSet(namespace string, opts ...podTemplateOption) *appsv1.DaemonSet {
 				Name: "cloud-credentials",
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
-						SecretName: "cloud-credentials",
+						SecretName: "velero",
 					},
 				},
 			},


### PR DESCRIPTION
Fix for datamgr daemonset to launch. 

Changes includes:
* non-existent service account.
* align secret with with velero server.

Signed-off-by: Chin-Ya Huang <chin-ya.huang@suse.com>