### PR TITLE
Add apis to handle multiple backup repository

### DIFF
--- a/pkg/apis/veleroplugin/v1/upload.go
+++ b/pkg/apis/veleroplugin/v1/upload.go
@@ -31,6 +31,10 @@ type UploadSpec struct {
 
 	// UploadCancel indicates request to cancel ongoing upload.
 	UploadCancel bool `json:"uploadCancel,omitempty"`
+
+	// BackupRepository provides backup repository info for upload. Used for
+	// multiple backup repository.
+	BackupRepositoryName string `json:"backupRepository,omitempty"`
 }
 
 // UploadPhase represents the lifecycle phase of a Upload.

--- a/pkg/builder/upload_builder.go
+++ b/pkg/builder/upload_builder.go
@@ -111,3 +111,9 @@ func (b *UploadBuilder) CurrentBackOff(backoff int32) *UploadBuilder {
 	b.object.Status.CurrentBackOff = backoff
 	return b
 }
+
+// BackupRepository sets the backup repository for upload.
+func (b *UploadBuilder) BackupRepositoryName(backuprepo string) *UploadBuilder {
+	b.object.Spec.BackupRepositoryName = backuprepo
+	return b
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -491,3 +491,17 @@ func GetClusterFlavor(clientset *kubernetes.Clientset) (ClusterFlavor, error) {
 	// Did not match any search criteria. Unknown cluster flavor.
 	return Unknown, errors.New("GetClusterFlavor: Failed to identify cluster flavor")
 }
+
+func GetRepositoryFromBackupRepository(backupRepository *backupdriverapi.BackupRepository, logger logrus.FieldLogger) (*s3repository.ProtectedEntityTypeManager, error) {
+	switch backupRepository.RepositoryDriver {
+	case S3RepositoryDriver:
+		params := make(map[string]interface{})
+		for k, v := range backupRepository.RepositoryParameters {
+			params[k] = v
+		}
+		return GetS3PETMFromParamsMap(params, logger)
+	default:
+		errMsg := fmt.Sprintf("Unsupported backuprepository driver type: %s. Only support %s.", backupRepository.RepositoryDriver, S3RepositoryDriver)
+		return nil, errors.New(errMsg)
+	}
+}


### PR DESCRIPTION
This change add apis to handle multiple backup repository instead of using hard-coding S3 repository:
1. Add backuprepository field in upload cr definition.
2.Add apis in snapshot manager to create snapshot and delete snapshot with backup repository .
API design: https://confluence.eng.vmware.com/pages/viewpage.action?spaceKey=~wxinyan&title=Multiple+Backup+Repository

Precheck: https://container-dp.svc.eng.vmware.com/job/Container_Precheck_Velero/213/
Manually test utility function:
```
PASS
ok  	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/utils	0.054s
```