### PR TITLE
Add CopyToRepoWithBackupRepository and CopyFromRepoWithBackupRepository in data_mover

### DIFF
--- a/pkg/controller/upload_controller.go
+++ b/pkg/controller/upload_controller.go
@@ -304,7 +304,16 @@ func (c *uploadController) processUpload(req *pluginv1api.Upload) error {
 		return errors.New(errMsg)
 	}
 
-	_, err = c.dataMover.CopyToRepo(peID)
+	if req.Spec.BackupRepositoryName != "" {
+		backupRepositoryCR, err := utils.GetBackupRepositoryFromBackupRepositoryName(req.Spec.BackupRepositoryName)
+		if err != nil {
+			log.WithError(err).Errorf("Failed to get BackupRepository from BackupRepositoryName %s", req.Spec.BackupRepositoryName)
+			return err
+		}
+		_, err = c.dataMover.CopyToRepoWithBackupRepository(peID, backupRepositoryCR)
+	} else {
+		_, err = c.dataMover.CopyToRepo(peID)
+	}
 	if err != nil {
 		log.Infof("CopyToRepo Error Received: %v", err.Error())
 		// Check if the request was canceled.

--- a/pkg/dataMover/data_mover.go
+++ b/pkg/dataMover/data_mover.go
@@ -23,7 +23,9 @@ import (
 	"github.com/vmware-tanzu/astrolabe/pkg/astrolabe"
 	"github.com/vmware-tanzu/astrolabe/pkg/ivd"
 	"github.com/vmware-tanzu/astrolabe/pkg/s3repository"
+	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/builder"
 	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/utils"
+	backupdriverv1 "github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/apis/backupdriver/v1"
 	"sync"
 )
 
@@ -87,6 +89,15 @@ func NewDataMoverFromCluster(params map[string]interface{}, logger logrus.FieldL
 }
 
 func (this *DataMover) CopyToRepo(peID astrolabe.ProtectedEntityID) (astrolabe.ProtectedEntityID, error) {
+	backupRepository := builder.ForBackupRepository(utils.WithoutBackupRepository).Result()
+	return this.copyToRepo(peID, backupRepository)
+}
+
+func (this *DataMover) CopyToRepoWithBackupRepository(peID astrolabe.ProtectedEntityID, backupRepository *backupdriverv1.BackupRepository) (astrolabe.ProtectedEntityID, error) {
+	return this.copyToRepo(peID, backupRepository)
+}
+
+func (this *DataMover) copyToRepo(peID astrolabe.ProtectedEntityID, backupRepository *backupdriverv1.BackupRepository) (astrolabe.ProtectedEntityID, error) {
 	log := this.WithField("Local PEID", peID.String())
 	log.Infof("Copying the snapshot from local to remote repository")
 	ctx := context.Background()
@@ -101,6 +112,14 @@ func (this *DataMover) CopyToRepo(peID astrolabe.ProtectedEntityID) (astrolabe.P
 	this.RegisterOngoingUpload(peID, cancelFunc)
 
 	log.Debugf("Ready to call s3 PETM copy API for local PE")
+	if backupRepository.Name != utils.WithoutBackupRepository {
+		repoPETM, err := utils.GetRepositoryFromBackupRepository(backupRepository, log)
+		if err != nil {
+			log.WithError(err).Errorf("Failed to get S3 repository from backup repository %s", backupRepository.Name)
+			return astrolabe.ProtectedEntityID{}, err
+		}
+		this.s3PETM = repoPETM
+	}
 	s3PE, err := this.s3PETM.Copy(ctx, updatedPE, astrolabe.AllocateNewObject)
 	log.Debugf("Return from the call of s3 PETM copy API for local PE")
 	if err != nil {
@@ -113,8 +132,25 @@ func (this *DataMover) CopyToRepo(peID astrolabe.ProtectedEntityID) (astrolabe.P
 }
 
 func (this *DataMover) CopyFromRepo(peID astrolabe.ProtectedEntityID) (astrolabe.ProtectedEntityID, error) {
+	backupRepository := builder.ForBackupRepository("Not use").Result()
+	return this.copyFromRepo(peID, backupRepository)
+}
+
+func (this *DataMover) CopyFromRepoWithBackupRepository(peID astrolabe.ProtectedEntityID, backupRepository *backupdriverv1.BackupRepository) (astrolabe.ProtectedEntityID, error) {
+	return this.copyFromRepo(peID, backupRepository)
+}
+
+func (this *DataMover) copyFromRepo(peID astrolabe.ProtectedEntityID, backupRepository *backupdriverv1.BackupRepository) (astrolabe.ProtectedEntityID, error) {
 	log := this.WithField("Remote PEID", peID.String())
 	log.Infof("Copying the snapshot from remote repository to local.")
+	if backupRepository.Name != utils.WithoutBackupRepository {
+		repoPETM, err := utils.GetRepositoryFromBackupRepository(backupRepository, log)
+		if err != nil {
+			log.WithError(err).Errorf("Failed to get S3 repository from backup repository %s", backupRepository.Name)
+			return astrolabe.ProtectedEntityID{}, err
+		}
+		this.s3PETM = repoPETM
+	}
 	ctx := context.Background()
 	pe, err := this.s3PETM.GetProtectedEntity(ctx, peID)
 	if err != nil {

--- a/pkg/snapshotmgr/snapshot_manager.go
+++ b/pkg/snapshotmgr/snapshot_manager.go
@@ -354,6 +354,7 @@ func (this *SnapshotManager) deleteSnapshot(peID astrolabe.ProtectedEntityID, ba
 			backupRepositoryCR, err := pluginClient.BackupdriverV1().BackupRepositories().Get(backupRepositoryName, metav1.GetOptions{})
 			if err != nil {
 				log.WithError(err).Errorf("Error while retrieving the backup repository CR %v", backupRepositoryName)
+				return err
 			}
 			err = this.DeleteRemoteSnapshotFromRepo(peID, backupRepositoryCR)
 		} else {

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -155,3 +155,7 @@ const (
 	PvTokenLocation     = "/credentials/token"
 	PvCrtLocation       = "/credentials/ca.crt"
 )
+
+const (
+	WithoutBackupRepository = "without-backup-repository"
+)


### PR DESCRIPTION
Update CopyToRepo and CopyFromRepo in data mover with BackupRepository to get S3PETM from BackupRepository params instead of hard coding S3PETM when initializing data mover.

Precheck(ongoing):
https://container-dp.svc.eng.vmware.com/job/Container_Precheck_Velero/217/