### PR TITLE
Create a Snapshot record only if one already does not exist.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -204,7 +204,7 @@ push-backup-driver: backup-driver-container
 push: push-datamgr push-plugin push-backup-driver
 
 push-pp:
-	$(MAKE) push-plugin LOCALMODE=true VERSION=$(VERSION)-pp
+	$(MAKE) push LOCALMODE=true VERSION=$(VERSION)-pp
 
 QUALIFIED_TAG ?=
 RELEASE_TAG ?= latest

--- a/pkg/builder/snapshot_builder.go
+++ b/pkg/builder/snapshot_builder.go
@@ -1,0 +1,56 @@
+package builder
+
+import (
+	backupdriverv1 "github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/apis/backupdriver/v1"
+	core_v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// SnapshotBuilder builds Snapshot objects.
+type SnapshotBuilder struct {
+	object *backupdriverv1.Snapshot
+}
+
+func ForSnapshot(ns, name string) *SnapshotBuilder {
+	return &SnapshotBuilder{
+		object: &backupdriverv1.Snapshot{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: backupdriverv1.SchemeGroupVersion.String(),
+				Kind:       "Snapshot",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: ns,
+			},
+		},
+	}
+}
+
+// Result returns the built Snapshot.
+func (b *SnapshotBuilder) Result() *backupdriverv1.Snapshot {
+	return b.object
+}
+
+// BackupRepository sets the name of the backup repository for this specific snapshot.
+func (b *SnapshotBuilder) BackupRepository(backupRepositoryName string) *SnapshotBuilder {
+	b.object.Spec.BackupRepository = backupRepositoryName
+	return b
+}
+
+// Set the spec object reference
+func (b *SnapshotBuilder) ObjectReference(objectToSnapshot core_v1.TypedLocalObjectReference) *SnapshotBuilder {
+	b.object.Spec.TypedLocalObjectReference = objectToSnapshot
+	return b
+}
+
+// Set the spec cancel state
+func (b *SnapshotBuilder) CancelState(cancelState bool) *SnapshotBuilder {
+	b.object.Spec.SnapshotCancel = cancelState
+	return b
+}
+
+// Set the status phase
+func (b *SnapshotBuilder) StatusPhase(phase backupdriverv1.SnapshotPhase) *SnapshotBuilder {
+	b.object.Status.Phase = phase
+	return b
+}

--- a/pkg/paravirt/paravirt_protected_entity.go
+++ b/pkg/paravirt/paravirt_protected_entity.go
@@ -2,13 +2,14 @@ package paravirt
 
 import (
 	"context"
+	"io"
+
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/vmware-tanzu/astrolabe/pkg/astrolabe"
 	"github.com/vmware-tanzu/astrolabe/pkg/pvc"
 	backupdriverv1api "github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/apis/backupdriver/v1"
 	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/snapshotUtils"
-	"io"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -77,7 +78,7 @@ func (this ParaVirtProtectedEntity) Snapshot(ctx context.Context, params map[str
 
 	this.logger.Info("Creating a snapshot CR")
 	backupRepository := snapshotUtils.NewBackupRepository(backupRepositoryName)
-	snapshot, err := snapshotUtils.SnapshopRef(ctx, this.pvpetm.svcBackupDriverClient, objectToSnapshot, this.pvpetm.svcNamespace, *backupRepository, []backupdriverv1api.SnapshotPhase{backupdriverv1api.SnapshotPhaseSnapshotted}, this.logger)
+	snapshot, err := snapshotUtils.SnapshotRef(ctx, this.pvpetm.svcBackupDriverClient, objectToSnapshot, this.pvpetm.svcNamespace, *backupRepository, []backupdriverv1api.SnapshotPhase{backupdriverv1api.SnapshotPhaseSnapshotted}, this.logger)
 	if err != nil {
 		this.logger.Errorf("Failed to create a snapshot CR: %v", err)
 		return astrolabe.ProtectedEntitySnapshotID{}, err

--- a/pkg/plugin/backup_pvc_action_plugin.go
+++ b/pkg/plugin/backup_pvc_action_plugin.go
@@ -2,6 +2,8 @@ package plugin
 
 import (
 	"context"
+	"os"
+
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	backupdriverv1api "github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/apis/backupdriver/v1"
@@ -15,7 +17,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
-	"os"
 )
 
 // PVCBackupItemAction is a backup item action plugin for Velero.
@@ -84,13 +85,13 @@ func (p *NewPVCBackupItemAction) Execute(item runtime.Unstructured, backup *vele
 
 	objectToSnapshot := corev1.TypedLocalObjectReference{
 		APIGroup: &corev1.SchemeGroupVersion.Group,
-		Kind: pvc.Kind,
-		Name: pvc.Name,
+		Kind:     pvc.Kind,
+		Name:     pvc.Name,
 	}
 
 	p.Log.Info("Creating a snapshot CR")
 	backupRepository := snapshotUtils.NewBackupRepository(backupRepositoryName)
-	_, err = snapshotUtils.SnapshopRef(ctx, backupdriverClient, objectToSnapshot, pvc.Namespace, *backupRepository, []backupdriverv1api.SnapshotPhase{backupdriverv1api.SnapshotPhaseSnapshotted}, p.Log)
+	_, err = snapshotUtils.SnapshotRef(ctx, backupdriverClient, objectToSnapshot, pvc.Namespace, *backupRepository, []backupdriverv1api.SnapshotPhase{backupdriverv1api.SnapshotPhaseSnapshotted}, p.Log)
 	if err != nil {
 		p.Log.Errorf("Failed to create a snapshot CR: %v", err)
 		return nil, nil, errors.WithStack(err)

--- a/pkg/snapshotUtils/snapshot_test.go
+++ b/pkg/snapshotUtils/snapshot_test.go
@@ -3,6 +3,9 @@ package snapshotUtils
 import (
 	"context"
 	"fmt"
+	"testing"
+	"time"
+
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	backupdriverv1 "github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/apis/backupdriver/v1"
@@ -10,8 +13,6 @@ import (
 	core_v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clientcmd"
-	"testing"
-	"time"
 )
 
 func TestWaitForPhases(t *testing.T) {
@@ -109,7 +110,7 @@ func TestSnapshotRef(t *testing.T) {
 		backupRepository: "test-repo",
 	}
 
-	snapshot, err := SnapshopRef(context.Background(), clientSet, objectToSnapshot, "backup-driver", backupRepository,
+	snapshot, err := SnapshotRef(context.Background(), clientSet, objectToSnapshot, "backup-driver", backupRepository,
 		[]backupdriverv1.SnapshotPhase{backupdriverv1.SnapshotPhaseSnapshotted})
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
An issue was seen when testing with guest backup. Multiple Snapshot
CRs were created in the supervisor namespace, until the snapshot state
was updated to "Snapshotted". This change fixes that issue.

Signed-off-by: Swati Gupta <swgupta@swgupta-a01.vmware.com>