### PR TITLE
Support upload data path on supervisor cluster.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.4.0
-	github.com/vmware-tanzu/astrolabe v0.1.2-0.20200723051124-31a004b864ae
+	github.com/vmware-tanzu/astrolabe v0.1.2-0.20200731185127-4afab021f6b3
 	github.com/vmware-tanzu/velero v1.3.2
 	k8s.io/api v0.17.3
 	k8s.io/apiextensions-apiserver v0.17.3

--- a/go.sum
+++ b/go.sum
@@ -444,8 +444,8 @@ github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyC
 github.com/valyala/fasttemplate v1.0.1 h1:tY9CJiPnMXf1ERmG2EyK7gNUd+c6RKGD0IfU8WdUSz8=
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
-github.com/vmware-tanzu/astrolabe v0.1.2-0.20200723051124-31a004b864ae h1:Ei7vSzMuiLnJMVNJ0EsgvDFNn4YrncaNwhsY9Rl7Zio=
-github.com/vmware-tanzu/astrolabe v0.1.2-0.20200723051124-31a004b864ae/go.mod h1:hgUcdPy7lXeCTMUxHkYY9wCJnzFcB7dNw38+qXdIi9Q=
+github.com/vmware-tanzu/astrolabe v0.1.2-0.20200731185127-4afab021f6b3 h1:gu4O4IUoFcu3/hV7ch7KcpFjvGJ8fbWayQQ64e64lHI=
+github.com/vmware-tanzu/astrolabe v0.1.2-0.20200731185127-4afab021f6b3/go.mod h1:hgUcdPy7lXeCTMUxHkYY9wCJnzFcB7dNw38+qXdIi9Q=
 github.com/vmware-tanzu/velero v1.3.2 h1:Rhn37gjxn6Hwg6OFZUsW1CTuRaVuHEL8p/eiXrcKNGw=
 github.com/vmware-tanzu/velero v1.3.2/go.mod h1:s+8IqUKWcprcMVOfZKNC+jFY3tr/ElJfaMCcAfhThts=
 github.com/vmware/govmomi v0.22.2-0.20200329013745-f2eef8fc745f h1:6LIYlihC1/LDUhZ7zYVp1WOEY5owzsvogiaHBqvBzPU=

--- a/pkg/backupdriver/backup_driver_controller.go
+++ b/pkg/backupdriver/backup_driver_controller.go
@@ -54,14 +54,16 @@ func (ctrl *backupDriverController) createSnapshot(snapshot *backupdriverapi.Sna
 	// but it is not really used
 	var tags map[string]string
 
-	brName := snapshot.Spec.BackupRepository
 	if ctrl.backupdriverClient == nil {
 		errMsg := fmt.Sprintf("backupdriverClient is not initialized")
 		ctrl.logger.Error(errMsg)
 		return errors.New(errMsg)
 	}
 
-	if ctrl.svcKubeConfig != nil {
+	// Get the BackupRepository name. The snapshot spec can have an empty backup repository
+	// name in case of local mode.
+	brName := snapshot.Spec.BackupRepository
+	if ctrl.svcKubeConfig != nil && brName != "" {
 		// For guest cluster, get the supervisor backup repository name
 		br, err := ctrl.backupdriverClient.BackupRepositories().Get(brName, metav1.GetOptions{})
 		if err != nil {

--- a/pkg/cmd/backupdriver/cli/server/server.go
+++ b/pkg/cmd/backupdriver/cli/server/server.go
@@ -226,7 +226,7 @@ func newServer(f client.Factory, config serverConfig, logger *logrus.Logger) (*s
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	// If CLUSTER_FLAVOR is GUEST_CLUSTER, set up svcKubeConfig to communicate with the Supervisor Cluster
-	clusterFlavor, _ := utils.GetClusterFlavor(kubeClient)
+	clusterFlavor, _ := utils.GetClusterFlavor(clientConfig)
 	var svcConfig *rest.Config
 	var svcNamespace string
 	if clusterFlavor == utils.TkgGuest {


### PR DESCRIPTION
The data manager VM accesses the supervisor cluster in a vsphere
admin role. Also, since the data manager is remote and not running
on the same cluster, we do not have to pick a data manager instance
running on the same node as the PV pod. Made changes to support the
above specifications for the supervisor cluster.

Signed-off-by: Swati Gupta <swgupta@swgupta-a01.vmware.com>