### PR TITLE
Fix cannot backup independent pv issue

### DIFF
--- a/changelogs/unreleased/068-xinyanw409
+++ b/changelogs/unreleased/068-xinyanw409
@@ -1,0 +1,1 @@
+Fix issue that cannot backup PVs which are not attached to volumes, support backup independent PVs.

--- a/pkg/controller/upload_controller.go
+++ b/pkg/controller/upload_controller.go
@@ -127,8 +127,14 @@ func (c *uploadController) enqueueUploadItem(obj interface{}) {
 
 	uploadNodeName, err := utils.RetrievePodNodesByVolumeId(peID.GetID())
 	if err != nil {
-		log.WithError(err).Errorf("Failed to retrieve pod nodes from volume ID, %v", peID.String())
-		return
+		_, ok := err.(utils.NotFoundError)
+		if ok {
+			log.Infof("Trying to back independent PV from volume ID, %v", peID.String())
+			uploadNodeName = c.nodeName
+		} else {
+			log.WithError(err).Errorf("Failed to retrieve pod nodes from volume ID, %v", peID.String())
+			return
+		}
 	}
 
 	log.Infof("Current node: %v. Expected node for uploading the upload CR: %v", c.nodeName, uploadNodeName)


### PR DESCRIPTION
This change fix the issue that cannot backup PVs which are not attached to volumes.

Create independent pv and try to backup it:
```
velero backup create pv-test --include-resources=pv --snapshot-volumes --volume-snapshot-locations  vsl-vsphere
```
```
time="2020-05-06T23:12:54Z" level=info msg="Copying the snapshot from local to remote repository" Local PEID="ivd:bdd09b60-5450-4811-83c2-33c5483c959e:5ae5e87b-d17e-4daa-bb47-6ec30e631376" logSource="/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/dataMover/data_mover.go:84"
time="2020-05-06T23:12:54Z" level=info msg="Trying to back independent PV from volume ID, ivd:bdd09b60-5450-4811-83c2-33c5483c959e:5ae5e87b-d17e-4daa-bb47-6ec30e631376" controller=upload generation=2 logSource="/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/controller/upload_controller.go:132" name=upload-cbcf7121-0a9f-4343-8b0f-53d50e713d9d namespace=velero phase=InProgress
```
Upload finished:
```
- apiVersion: veleroplugin.io/v1
  kind: Upload
  metadata:
    creationTimestamp: "2020-05-06T23:12:54Z"
    generation: 3
    name: upload-cbcf7121-0a9f-4343-8b0f-53d50e713d9d
    namespace: velero
    resourceVersion: "58314"
    selfLink: /apis/veleroplugin.io/v1/namespaces/velero/uploads/upload-cbcf7121-0a9f-4343-8b0f-53d50e713d9d
    uid: 1dab1df2-8fef-11ea-a819-005056b46bd7
  spec:
    backupTimestamp: "2020-05-06T23:12:54Z"
    snapshotID: ivd:bdd09b60-5450-4811-83c2-33c5483c959e:5ae5e87b-d17e-4daa-bb47-6ec30e631376
  status:
    completionTimestamp: "2020-05-06T23:17:15Z"
    message: Upload completed
    nextRetryTimestamp: "2020-05-06T23:12:54Z"
    phase: Completed
    processingNode: k8s-node-0487
    progress: {}
    startTimestamp: "2020-05-06T23:12:54Z"
```
Precheck: https://container-dp.svc.eng.vmware.com/job/Container_Precheck_Velero/86/