### PR TITLE
Update dockerfile and makefile to be compatible with internal build tools

### DIFF
--- a/Dockerfile-datamgr
+++ b/Dockerfile-datamgr
@@ -15,10 +15,6 @@
 FROM ubuntu:bionic
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates wget bzip2 && \
-    wget --quiet https://github.com/restic/restic/releases/download/v0.9.5/restic_0.9.5_linux_amd64.bz2 && \
-    bunzip2 restic_0.9.5_linux_amd64.bz2 && \
-    mv restic_0.9.5_linux_amd64 /usr/bin/restic && \
-    chmod +x /usr/bin/restic && \
     apt-get remove -y wget bzip2 && \
     rm -rf /var/lib/apt/lists/*
 ADD /bin/linux/amd64/data-* /datamgr

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,10 @@ VERSION := $(shell echo `git rev-parse --abbrev-ref HEAD`-`git log -1 --pretty=f
 endif
 LOCALMODE ?= false
 
+# set git sha and tree state
+GIT_SHA = $(shell git rev-parse HEAD)
+GIT_DIRTY = $(shell git status --porcelain 2> /dev/null)
+
 platform_temp = $(subst -, ,$(ARCH))
 GOOS = $(word 1, $(platform_temp))
 GOARCH = $(word 2, $(platform_temp))
@@ -76,6 +80,8 @@ local: build-dirs
 	GOARCH=$(GOARCH) \
 	PKG=$(PKG) \
 	BIN=$(BIN) \
+	GIT_SHA=$(GIT_SHA) \
+	GIT_DIRTY="$(GIT_DIRTY)" \
 	OUTPUT_DIR=$$(pwd)/_output/bin/$(GOOS)/$(GOARCH) \
 	GO111MODULE=on \
 	GOFLAGS=-mod=readonly \ 
@@ -93,6 +99,8 @@ _output/bin/$(GOOS)/$(GOARCH)/$(BIN): build-dirs
 		LOCALMODE=$(LOCALMODE) \
 		PKG=$(PKG) \
 		BIN=$(BIN) \
+		GIT_SHA=$(GIT_SHA) \
+		GIT_DIRTY=\"$(GIT_DIRTY)\" \
 		OUTPUT_DIR=/output/$(GOOS)/$(GOARCH) \
 		GO111MODULE=on \
 		GOFLAGS=-mod=readonly \

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -46,12 +46,14 @@ if [ -z "${LOCALMODE}" ]; then
     echo "LOCALMODE must be set"
     exit 1
 fi
+if [ -z "${GIT_SHA}" ]; then
+    echo "GIT_SHA must be set"
+    exit 1
+fi
 
 
 export CGO_ENABLED=1
 
-GIT_SHA=$(git rev-parse HEAD)
-GIT_DIRTY=$(git status --porcelain 2> /dev/null)
 if [[ -z "${GIT_DIRTY}" ]]; then
   GIT_TREE_STATE=clean
 else


### PR DESCRIPTION
A few improvements to help integrate this codebase on internal build systems:

* Remove the unused restic download
* Update the git revision parsing so that it's aware of submodule usage.