### PR TITLE
Change upload in createsnapshot to upload subcomponent for pvc

### DIFF
--- a/pkg/dataMover/data_mover.go
+++ b/pkg/dataMover/data_mover.go
@@ -132,7 +132,7 @@ func (this *DataMover) copyToRepo(peID astrolabe.ProtectedEntityID, backupReposi
 }
 
 func (this *DataMover) CopyFromRepo(peID astrolabe.ProtectedEntityID) (astrolabe.ProtectedEntityID, error) {
-	backupRepository := builder.ForBackupRepository("Not use").Result()
+	backupRepository := builder.ForBackupRepository(utils.WithoutBackupRepository).Result()
 	return this.copyFromRepo(peID, backupRepository)
 }
 


### PR DESCRIPTION
Currently when upload snapshot for pvc it will failed due to format error when GetProtectedEntity. This pr change to upload subcomponent for pvc to avoid such issue.
This change will also resolve https://bugzilla.eng.vmware.com/show_bug.cgi?id=2612891

Test:
https://container-dp.svc.eng.vmware.com/job/Container_Precheck_Velero/279/

Manually tested backup, all upload succeeded.