### PR TITLE
Translate BSL to Repoistory Parameters.

### DIFF
--- a/pkg/dataMover/data_mover.go
+++ b/pkg/dataMover/data_mover.go
@@ -46,7 +46,7 @@ func NewDataMoverFromCluster(params map[string]interface{}, logger logrus.FieldL
 		logger.Infof("DataMover: vSphere VC credential is retrieved")
 	}
 
-	err := utils.RetrieveVSLFromVeleroBSLs(params, nil, logger)
+	err := utils.RetrieveVSLFromVeleroBSLs(params, utils.DefaultS3BackupLocation, nil, logger)
 	if err != nil {
 		logger.WithError(err).Errorf("Could not retrieve velero default backup location.")
 		return nil, err

--- a/pkg/plugin/backup_pvc_action_plugin.go
+++ b/pkg/plugin/backup_pvc_action_plugin.go
@@ -74,7 +74,7 @@ func (p *NewPVCBackupItemAction) Execute(item runtime.Unstructured, backup *vele
 
 	p.Log.Info("Claiming backup repository for snapshot")
 	bslName := backup.Spec.StorageLocation
-	repositoryParameters := make(map[string]string) // TODO: retrieve the real object store config from velero storage location
+	repositoryParameters := make(map[string]string)
 
 	err = utils.RetrieveParamsFromBSL(repositoryParameters, bslName, restConfig, p.Log)
 	if err != nil {

--- a/pkg/plugin/backup_pvc_action_plugin.go
+++ b/pkg/plugin/backup_pvc_action_plugin.go
@@ -70,8 +70,17 @@ func (p *NewPVCBackupItemAction) Execute(item runtime.Unstructured, backup *vele
 		return nil, nil, errors.WithStack(err)
 	}
 
+
+
 	p.Log.Info("Claiming backup repository for snapshot")
+	bslName := backup.Spec.StorageLocation
 	repositoryParameters := make(map[string]string) // TODO: retrieve the real object store config from velero storage location
+
+	err = utils.RetrieveParamsFromBSL(repositoryParameters, bslName, restConfig, p.Log)
+	if err != nil {
+		p.Log.Errorf("Failed to translate BSL to repository parameters: %v", err)
+		return nil, nil, errors.WithStack(err)
+	}
 	ctx := context.Background()
 
 	backupRepositoryName, err := backupdriver.ClaimBackupRepository(ctx, utils.S3RepositoryDriver, repositoryParameters,

--- a/pkg/snapshotmgr/snapshot_manager.go
+++ b/pkg/snapshotmgr/snapshot_manager.go
@@ -120,7 +120,7 @@ func NewSnapshotManagerFromConfig(configInfo server.ConfigInfo, s3RepoParams map
 			s3RepoParams["region"] = region
 			s3RepoParams["bucket"] = bucket
 		} else {
-			err = utils.RetrieveVSLFromVeleroBSLs(s3RepoParams, k8sRestConfig, logger)
+			err = utils.RetrieveVSLFromVeleroBSLs(s3RepoParams, utils.DefaultS3BackupLocation, k8sRestConfig, logger)
 			if err != nil {
 				logger.WithError(err).Errorf("Could not retrieve velero default backup location")
 				return nil, err

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -70,9 +70,12 @@ const (
 
 // configuration constants for the S3 repository
 const (
-	DefaultS3RepoPrefix = "plugins/vsphere-astrolabe-repo"
+	DefaultS3RepoPrefix     = "plugins/vsphere-astrolabe-repo"
 	DefaultS3BackupLocation = "default"
+	AWS_ACCESS_KEY_ID       = "aws_access_key_id"
+	AWS_SECRET_ACCESS_KEY   = "aws_secret_access_key"
 )
+
 const (
 	// Minimum velero version number to meet velero plugin requirement
 	VeleroMinVersion = "v1.3.2"
@@ -84,7 +87,8 @@ const (
 const (
 	// DefaultNamespace is the Kubernetes namespace that is used by default for
 	// the Velero server and API objects.
-	DefaultNamespace = "velero"
+	DefaultNamespace  = "velero"
+	DefaultSecretName = "cloud-credentials"
 )
 
 const (

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -71,6 +71,7 @@ const (
 // configuration constants for the S3 repository
 const (
 	DefaultS3RepoPrefix = "plugins/vsphere-astrolabe-repo"
+	DefaultS3BackupLocation = "default"
 )
 const (
 	// Minimum velero version number to meet velero plugin requirement

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -87,8 +87,8 @@ const (
 const (
 	// DefaultNamespace is the Kubernetes namespace that is used by default for
 	// the Velero server and API objects.
-	DefaultNamespace  = "velero"
-	DefaultSecretName = "cloud-credentials"
+	DefaultNamespace          = "velero"
+	CloudCredentialSecretName = "cloud-credentials"
 )
 
 const (

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -161,9 +161,9 @@ func RetrieveParamsFromBSL(repositoryParams map[string]string, bslName string, c
 	}
 
 	secretsClient := clientset.CoreV1().Secrets(veleroNs)
-	secret, err := secretsClient.Get(DefaultSecretName, metav1.GetOptions{})
+	secret, err := secretsClient.Get(CloudCredentialSecretName, metav1.GetOptions{})
 	if err != nil {
-		logger.Errorf("RetrieveParamsFromBSL: Failed to retrieve the Secret for %s", DefaultSecretName)
+		logger.Errorf("RetrieveParamsFromBSL: Failed to retrieve the Secret for %s", CloudCredentialSecretName)
 		return err
 	}
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -143,12 +143,6 @@ func RetrieveParamsFromBSL(repositoryParams map[string]string, bslName string, c
 		repositoryParams[key] = paramValue
 	}
 
-	// Extract credentials
-	config, err = rest.InClusterConfig()
-	if err != nil {
-		return errors.Wrap(err, "Could not retrieve in-cluster config")
-	}
-
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return errors.Wrap(err, "Failed to retrieve the k8s clientset")

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -18,23 +18,29 @@ package utils
 
 import (
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	veleroplugintest "github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/test"
 	v1 "github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/apis/backupdriver/v1"
-	"testing"
+	backupdriverTypedV1 "github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/typed/backupdriver/v1"
+	veleroplugintest "github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/test"
+	"github.com/vmware-tanzu/velero/pkg/generated/clientset/versioned"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/clientcmd"
+	"os"
+	"testing"
+	"time"
 )
 
 func TestGetStringFromParamsMap(t *testing.T) {
-    params := make(map[string]interface{})
-    params["ValidKey"] = "ValidValue"
-    params["NonString"] = false
-    tests := []struct{
-    	name          string
-    	key           string
-    	expectedValue string
-    	ok            bool
+	params := make(map[string]interface{})
+	params["ValidKey"] = "ValidValue"
+	params["NonString"] = false
+	tests := []struct {
+		name          string
+		key           string
+		expectedValue string
+		ok            bool
 	}{
 		{
 			name:          "Valid key with string value should return corresponding value and true",
@@ -56,19 +62,19 @@ func TestGetStringFromParamsMap(t *testing.T) {
 		},
 	}
 
-    logger := veleroplugintest.NewLogger()
+	logger := veleroplugintest.NewLogger()
 
-    for _, test := range tests {
-    	t.Run(test.name, func(t *testing.T) {
-    		str, ok := GetStringFromParamsMap(params, test.key, logger)
-            assert.Equal(t, test.expectedValue, str)
-    		assert.Equal(t, test.ok, ok)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			str, ok := GetStringFromParamsMap(params, test.key, logger)
+			assert.Equal(t, test.expectedValue, str)
+			assert.Equal(t, test.ok, ok)
 		})
 	}
 }
 
 func TestGetBool(t *testing.T) {
-	tests := []struct{
+	tests := []struct {
 		name        string
 		str         string
 		defValue    bool
@@ -87,16 +93,16 @@ func TestGetBool(t *testing.T) {
 			expectedVal: false,
 		},
 		{
-			name:     "Empty string",
-			str:      "",
-			defValue: false,
-                        expectedVal: false,
+			name:        "Empty string",
+			str:         "",
+			defValue:    false,
+			expectedVal: false,
 		},
 		{
-			name:     "Invalid str",
-			str:      "AAA",
-			defValue: true,
-                        expectedVal: true,
+			name:        "Invalid str",
+			str:         "AAA",
+			defValue:    true,
+			expectedVal: true,
 		},
 	}
 	for _, test := range tests {
@@ -111,15 +117,15 @@ func TestCreateRepositoryFromBackupRepository(t *testing.T) {
 	map1 := make(map[string]string)
 	map2 := make(map[string]string)
 	map2["region"] = "us-west-1"
-	tests := []struct{
+	tests := []struct {
 		name             string
 		key              string
 		backupRepository *v1.BackupRepository
 		expectedErr      error
 	}{
 		{
-			name:             "Unsupported backup driver type returns error",
-			key:              "backupdriver/backuprepository-1",
+			name: "Unsupported backup driver type returns error",
+			key:  "backupdriver/backuprepository-1",
 			backupRepository: &v1.BackupRepository{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: v1.SchemeGroupVersion.String(),
@@ -130,27 +136,11 @@ func TestCreateRepositoryFromBackupRepository(t *testing.T) {
 				},
 				RepositoryDriver: "unsupported-driver",
 			},
-			expectedErr:      errors.New("Unsupported backuprepository driver type: unsupported-driver. Only support s3repository.astrolabe.vmware-tanzu.com."),
+			expectedErr: errors.New("Unsupported backuprepository driver type: unsupported-driver. Only support s3repository.astrolabe.vmware-tanzu.com."),
 		},
 		{
 			name: "Repository parameter missing region should return error",
-			key:   "miss-region",
-			backupRepository: &v1.BackupRepository{
-			    TypeMeta: metav1.TypeMeta{
-			        APIVersion: v1.SchemeGroupVersion.String(),
-			        Kind:       "BackupRepository",
-		        },
-			    ObjectMeta: metav1.ObjectMeta{
-			        Name: "default",
-		        },
-			    RepositoryDriver: S3RepositoryDriver,
-			    RepositoryParameters: map1,
-		    },
-			expectedErr: errors.New("Missing region param, cannot initialize S3 PETM"),
-		},
-		{
-			name: "Repository parameter missing bucket should return error",
-			key:   "miss-bucket",
+			key:  "miss-region",
 			backupRepository: &v1.BackupRepository{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: v1.SchemeGroupVersion.String(),
@@ -159,7 +149,23 @@ func TestCreateRepositoryFromBackupRepository(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "default",
 				},
-				RepositoryDriver: S3RepositoryDriver,
+				RepositoryDriver:     S3RepositoryDriver,
+				RepositoryParameters: map1,
+			},
+			expectedErr: errors.New("Missing region param, cannot initialize S3 PETM"),
+		},
+		{
+			name: "Repository parameter missing bucket should return error",
+			key:  "miss-bucket",
+			backupRepository: &v1.BackupRepository{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: v1.SchemeGroupVersion.String(),
+					Kind:       "BackupRepository",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "default",
+				},
+				RepositoryDriver:     S3RepositoryDriver,
 				RepositoryParameters: map2,
 			},
 			expectedErr: errors.New("Missing bucket param, cannot initialize S3 PETM"),
@@ -167,12 +173,60 @@ func TestCreateRepositoryFromBackupRepository(t *testing.T) {
 	}
 	for _, test := range tests {
 		var (
-			logger          = veleroplugintest.NewLogger()
+			logger = veleroplugintest.NewLogger()
 		)
 
 		t.Run(test.name, func(t *testing.T) {
 			_, err := GetRepositoryFromBackupRepository(test.backupRepository, logger)
 			assert.Equal(t, test.expectedErr.Error(), err.Error())
 		})
+	}
+}
+
+func TestRetrieveParamsFromBSL(t *testing.T) {
+	path := os.Getenv("KUBECONFIG")
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		t.Skipf("The KubeConfig file, %v, is not exist", path)
+	}
+
+	config, err := clientcmd.BuildConfigFromFlags("", path)
+	if err != nil {
+		t.Fatalf("Failed to build k8s config from kubeconfig file: %+v ", err)
+	}
+
+	// Setup Logger
+	logger := logrus.New()
+	formatter := new(logrus.TextFormatter)
+	formatter.TimestampFormat = time.RFC3339Nano
+	formatter.FullTimestamp = true
+	logger.SetFormatter(formatter)
+	logger.SetLevel(logrus.DebugLevel)
+
+	// using velero ns for testing.
+	veleroNs := "velero"
+
+	veleroClient, err := versioned.NewForConfig(config)
+	if err != nil {
+		t.Fatalf("Failed to retrieve veleroClient")
+	}
+
+	_, err = backupdriverTypedV1.NewForConfig(config)
+	if err != nil {
+		t.Fatalf("Failed to retrieve backupdriverClient from config: %v", config)
+	}
+
+	backupStorageLocationList, err := veleroClient.VeleroV1().BackupStorageLocations(veleroNs).List(metav1.ListOptions{})
+	if err != nil || len(backupStorageLocationList.Items) <= 0 {
+		t.Fatalf("RetrieveVSLFromVeleroBSLs: Failed to list Velero default backup storage location")
+	}
+	for _, item := range backupStorageLocationList.Items {
+		repositoryParameters := make(map[string]string)
+		bslName := item.Name
+		err := RetrieveParamsFromBSL(repositoryParameters, bslName, config, logger)
+		if err != nil {
+			logger.Errorf("Retrieve Failed %v", err)
+			t.Fatalf("RetrieveParamsFromBSL failed!")
+		}
+		logger.Infof("Repository Parameters: %v", repositoryParameters)
 	}
 }


### PR DESCRIPTION
1. Retrieve the BSL for the specific backup request.
2. From the BSL extract all the necessary aws params- region, bucket, s3ForcePathStyle, s3Url
3. Among them, extract the current profile in use, this is specified in bsl.Spec.Config["profile"]
4. The above profile determines which credentials will be used from the cloud-credential file.
5. Retrieve the "cloud-credential" Secret from velero namespace.
6. secret.Data holds the whole credential file in byte format.
7. Create a temp file to move the credentials into it, this is done so that we can use pre-existing aws credential
apis to extract the access key/secret.
8. Use credentials.NewSharedCredentials(tmpfileName, bsl-profile) to extract the relevant key/secret.
9. Store them in repository parameters.
10. Use the repo parameters everywhere the s3 repo is being initialized, currently this happens in GetS3PETMFromParamsMap.

Testing.
1. Read bsl name and extracted the credentials for the bsl in the guest cluster.
2. Triggered BRC creation in the guest.
3. Verified that the BR in supervisor cluster has the credentials populated.

Signed-off-by: Deepak Kinni <dkinni@vmware.com>