### PR TITLE
Add uinstall plugin instruction in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,16 @@ follow these steps to set a default VolumeSnapshotLocation.
             - --default-volume-snapshot-locations
             - velero.io/vsphere:<your-volume-snapshot-location-name>
     ```
+## Uninstall the plugin
+To uninstall the plugin, run
+```bash
+velero plugin remove <plugin-image>
+```
+to remove the plugin from the Velero deployment. To finish the cleanup, delete the Data Manager daemonset and related CRDs.
+```bash
+kubectl -n velero delete daemonset.apps/datamgr-for-vsphere-plugin
+kubectl delete crds uploads.veleroplugin.io downloads.veleroplugin.io
+```
 
 ## S3 data
 Your volume data is stored in the Velero bucket with prefixes beginning with *plugins/vsphere-astrolabe-repo*

--- a/changelogs/unreleased/065-xinyanw409
+++ b/changelogs/unreleased/065-xinyanw409
@@ -1,0 +1,1 @@
+Add uninstall steps to delete data manager and related resources.


### PR DESCRIPTION
This change adds uninstall instruction for velero vsphere plugin in README.md to solve plugin remove issue mentioned in https://bugzilla.eng.vmware.com/show_bug.cgi?id=2544913 temporarily.

To solve this issue completely needs code change in velero side. Will create another change to add some remove code in the future.

Precheck: https://container-dp.svc.eng.vmware.com/job/Container_Precheck_Velero/74/