### PR TITLE
Added a feature flag for Velero ItemAction Plugin and resolved the failure in local test cases

### DIFF
--- a/pkg/backupdriver/snapshot.go
+++ b/pkg/backupdriver/snapshot.go
@@ -49,7 +49,6 @@ func checkPhasesAndSendResult(waitForPhases []backupdriverv1.SnapshotPhase, snap
 }
 
 func SnapshopRef(ctx context.Context, clientSet *v1.BackupdriverV1Client, objectToSnapshot core_v1.TypedLocalObjectReference, namespace string, repository BackupRepository, waitForPhases []backupdriverv1.SnapshotPhase, logger logrus.FieldLogger) (backupdriverv1.Snapshot, error) {
-
 	snapshotUUID, err := uuid.NewRandom()
 
 	if err != nil {

--- a/pkg/backupdriver/snapshot_test.go
+++ b/pkg/backupdriver/snapshot_test.go
@@ -18,6 +18,10 @@ func TestWaitForPhases(t *testing.T) {
 	clientSet, err := createClientSet()
 
 	if err != nil {
+		_, ok := err.(ClientConfigNotFoundError)
+		if ok {
+			t.Skip(err)
+		}
 		t.Fatal(err)
 	}
 	apiGroup := "xyzzy"
@@ -122,7 +126,7 @@ func createClientSet() (*v1.BackupdriverV1Client, error) {
 	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
 	config, err := kubeConfig.ClientConfig()
 	if err != nil {
-		return nil, errors.Wrap(err, "Could not create client config")
+		return nil, NewClientConfigNotFoundError("Could not create client config")
 	}
 
 	clientset, err := v1.NewForConfig(config)
@@ -131,5 +135,20 @@ func createClientSet() (*v1.BackupdriverV1Client, error) {
 		return nil, errors.Wrap(err, "Could not create clientset")
 	}
 	return clientset, err
+}
+
+type ClientConfigNotFoundError struct {
+	errMsg string
+}
+
+func (this ClientConfigNotFoundError) Error() string {
+	return this.errMsg
+}
+
+func NewClientConfigNotFoundError(errMsg string) ClientConfigNotFoundError {
+	err := ClientConfigNotFoundError{
+		errMsg: errMsg,
+	}
+	return err
 }
 

--- a/pkg/plugin/restore_pvc_action_plugin.go
+++ b/pkg/plugin/restore_pvc_action_plugin.go
@@ -16,7 +16,7 @@ type NewPVCRestoreItemAction struct {
 
 // AppliesTo returns information indicating that the PVCBackupItemAction should be invoked to backup PVCs.
 func (p *NewPVCRestoreItemAction) AppliesTo() (velero.ResourceSelector, error) {
-	p.Log.Info("PVCBackupItemAction AppliesTo for vSphere")
+	p.Log.Info("VSphere PVCBackupItemAction AppliesTo")
 
 	return velero.ResourceSelector{
 		IncludedResources: []string{"persistentvolumeclaims"},
@@ -24,13 +24,16 @@ func (p *NewPVCRestoreItemAction) AppliesTo() (velero.ResourceSelector, error) {
 }
 
 func (p *NewPVCRestoreItemAction) Execute(input *velero.RestoreItemActionExecuteInput) (*velero.RestoreItemActionExecuteOutput, error) {
-
 	var pvc corev1api.PersistentVolumeClaim
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(input.Item.UnstructuredContent(), &pvc); err != nil {
 		return nil, errors.WithStack(err)
 	}
 
-	p.Log.Infof("Starting PVCRestoreItemAction for PVC %s/%s", pvc.Namespace, pvc.Name)
+	p.Log.Infof("VSphere PVCRestoreItemAction for PVC %s/%s started", pvc.Namespace, pvc.Name)
+	var err error
+	defer func() {
+		p.Log.WithError(err).Infof("VSphere PVCRestoreItemAction for PVC %s/%s completed", pvc.Namespace, pvc.Name)
+	}()
 
 	// TODO: add logic for PVC restoration
 
@@ -38,7 +41,6 @@ func (p *NewPVCRestoreItemAction) Execute(input *velero.RestoreItemActionExecute
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	p.Log.Infof("Returning from PVCRestoreItemAction for PVC %s/%s", pvc.Namespace, pvc.Name)
 
 	return &velero.RestoreItemActionExecuteOutput{
 		UpdatedItem: &unstructured.Unstructured{Object: pvcMap},

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -102,3 +102,8 @@ const (
 const (
 	S3RepositoryDriver string = "s3repository.astrolabe.vmware-tanzu.com"
 )
+
+const (
+	// VSphereItemActionPluginFlag is the feature flag string that defines whether or not vSphere ItemActionPlugin features are being used.
+	VSphereItemActionPluginFlag = "EnableVSphereItemActionPlugin"
+)


### PR DESCRIPTION
Added a feature flag for Velero ItemAction Plugin and resolved the failure in local test cases

Signed-off-by: Lintong Jiang <lintongj@vmware.com>

Below are two items involved in this commit,

1. Added a feature flag, `EnableVSphereItemActionPlugin`, for Velero ItemAction Plugin.
2. Resolved the failure in local test cases. 

So far, we should be safe to merge our sprint branches back to `master` branch. To enable the feature of new vSphere plugin, we are supposed to add `--features EnableVSphereItemActionPlugin` to `velero install` command.

Precheckin Test: https://container-dp.svc.eng.vmware.com/job/Container_Precheck_Velero/182/