### PR TITLE
Update ClaimBackupRepository to avoid watching BR

### DIFF
--- a/pkg/backupdriver/backup_repository.go
+++ b/pkg/backupdriver/backup_repository.go
@@ -9,6 +9,7 @@ import (
 	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/builder"
 	v1 "github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/typed/backupdriver/v1"
 	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/utils"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/tools/cache"

--- a/pkg/backupdriver/backup_repository_test.go
+++ b/pkg/backupdriver/backup_repository_test.go
@@ -33,11 +33,8 @@ func TestClaimBackupRepository(t *testing.T) {
 	logger.SetFormatter(formatter)
 	logger.SetLevel(logrus.DebugLevel)
 
-	veleroNs, exist := os.LookupEnv("VELERO_NAMESPACE")
-	if !exist {
-		errMsg := "Failed to lookup the ENV variable for velero namespace"
-		t.Fatalf(errMsg)
-	}
+	// using velero ns for testing.
+	veleroNs := "velero"
 
 	backupdriverClient, err := backupdriverTypedV1.NewForConfig(config)
 	if err != nil {

--- a/pkg/backupdriver/backup_repository_test.go
+++ b/pkg/backupdriver/backup_repository_test.go
@@ -92,9 +92,7 @@ func handleNewBackupRepositoryClaim(ctx context.Context,
 	ns string,
 	backupdriverClient *backupdriverTypedV1.BackupdriverV1Client,
 	logger logrus.FieldLogger) error {
-	backupRepository, err := CreateBackupRepository(ctx, backupRepositoryClaim.RepositoryDriver,
-		backupRepositoryClaim.RepositoryParameters, backupRepositoryClaim.AllowedNamespaces, backupRepositoryClaim.Name,
-		backupdriverClient, logger)
+	backupRepository, err := CreateBackupRepository(ctx, backupRepositoryClaim, backupdriverClient, logger)
 	if err != nil {
 		logger.Errorf("Failed to create the BackupRepository")
 		return err

--- a/pkg/backupdriver/backup_repository_test.go
+++ b/pkg/backupdriver/backup_repository_test.go
@@ -1,0 +1,110 @@
+package backupdriver
+
+import (
+	"context"
+	"github.com/sirupsen/logrus"
+	backupdriverv1 "github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/apis/backupdriver/v1"
+	backupdriverTypedV1 "github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/typed/backupdriver/v1"
+	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/utils"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/clientcmd"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestClaimBackupRepository(t *testing.T) {
+	path := os.Getenv("KUBECONFIG")
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		t.Skipf("The KubeConfig file, %v, is not exist", path)
+	}
+
+	config, err := clientcmd.BuildConfigFromFlags("", path)
+	if err != nil {
+		t.Fatalf("Failed to build k8s config from kubeconfig file: %+v ", err)
+	}
+
+	// Setup Logger
+	logger := logrus.New()
+	formatter := new(logrus.TextFormatter)
+	formatter.TimestampFormat = time.RFC3339Nano
+	formatter.FullTimestamp = true
+	logger.SetFormatter(formatter)
+	logger.SetLevel(logrus.DebugLevel)
+
+	veleroNs, exist := os.LookupEnv("VELERO_NAMESPACE")
+	if !exist {
+		errMsg := "Failed to lookup the ENV variable for velero namespace"
+		t.Fatalf(errMsg)
+	}
+
+	backupdriverClient, err := backupdriverTypedV1.NewForConfig(config)
+	if err != nil {
+		t.Fatalf("Failed to retrieve backupdriverClient from config: %v", config)
+	}
+	repositoryParameters := make(map[string]string)
+	ctx := context.Background()
+	testDoneStatus := make(chan bool)
+
+	// The following anon function triggers ClaimBackupRepository and waits for the BR
+	go func() {
+		backupRepositoryName, err := ClaimBackupRepository(ctx, utils.S3RepositoryDriver, repositoryParameters,
+			[]string{"test"}, veleroNs, backupdriverClient, logger)
+		if err != nil {
+			t.Fatalf("Failed to retrieve the BackupRepository name.")
+		}
+		logger.Infof("Successfully retrieved the BackupRepository name: %s", backupRepositoryName)
+		// Trigger a test complete.
+		testDoneStatus <- true
+	}()
+
+
+	// Wait for the BRC to be created and create corresponding BR.
+	watchlist := cache.NewListWatchFromClient(backupdriverClient.RESTClient(),
+		"backuprepositoryclaims", veleroNs, fields.Everything())
+	_, controller := cache.NewInformer(
+		watchlist,
+		&backupdriverv1.BackupRepositoryClaim{},
+		time.Second*0,
+		cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				backupRepoClaim := obj.(*backupdriverv1.BackupRepositoryClaim)
+				logger.Infof("Backup Repository Claim added: %s", backupRepoClaim.Name)
+				err = handleNewBackupRepositoryClaim(ctx, backupRepoClaim, veleroNs, backupdriverClient, logger)
+				if err != nil {
+					t.Fatalf("The test failed while processing new BRC.")
+				}
+				logger.Infof("Successfully created BR and patched BRC to point to BR.")
+			},
+		})
+	stop := make(chan struct{})
+	go controller.Run(stop)
+	select {
+	case <-ctx.Done():
+		stop <- struct{}{}
+	case <-testDoneStatus:
+		logger.Infof("Test completed successfully")
+	}
+}
+
+// This function creates a new BR in response to the BRC.
+// Patches the BRC with the BR
+func handleNewBackupRepositoryClaim(ctx context.Context,
+	backupRepositoryClaim *backupdriverv1.BackupRepositoryClaim,
+	ns string,
+	backupdriverClient *backupdriverTypedV1.BackupdriverV1Client,
+	logger logrus.FieldLogger) error {
+	backupRepository, err := CreateBackupRepository(ctx, backupRepositoryClaim.RepositoryDriver,
+		backupRepositoryClaim.RepositoryParameters, backupRepositoryClaim.AllowedNamespaces, backupRepositoryClaim.Name,
+		backupdriverClient, logger)
+	if err != nil {
+		logger.Errorf("Failed to create the BackupRepository")
+		return err
+	}
+	err = PatchBackupRepositoryClaim(backupRepositoryClaim, backupRepository.Name, ns, backupdriverClient)
+	if err != nil {
+		logger.Errorf("Failed to patch the BRC with the newly created BR")
+	}
+	return nil
+}

--- a/pkg/plugin/backup_pvc_action_plugin.go
+++ b/pkg/plugin/backup_pvc_action_plugin.go
@@ -74,7 +74,7 @@ func (p *NewPVCBackupItemAction) Execute(item runtime.Unstructured, backup *vele
 	repositoryParameters := make(map[string]string) // TODO: retrieve the real object store config from velero storage location
 	ctx := context.Background()
 
-	backupRepositoryCR, err := backupdriver.ClaimBackupRepository(ctx, utils.S3RepositoryDriver, repositoryParameters,
+	backupRepositoryName, err := backupdriver.ClaimBackupRepository(ctx, utils.S3RepositoryDriver, repositoryParameters,
 		[]string{pvc.Namespace}, veleroNs, backupdriverClient, p.Log)
 	if err != nil {
 		p.Log.Errorf("Failed to claim backup repository: %v", err)
@@ -88,7 +88,7 @@ func (p *NewPVCBackupItemAction) Execute(item runtime.Unstructured, backup *vele
 	}
 
 	p.Log.Info("Creating a snapshot CR")
-	backupRepository := backupdriver.NewBackupRepository(backupRepositoryCR.Name)
+	backupRepository := backupdriver.NewBackupRepository(backupRepositoryName)
 	_, err = backupdriver.SnapshopRef(ctx, backupdriverClient, objectToSnapshot, pvc.Namespace, *backupRepository, []backupdriverv1api.SnapshotPhase{backupdriverv1api.SnapshotPhaseSnapshotted}, p.Log)
 	if err != nil {
 		p.Log.Errorf("Failed to create a snapshot CR: %v", err)


### PR DESCRIPTION
1. Previously ClaimBackupRepository watched BRs to check if has a BRC reference, if so, the BR was returned.
2. This code path does not work when its called in GC to create a BRC in the supervisor cluster as there are insufficient privileges to list BRs from the supervisor cluster.
3. Current change watches BRCs to see if it has a BR reference.
3. Changed return type from BR to string.
4. Added unit test

KUBECONFIG=~/.kube/config go test -run TestClaimBackupRepository -timeout 0 -v PASS