### PR TITLE
Update Data Manager server code to accept VM config parameters

### DIFF
--- a/changelogs/unreleased/078-swgupta
+++ b/changelogs/unreleased/078-swgupta
@@ -1,0 +1,1 @@
+Update Data Manager server code to accept VM config parameters.

--- a/pkg/dataMover/data_mover.go
+++ b/pkg/dataMover/data_mover.go
@@ -18,6 +18,7 @@ package dataMover
 
 import (
 	"context"
+
 	"github.com/sirupsen/logrus"
 	"github.com/vmware-tanzu/astrolabe/pkg/astrolabe"
 	"github.com/vmware-tanzu/astrolabe/pkg/ivd"
@@ -31,17 +32,19 @@ type DataMover struct {
 	s3PETM  *s3repository.ProtectedEntityTypeManager
 }
 
-func NewDataMoverFromCluster(logger logrus.FieldLogger) (*DataMover, error) {
-	params := make(map[string]interface{})
-	err := utils.RetrieveVcConfigSecret(params, logger)
+func NewDataMoverFromCluster(params map[string]interface{}, logger logrus.FieldLogger) (*DataMover, error) {
+	// Retrieve VC configuration from the cluster only of it has not been passed by the caller
+	if _, ok := params[ivd.HostVcParamKey]; !ok {
+		err := utils.RetrieveVcConfigSecret(params, logger)
 
-	if err != nil {
-		logger.WithError(err).Errorf("Could not retrieve vsphere credential from k8s secret.")
-		return nil, err
+		if err != nil {
+			logger.WithError(err).Errorf("Could not retrieve vsphere credential from k8s secret.")
+			return nil, err
+		}
+		logger.Infof("DataMover: vSphere VC credential is retrieved")
 	}
-	logger.Infof("DataMover: vSphere VC credential is retrieved")
 
-	err = utils.RetrieveVSLFromVeleroBSLs(params, logger)
+	err := utils.RetrieveVSLFromVeleroBSLs(params, logger)
 	if err != nil {
 		logger.WithError(err).Errorf("Could not retrieve velero default backup location.")
 		return nil, err
@@ -71,8 +74,8 @@ func NewDataMoverFromCluster(logger logrus.FieldLogger) (*DataMover, error) {
 
 	dataMover := DataMover{
 		FieldLogger: logger,
-		ivdPETM: ivdPETM,
-		s3PETM:  s3PETM,
+		ivdPETM:     ivdPETM,
+		s3PETM:      s3PETM,
 	}
 
 	logger.Infof("DataMover is initialized")

--- a/pkg/plugin/volume_snapshotter_plugin.go
+++ b/pkg/plugin/volume_snapshotter_plugin.go
@@ -17,12 +17,12 @@
 package plugin
 
 import (
-	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/utils"
-	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/vmware-tanzu/astrolabe/pkg/astrolabe"
 	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/snapshotmgr"
+	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/utils"
+	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -45,13 +45,15 @@ func (p *NewVolumeSnapshotter) Init(config map[string]string) error {
 	p.config = config
 
 	// Initializing snapshot manager
+	// Pass empty param list. VC credentials will be retrieved from the cluster configuration
 	p.Infof("Initializing snapshot manager")
 	if config == nil {
 		config = make(map[string]string)
 	}
 	config[utils.VolumeSnapshotterManagerLocation] = utils.VolumeSnapshotterPlugin
 	var err error
-	p.snapMgr, err = snapshotmgr.NewSnapshotManagerFromCluster(config, p.FieldLogger)
+	params := make(map[string]interface{})
+	p.snapMgr, err = snapshotmgr.NewSnapshotManagerFromCluster(params, config, p.FieldLogger)
 	if err != nil {
 		p.WithError(err).Errorf("Failed at calling snapshotmgr.NewSnapshotManagerFromConfigFile with config: %v", config)
 		return err
@@ -68,7 +70,7 @@ func (p *NewVolumeSnapshotter) CreateVolumeFromSnapshot(snapshotID, volumeType, 
 	p.Infof("CreateVolumeFromSnapshot called with snapshotID %s, volumeType %s", snapshotID, volumeType)
 	var returnVolumeID, returnVolumeType string
 
-	var peId,returnPeId astrolabe.ProtectedEntityID
+	var peId, returnPeId astrolabe.ProtectedEntityID
 	var err error
 	peId, err = astrolabe.NewProtectedEntityIDFromString(snapshotID)
 	if err != nil {


### PR DESCRIPTION
In the supervisor/guest cluster backup solution, the data manager is run as a
standalone container inside a VM with reduced access priveleges (VC admin/user).
The DataMgr currently retrieves the VC config details and credentials from the CSI
secret. There are some downsides to doing this:

- It might require cluster admin privileges. Service account token can however be
  used to retrieve the CSI secret, which might be a security hole.
- The CSI secret location in the supervisor cluster has changed.
- The VC credentials in the CSI secret file might not have the required privleges
  for data movement from the host.
- Provides flexibility for the user to provide VC configuration details.

Updated the code for the server to accept the credentials and other VC configuration
as input parameters.

Usage:
  datamgr server [flags]

Flags:
      --client-burst int          maximum number of requests by the server to the Kubernetes API in a short period of time (default 30)
      --client-qps float32        maximum number of requests per second by the server to the Kubernetes API once the burst limit has been reached (default 20)
      --cluster-id string         kubernetes cluster id. If specified, --use-secret should be set to False.
  -h, --help                      help for server
      --insecure-Flag             insecure flag. If specified, --use-secret should be set to False. (default true)
      --log-format                the format for log output. Valid values are text, json. (default text)
      --log-level                 the level at which to log. Valid values are trace, debug, info, warning, error, fatal, panic. (default info)
      --metrics-address string    the address to expose prometheus metrics (default ":8085")
      --profiler-address string   the address to expose the pprof profiler (default "localhost:6060")
      --use-secret                retrieve VirtualCenter configuration from secret (default true)
      --vcenter-address string    VirtualCenter address. If specified, --use-secret should be set to False.
      --vcenter-port string       VirtualCenter port. If specified, --use-secret should be set to False. (default "443")
      --vcenter-user string       VirtualCenter user. If specified, --use-secret should be set to False.

JiraId: DPCP-197

Testing Done:
  Manually tested with Vanilla cluster. No change in workflow.
  Manually tested stating datmanager server on a standalone VM.
  Precheck test: https://container-dp.svc.eng.vmware.com/job/Container_Precheck_Velero/120/

Signed-off-by: Swati Gupta <swgupta@swgupta-a01.vmware.com>