### PR TITLE
Add "make release" command to push qualified images from dpcpinternal repo to vsphereveleroplugin repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ VDDK_LIBS:= $(GVDDK)/vmware-vix-disklib-distrib/lib64
 PLUGIN_BIN ?= $(wildcard velero-*)
 DATAMGR_BIN ?= $(wildcard data-manager-*)
 
+RELEASE_REGISTRY = vsphereveleroplugin
 REGISTRY ?= dpcpinternal
 PLUGIN_IMAGE ?= $(REGISTRY)/$(PLUGIN_BIN)
 DATAMGR_IMAGE ?= $(REGISTRY)/$(DATAMGR_BIN)
@@ -191,6 +192,18 @@ push: push-datamgr push-plugin
 
 push-pp:
 	$(MAKE) push-plugin LOCALMODE=true VERSION=$(VERSION)-pp
+
+QUALIFIED_TAG ?=
+RELEASE_TAG ?= latest
+release:
+ifneq (,$(QUALIFIED_TAG))
+	docker pull $(DATAMGR_IMAGE):$(QUALIFIED_TAG)
+	docker pull $(PLUGIN_IMAGE):$(QUALIFIED_TAG)
+	@docker tag $(DATAMGR_IMAGE):$(QUALIFIED_TAG) $(RELEASE_REGISTRY)/$(DATAMGR_BIN):$(RELEASE_TAG)
+	@docker tag $(PLUGIN_IMAGE):$(QUALIFIED_TAG) $(RELEASE_REGISTRY)/$(PLUGIN_BIN):$(RELEASE_TAG)
+	docker push $(RELEASE_REGISTRY)/$(DATAMGR_BIN):$(RELEASE_TAG)
+	docker push $(RELEASE_REGISTRY)/$(PLUGIN_BIN):$(RELEASE_TAG)
+endif
 
 verify:
 	@echo "verify: Started"


### PR DESCRIPTION
Currently, according to our plug-in workflow, a pair of images: data-manager-for-plugin:tag and velero-plugin-for-vsphere:tag, will be pushed to dpcpinternal repo when a new feature is merged into master branch. After passing CICD pipeline and QE tests, the qualified images will be promoted and further place in the official repo, vsphereveleroplugin.

This change add a 'make release' command in Makefile to get the qualified images and push images to vsphereveleroplugin repo.

To run this command, qualified image tag is required.
```
make release QUALIFIED_TAG=fix-hardcoding-for-matching-image-e2bf4e7-19.May.2020.04.11.40 RELEASED_TAG=1.0.1
```

Test done:
I used my own repository instead of vsphereveleroplugin to run some manual tests.
Precheck: https://container-dp.svc.eng.vmware.com/job/Container_Precheck_Velero/103/