### PR TITLE
Initiated the PVC restore request in RestoreItemAction plugin

### DIFF
--- a/pkg/plugin/restore_pvc_action_plugin.go
+++ b/pkg/plugin/restore_pvc_action_plugin.go
@@ -1,12 +1,19 @@
 package plugin
 
 import (
+	"context"
+	"fmt"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	backupdriverv1 "github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/apis/backupdriver/v1"
+	backupdriverTypedV1 "github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/typed/backupdriver/v1"
+	pluginItem "github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/plugin/util"
+	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/snapshotUtils"
+	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/utils"
 	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
-	corev1api "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
 )
 
 // PVCBackupItemAction is a backup item action plugin for Velero.
@@ -24,25 +31,65 @@ func (p *NewPVCRestoreItemAction) AppliesTo() (velero.ResourceSelector, error) {
 }
 
 func (p *NewPVCRestoreItemAction) Execute(input *velero.RestoreItemActionExecuteInput) (*velero.RestoreItemActionExecuteOutput, error) {
-	var pvc corev1api.PersistentVolumeClaim
+	var pvc corev1.PersistentVolumeClaim
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(input.Item.UnstructuredContent(), &pvc); err != nil {
 		return nil, errors.WithStack(err)
 	}
 
-	p.Log.Infof("VSphere PVCRestoreItemAction for PVC %s/%s started", pvc.Namespace, pvc.Name)
 	var err error
+	// get snapshot blob from PVC annotation and reset PVC annotation
+	snapshotAnnotation, ok := pvc.Annotations[utils.ItemSnapshotLabel]
+	if !ok {
+		p.Log.Infof("Skipping PVCRestoreItemAction for PVC %s/%s, PVC does not have a vSphere BackupItemAction snapshot.", pvc.Namespace, pvc.Name)
+		return &velero.RestoreItemActionExecuteOutput{
+			UpdatedItem: input.Item,
+		}, nil
+	}
+
+	var itemSnapshot backupdriverv1.Snapshot
+	if err = pluginItem.GetSnapshotFromPVCAnnotation(snapshotAnnotation, &itemSnapshot); err != nil {
+		p.Log.Errorf("Failed to parse the Snapshot object from PVC annotation: %v", err)
+		return nil, errors.WithStack(err)
+	}
+
+	p.Log.Infof("VSphere PVCRestoreItemAction for PVC %s/%s started", pvc.Namespace, pvc.Name)
 	defer func() {
-		p.Log.WithError(err).Infof("VSphere PVCRestoreItemAction for PVC %s/%s completed", pvc.Namespace, pvc.Name)
+		p.Log.Infof("VSphere PVCRestoreItemAction for PVC %s/%s completed with err: %v", pvc.Namespace, pvc.Name, err)
 	}()
 
-	// TODO: add logic for PVC restoration
-
-	pvcMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&pvc)
+	ctx := context.Background()
+	restConfig, err := rest.InClusterConfig()
+	if err != nil {
+		p.Log.Error("Failed to get the rest config in k8s cluster: %v", err)
+		return nil, errors.WithStack(err)
+	}
+	backupdriverClient, err := backupdriverTypedV1.NewForConfig(restConfig)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
 
+	snapshotID := itemSnapshot.Status.SnapshotID
+	snapshotMetadata := itemSnapshot.Status.Metadata
+	apiGroup := itemSnapshot.Spec.APIGroup
+	kind := itemSnapshot.Spec.Kind
+	backupRepository := snapshotUtils.NewBackupRepository(itemSnapshot.Spec.BackupRepository)
+
+	p.Log.Info("Creating a CloneFromSnapshot CR")
+	updatedCloneFromSnapshot, err := snapshotUtils.CloneFromSnapshopRef(ctx, backupdriverClient, snapshotID, snapshotMetadata, apiGroup, kind, pvc.Namespace, *backupRepository,
+		[]backupdriverv1.ClonePhase{backupdriverv1.ClonePhaseCompleted, backupdriverv1.ClonePhaseFailed}, p.Log)
+	if err != nil {
+		p.Log.Errorf("Failed to create a CloneFromSnapshot CR: %v", err)
+		return nil, errors.WithStack(err)
+	}
+	if updatedCloneFromSnapshot.Status.Phase == backupdriverv1.ClonePhaseFailed {
+		errMsg := fmt.Sprintf("Failed to create a CloneFromSnapshot CR: Phase=Failed, err=%v", updatedCloneFromSnapshot.Status.Message)
+		p.Log.Error(errMsg)
+		return nil, errors.New(errMsg)
+	}
+	p.Log.Info("Restored, %v, from PVC %s/%s in the backup", updatedCloneFromSnapshot.Status.ResourceHandle, pvc.Namespace, pvc.Name)
+
 	return &velero.RestoreItemActionExecuteOutput{
-		UpdatedItem: &unstructured.Unstructured{Object: pvcMap},
+		SkipRestore: true,
 	}, nil
 }
+

--- a/pkg/plugin/util/util.go
+++ b/pkg/plugin/util/util.go
@@ -1,0 +1,39 @@
+package util
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func GetSnapshotFromPVCAnnotation(snapshotAnnotation string, itemSnapshot interface{}) error {
+	decodedItemSnapshot, err := base64.StdEncoding.DecodeString(snapshotAnnotation)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	err = json.Unmarshal(decodedItemSnapshot, itemSnapshot)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	return nil
+}
+
+func GetAnnotationFromSnapshot(itemSnapshot interface{}) (string, error) {
+	itemSnapshotByteArray, err := json.Marshal(itemSnapshot)
+	if err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(itemSnapshotByteArray), nil
+}
+
+// AddAnnotations adds the supplied key-values to the annotations on the object
+func AddAnnotations(o *metav1.ObjectMeta, vals map[string]string) {
+	if o.Annotations == nil {
+		o.Annotations = make(map[string]string)
+	}
+	for k, v := range vals {
+		o.Annotations[k] = v
+	}
+}

--- a/pkg/snapshotUtils/snapshot_test.go
+++ b/pkg/snapshotUtils/snapshot_test.go
@@ -74,11 +74,11 @@ func TestWaitForPhases(t *testing.T) {
 	}
 
 	timeoutContext, _ := context.WithDeadline(context.Background(), time.Now().Add(time.Second*10))
-	endPhase, err := WaitForPhases(timeoutContext, clientSet, testSnapshot, []backupdriverv1.SnapshotPhase{backupdriverv1.SnapshotPhaseSnapshotted}, "backup-driver", logger)
+	updatedSnapshot, err := WaitForPhases(timeoutContext, clientSet, testSnapshot, []backupdriverv1.SnapshotPhase{backupdriverv1.SnapshotPhaseSnapshotted}, "backup-driver", logger)
 	if err != nil {
 		t.Fatalf("WaitForPhases returned err = %v\n", err)
 	} else {
-		fmt.Printf("WaitForPhases returned phase = %s\n", endPhase)
+		fmt.Printf("WaitForPhases returned phase = %s\n", updatedSnapshot.Status.Phase)
 	}
 }
 
@@ -140,11 +140,11 @@ func TestWaitForClonePhases(t *testing.T) {
 	}
 
 	timeoutContext, _ := context.WithDeadline(context.Background(), time.Now().Add(time.Second*10))
-	endPhase, err := WaitForClonePhases(timeoutContext, clientSet, testClone, []backupdriverv1.ClonePhase{backupdriverv1.ClonePhaseCompleted}, "backup-driver", logger)
+	updatedClone, err := WaitForClonePhases(timeoutContext, clientSet, testClone, []backupdriverv1.ClonePhase{backupdriverv1.ClonePhaseCompleted}, "backup-driver", logger)
 	if err != nil {
 		t.Fatalf("WaitForClonePhases returned err = %v\n", err)
 	} else {
-		fmt.Printf("WaitForClonePhases returned phase = %s\n", endPhase)
+		fmt.Printf("WaitForClonePhases returned phase = %s\n", updatedClone.Status.Phase)
 	}
 }
 

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -159,3 +159,7 @@ const (
 const (
 	WithoutBackupRepository = "without-backup-repository"
 )
+
+const (
+	ItemSnapshotLabel              = "velero-plugin-for-vsphere/item-snapshot-blob"
+)


### PR DESCRIPTION
Initiated the PVC restore request in RestoreItemAction plugin and updated CloneFromSnapshot CRD accordingly. Below are items included.

1. Initiated the PVC restore request in RestoreItemAction plugin 
2. Added encoded snapshot object as an annotation of the snapshotted PVC in BackupItemPlugin plugin (The annotation will be removed in RestoreItemAction plugin)
3. Updated util funcs in SnapshotUtils to return updated CR after updating status.

[Testing]
Regression Test: https://container-dp.svc.eng.vmware.com/job/Container_Precheck_Velero/283/ (Passed except unrelated failure)
Functional Test: Run velero  backup & restore. CloneFromSnapshot CR can be created and updated to `New` as expected in the velero restore workflow. (The restore path will not be end-to-end working until the corresponding restore logic in BackupDriver is completed)  