### PR TITLE
Add unit test for fix which resolves vSphere login failure due to password has certain special chars

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -103,6 +103,17 @@ func RetrieveVcConfigSecret(params map[string]interface{}, config *rest.Config, 
 	sEnc := string(secret.Data[secretData])
 	lines := strings.Split(sEnc, "\n")
 
+	ParseLines(lines, params, logger)
+
+	// If port is missing, add an entry in the params to use the standard https port
+	if _, ok := params["port"]; !ok {
+		params["port"] = DefaultVCenterPort
+	}
+
+	return nil
+}
+
+func ParseLines(lines []string, params map[string]interface{}, logger logrus.FieldLogger) {
 	for _, line := range lines {
 		if strings.Contains(line, "VirtualCenter") {
 			parts := strings.Split(line, "\"")
@@ -121,13 +132,6 @@ func RetrieveVcConfigSecret(params map[string]interface{}, config *rest.Config, 
 			params[key] = unquotedValue
 		}
 	}
-
-	// If port is missing, add an entry in the params to use the standard https port
-	if _, ok := params["port"]; !ok {
-		params["port"] = DefaultVCenterPort
-	}
-
-	return nil
 }
 
 func RetrieveParamsFromBSL(repositoryParams map[string]string, bslName string, config *rest.Config,


### PR DESCRIPTION
This change adds unit tests for fix which resolves vSphere login failure due to password has certain special chars.
https://jira.eng.vmware.com/browse/DPCP-223
This issue was resolved in PR https://github.com/vmware-tanzu/velero-plugin-for-vsphere/pull/130.

Precheck(ongoing):
https://container-dp.svc.eng.vmware.com/job/Container_Precheck_Velero/293/

