### PR TITLE
Calls snapshotmgr to create snapshot and updates status

### DIFF
--- a/pkg/backupdriver/backup_driver_controller.go
+++ b/pkg/backupdriver/backup_driver_controller.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2020 the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package backupdriver
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/vmware-tanzu/astrolabe/pkg/astrolabe"
+	backupdriverapi "github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/apis/backupdriver/v1"
+)
+
+// CreateSnapshot creates a snapshot of the specified volume, and applies any provided
+// set of tags to the snapshot.
+func (ctrl *backupDriverController) CreateSnapshot(snapshot *backupdriverapi.Snapshot) error {
+	ctrl.logger.Infof("Entering CreateSnapshot: %s/%s", snapshot.Namespace, snapshot.Name)
+
+	objName := snapshot.Spec.TypedLocalObjectReference.Name
+	objKind := snapshot.Spec.TypedLocalObjectReference.Kind
+	if objKind != "PersistentVolumeClaim" {
+		errMsg := fmt.Sprintf("resourceHandle Kind %s is not supported. Only PersistentVolumeClaim Kind is supported", objKind)
+		ctrl.logger.Error(errMsg)
+		return errors.New(errMsg)
+	}
+
+	pvc, err := ctrl.pvcLister.PersistentVolumeClaims(snapshot.Namespace).Get(objName)
+	if err != nil {
+		errMsg := fmt.Sprintf("pvc %s/%s not found in the informer cache: %v", snapshot.Namespace, objName, err)
+		ctrl.logger.Error(errMsg)
+		return err
+	}
+
+	pv, err := ctrl.pvLister.Get(pvc.Spec.VolumeName)
+	if err != nil {
+		errMsg := fmt.Sprintf("pv %s not found in the informer cache: %v", pvc.Spec.VolumeName, err)
+		ctrl.logger.Error(errMsg)
+		return err
+	}
+
+	if nil == pv.Spec.PersistentVolumeSource.CSI {
+		errMsg := fmt.Sprintf("the CSI PersistentVolumeSource cannot be nil in PV %s", pv.Name)
+		ctrl.logger.Error(errMsg)
+		return errors.New(errMsg)
+	}
+
+	volumeID := pv.Spec.PersistentVolumeSource.CSI.VolumeHandle
+
+	// call SnapshotMgr CreateSnapshot API
+	peID := astrolabe.NewProtectedEntityID("ivd", volumeID)
+	ctrl.logger.Infof("CreateSnapshot: The initial Astrolabe PE ID: %s", peID)
+	if ctrl.snapManager == nil {
+		errMsg := fmt.Sprintf("snapManager is not initialized.")
+		ctrl.logger.Error(errMsg)
+		return errors.New(errMsg)
+	}
+
+	// NOTE: tags is required to call snapManager.CreateSnapshot
+	// but it is not really used
+	var tags map[string]string
+
+	peID, err = ctrl.snapManager.CreateSnapshot(peID, tags)
+	if err != nil {
+		errMsg := fmt.Sprintf("failed at calling SnapshotManager CreateSnapshot from peID %v", peID)
+		ctrl.logger.Error(errMsg)
+		return err
+	}
+
+	// Construct the snapshotID for cns volume
+	snapshotID := peID.String()
+	ctrl.logger.Infof("CreateSnapshot: The snapshotID depends on the Astrolabe PE ID in the format, <peType>:<id>:<snapshotID>, %s", snapshotID)
+
+	// NOTE: Uncomment the code to retrieve snapshot from API server
+	// when needed.
+	// Retrieve snapshot from API server to make sure it is up to date
+	//newSnapshot, err := ctrl.backupdriverClient.Snapshots(snapshot.Namespace).Get(snapshot.Name, metav1.GetOptions{})
+	//if err != nil {
+	//	return err
+	//}
+	//snapshotClone := newSnapshot.DeepCopy()
+
+	snapshotClone := snapshot.DeepCopy()
+	snapshotClone.Status.Phase = backupdriverapi.SnapshotPhaseSnapshotted
+	snapshotClone.Status.Progress.TotalBytes = 0
+	snapshotClone.Status.Progress.BytesDone = 0
+	snapshotClone.Status.SnapshotID = snapshotID
+	// NOTE: snapshotClone.Status.Metadata is not populated yet
+
+	if ctrl.backupdriverClient == nil {
+		errMsg := fmt.Sprintf("backupdriverClient is not initialized")
+		ctrl.logger.Error(errMsg)
+		return errors.New(errMsg)
+	}
+	snapshot, err = ctrl.backupdriverClient.Snapshots(snapshotClone.Namespace).UpdateStatus(snapshotClone)
+	if err != nil {
+		return err
+	}
+
+	ctrl.logger.Infof("CreateSnapshot %s/%s completed with snapshotID: %s, phase in status updated to %s", snapshot.Namespace, snapshot.Name, snapshotID, snapshot.Status.Phase)
+	return nil
+}

--- a/pkg/backupdriver/backup_repository.go
+++ b/pkg/backupdriver/backup_repository.go
@@ -1,6 +1,5 @@
 package backupdriver
 
-
 import (
 	"context"
 	"fmt"
@@ -171,4 +170,3 @@ func patchBackupRepositoryClaim(backupRepositoryClaim *backupdriverv1.BackupRepo
 	}
 	return nil
 }
-

--- a/pkg/backupdriver/local_snapshot.go
+++ b/pkg/backupdriver/local_snapshot.go
@@ -1,2 +1,1 @@
 package backupdriver
-

--- a/pkg/backupdriver/snapshot_test.go
+++ b/pkg/backupdriver/snapshot_test.go
@@ -81,9 +81,10 @@ func TestWaitForPhases(t *testing.T) {
 		fmt.Printf("WaitForPhases returned phase = %s\n", endPhase)
 	}
 }
+
 /*
 TODO - figure out how to advance the phase and status
- */
+*/
 /*
 func TestSnapshotRef(t *testing.T) {
 	clientSet, err := createClientSet()
@@ -151,4 +152,3 @@ func NewClientConfigNotFoundError(errMsg string) ClientConfigNotFoundError {
 	}
 	return err
 }
-


### PR DESCRIPTION
This PR calls snapshot manager to create snapshot and updates snapshot status.

Tested using "velero backup create" and resulted in a successful backup with a local FCD snapshot taken by the snapshot manager.