### PR TITLE
Fix to get vSphere credentials for TKG cluster.

### DIFF
--- a/changelogs/unreleased/066-swgupta
+++ b/changelogs/unreleased/066-swgupta
@@ -1,0 +1,1 @@
+Fix to get vSphere credentials for TKG cluster.

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.4.0
-	github.com/vmware-tanzu/astrolabe v0.1.1-0.20200429173621-1f6b7a39655f
+	github.com/vmware-tanzu/astrolabe v0.1.1-0.20200519042640-570f84703079
 	github.com/vmware-tanzu/velero v1.3.2
 	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.17.3

--- a/go.sum
+++ b/go.sum
@@ -433,8 +433,8 @@ github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijb
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
-github.com/vmware-tanzu/astrolabe v0.1.1-0.20200429173621-1f6b7a39655f h1:Jo+7t1wTmgWIV2iMAEiPs8iceWooFXDo/HOpITvHeag=
-github.com/vmware-tanzu/astrolabe v0.1.1-0.20200429173621-1f6b7a39655f/go.mod h1:SChYb3UPGc4UpCOs/9IhPb5Fpxd+8C9blc0RG5KfxtY=
+github.com/vmware-tanzu/astrolabe v0.1.1-0.20200519042640-570f84703079 h1:2hU79KD862mfFgc/Di+mY4RCVJbUZakAptlWT5gsTpM=
+github.com/vmware-tanzu/astrolabe v0.1.1-0.20200519042640-570f84703079/go.mod h1:SChYb3UPGc4UpCOs/9IhPb5Fpxd+8C9blc0RG5KfxtY=
 github.com/vmware-tanzu/velero v1.3.2 h1:Rhn37gjxn6Hwg6OFZUsW1CTuRaVuHEL8p/eiXrcKNGw=
 github.com/vmware-tanzu/velero v1.3.2/go.mod h1:s+8IqUKWcprcMVOfZKNC+jFY3tr/ElJfaMCcAfhThts=
 github.com/vmware/govmomi v0.22.2-0.20200329013745-f2eef8fc745f h1:6LIYlihC1/LDUhZ7zYVp1WOEY5owzsvogiaHBqvBzPU=

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -47,25 +47,25 @@ const (
 	// The key of SnapshotManager location
 	VolumeSnapshotterManagerLocation = "SnapshotManagerLocation"
 	// Valid values for the config with the VolumeSnapshotterManagerLocation key
-	VolumeSnapshotterPlugin = "Plugin"
+	VolumeSnapshotterPlugin     = "Plugin"
 	VolumeSnapshotterDataServer = "DataServer"
 )
 
 const (
-    // Max retry limit for downloads.
+	// Max retry limit for downloads.
 	DOWNLOAD_MAX_RETRY = 5
 
 	// Initial retry for both uploads and downloads.
-    MIN_RETRY = 0
+	MIN_RETRY = 0
 
-    // BACKOFF for downloads.
-    DOWNLOAD_BACKOFF  = 5
+	// BACKOFF for downloads.
+	DOWNLOAD_BACKOFF = 5
 
-    // Max backoff limit for uploads.
-    UPLOAD_MAX_BACKOFF = 60
+	// Max backoff limit for uploads.
+	UPLOAD_MAX_BACKOFF = 60
 
-    // Exceeds this number of retry, will give a warning message to ask user to fix network issue in cluster.
-    RETRY_WARNING_COUNT = 8
+	// Exceeds this number of retry, will give a warning message to ask user to fix network issue in cluster.
+	RETRY_WARNING_COUNT = 8
 )
 
 // configuration constants for the S3 repository
@@ -76,7 +76,7 @@ const (
 	// Minimum velero version number to meet velero plugin requirement
 	VeleroMinVersion = "v1.3.2"
 
-    // Minimum csi driver version number to meet velero plugin requirement
+	// Minimum csi driver version number to meet velero plugin requirement
 	CsiMinVersion = "v1.0.2"
 )
 
@@ -84,4 +84,9 @@ const (
 	// DefaultNamespace is the Kubernetes namespace that is used by default for
 	// the Velero server and API objects.
 	DefaultNamespace = "velero"
+)
+
+const (
+	// Default port used to access vCenter.
+	DefaultVCenterPort string = "443"
 )


### PR DESCRIPTION
The velero vsphere plugin piggy backs on the csi secret in the worker nodes to
get VC credentials. For a Vanilla Kubernetes cluster, the secret is stored in
vsphere-config-secret in the kube-system namespace. However, for the TKG cluster,
the secret name is not the same and so the call to retrive the VCConfigSecret
fails.
Made the following change:
1. Added a new secret location csi-vsphere-config, that is valid for TKG
cluster, to check for csi-vsphere.conf with the VC credentials.

2. Updated the VC config params for the following checks in csi-vsphere.conf:
   - Added a default port if the port is missing in the CSI config file. This is
     similar to CSI code behavior.
   - Updated the config values correctly even if "" are missing in the config file.

3. Create a new IDV preotected entity by passing all the secret params so astrolabe
   code does not have to retrieve them again.

Testing Done:
  Manually tested with TKG cluster and vanilla cluster on vsphere.
  https://container-dp.svc.eng.vmware.com/job/Container_Precheck_Velero/93/

Dependent on Astrolabe #22 pull request.
Bug Number: DPCP-144

Signed-off-by: Swati Gupta <swgupta@swgupta-a01.vmware.com>