### PR TITLE
Add retry logic to patch upload/download cr

### DIFF
--- a/pkg/controller/upload_controller.go
+++ b/pkg/controller/upload_controller.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"math"
 	"time"
 
@@ -293,7 +294,7 @@ func (c *uploadController) processUpload(req *pluginv1api.Upload) error {
 	// update status to InProgress
 	if req.Status.Phase != pluginv1api.UploadPhaseInProgress {
 		// update status to InProgress
-		req, err = c.patchUploadByStatus(req, pluginv1api.UploadPhaseInProgress, "")
+		req, err = c.patchUploadByStatusWithRetry(req, pluginv1api.UploadPhaseInProgress, "")
 		if err != nil {
 			return errors.WithStack(err)
 		}
@@ -303,7 +304,7 @@ func (c *uploadController) processUpload(req *pluginv1api.Upload) error {
 	peID, err := astrolabe.NewProtectedEntityIDFromString(req.Spec.SnapshotID)
 	if err != nil {
 		errMsg := fmt.Sprintf("Failed to get PEID from SnapshotID, %v. %v", req.Spec.SnapshotID, errors.WithStack(err))
-		_, err = c.patchUploadByStatus(req, pluginv1api.UploadPhaseUploadError, errMsg)
+		_, err = c.patchUploadByStatusWithRetry(req, pluginv1api.UploadPhaseUploadError, errMsg)
 		if err != nil {
 			errMsg = fmt.Sprintf("%v. %v", errMsg, errors.WithStack(err))
 		}
@@ -326,7 +327,7 @@ func (c *uploadController) processUpload(req *pluginv1api.Upload) error {
 		// Check if the request was canceled.
 		if errors.Is(err, context.Canceled) {
 			log.Infof("The upload of PE %v upload was canceled.", peID.String())
-			_, err = c.patchUploadByStatus(req, pluginv1api.UploadPhaseCanceled, "The upload was canceled.")
+			_, err = c.patchUploadByStatusWithRetry(req, pluginv1api.UploadPhaseCanceled, "The upload was canceled.")
 			if err != nil {
 				return err
 			}
@@ -334,7 +335,7 @@ func (c *uploadController) processUpload(req *pluginv1api.Upload) error {
 			return nil
 		} else {
 			errMsg := fmt.Sprintf("Failed to upload snapshot, %v, to durable object storage. %v", peID.String(), errors.WithStack(err))
-			_, err = c.patchUploadByStatus(req, pluginv1api.UploadPhaseUploadError, errMsg)
+			_, err = c.patchUploadByStatusWithRetry(req, pluginv1api.UploadPhaseUploadError, errMsg)
 			if err != nil {
 				errMsg = fmt.Sprintf("%v. %v", errMsg, errors.WithStack(err))
 			}
@@ -351,7 +352,7 @@ func (c *uploadController) processUpload(req *pluginv1api.Upload) error {
 	if err != nil {
 		errMsg := fmt.Sprintf("Failed to clean up local snapshot after uploading snapshot, %v. %v", peID.String(), errors.WithStack(err))
 		// TODO: Change the upload CRD definition to add one more phase, such as, UploadPhaseFailedLocalCleanup
-		_, err = c.patchUploadByStatus(req, pluginv1api.UploadPhaseCleanupFailed, errMsg)
+		_, err = c.patchUploadByStatusWithRetry(req, pluginv1api.UploadPhaseCleanupFailed, errMsg)
 		if err != nil {
 			errMsg = fmt.Sprintf("%v. %v", errMsg, errors.WithStack(err))
 		}
@@ -360,7 +361,7 @@ func (c *uploadController) processUpload(req *pluginv1api.Upload) error {
 	}
 
 	// update status to Completed with path & snapshot id
-	req, err = c.patchUploadByStatus(req, pluginv1api.UploadPhaseCompleted, "Upload completed")
+	req, err = c.patchUploadByStatusWithRetry(req, pluginv1api.UploadPhaseCompleted, "Upload completed")
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -376,6 +377,25 @@ func (c *uploadController) processUpload(req *pluginv1api.Upload) error {
 func (c *uploadController) patchUpload(req *pluginv1api.Upload, mutate func(*pluginv1api.Upload)) (*pluginv1api.Upload, error) {
 	log := loggerForUpload(c.logger, req)
 	return utils.PatchUpload(req, mutate, c.uploadClient.Uploads(req.Namespace), log)
+}
+
+func (c *uploadController) patchUploadByStatusWithRetry(req *pluginv1api.Upload, newPhase pluginv1api.UploadPhase, msg string) (*pluginv1api.Upload, error) {
+	var updatedUpload *pluginv1api.Upload
+	var err error
+	log := loggerForUpload(c.logger, req)
+	log.Infof("Ready to call patchUploadByStatus API. Will retry on patch failure of Upload status every %d seconds up to %d seconds.", utils.RetryInterval, utils.RetryMaximum)
+	err = wait.PollImmediate(utils.RetryInterval * time.Second, utils.RetryInterval * utils.RetryMaximum * time.Second, func() (bool, error) {
+		updatedUpload, err = c.patchUploadByStatus(req, newPhase, msg)
+		if err != nil {
+			return false, nil
+		}
+		return true, nil
+	})
+	log.Debugf("Return from patchUploadByStatus with retry %v times.", utils.RetryMaximum)
+	if err != nil {
+		log.WithError(err).Errorf("Failed to patch Upload, retry time exceeds maximum %d.", utils.RetryMaximum)
+	}
+	return updatedUpload, err
 }
 
 func (c *uploadController) patchUploadByStatus(req *pluginv1api.Upload, newPhase pluginv1api.UploadPhase, msg string) (*pluginv1api.Upload, error) {
@@ -504,7 +524,7 @@ func (c *uploadController) triggerUploadCancellation(req *pluginv1api.Upload) er
 		log.Infof("Current node: %v is not processing the upload, skipping", c.nodeName)
 		return nil
 	}
-	_, err = c.patchUploadByStatus(req, pluginv1api.UploadPhaseCanceling, "Canceling on-going upload to repository.")
+	_, err = c.patchUploadByStatusWithRetry(req, pluginv1api.UploadPhaseCanceling, "Canceling on-going upload to repository.")
 	if err != nil {
 		log.WithError(err).Error("Failed to patch ongoing Upload to Canceling state")
 		return err

--- a/pkg/snapshotmgr/snapshot_manager.go
+++ b/pkg/snapshotmgr/snapshot_manager.go
@@ -288,7 +288,15 @@ func (this *SnapshotManager) createSnapshot(peID astrolabe.ProtectedEntityID, ta
 		uploadBuilder = uploadBuilder.BackupRepositoryName(backupRepositoryName)
 	}
 	upload := uploadBuilder.Result()
-	_, err = pluginClient.VeleropluginV1().Uploads(veleroNs).Create(upload)
+	this.Infof("Ready to create upload CR. Will retry on network issue every 5 seconds for 5 retries at maximum")
+	err = wait.PollImmediate(utils.RetryInterval * time.Second, utils.RetryInterval * utils.RetryMaximum * time.Second, func() (bool, error) {
+		_, err = pluginClient.VeleropluginV1().Uploads(veleroNs).Create(upload)
+		if err != nil {
+			return false, nil
+		}
+		return true, nil
+	})
+
 	if err != nil {
 		this.WithError(err).Errorf("CreateSnapshot: Failed to create Upload CR for PE %s", updatedPeID.String())
 		return updatedPeID, err
@@ -490,7 +498,15 @@ func (this *SnapshotManager) CreateVolumeFromSnapshot(peID astrolabe.ProtectedEn
 	downloadRecordName := "download-" + peID.GetSnapshotID().GetID() + "-" + uuid.String()
 	download := builder.ForDownload(veleroNs, downloadRecordName).
 		RestoreTimestamp(time.Now()).NextRetryTimestamp(time.Now()).SnapshotID(peID.String()).Phase(v1api.DownloadPhaseNew).Result()
-	_, err = pluginClient.VeleropluginV1().Downloads(veleroNs).Create(download)
+	this.Infof("Ready to create download CR. Will retry on network issue every 5 seconds for 5 retries at maximum")
+	err = wait.PollImmediate(utils.RetryInterval * time.Second, utils.RetryInterval * utils.RetryMaximum * time.Second, func() (bool, error) {
+		_, err = pluginClient.VeleropluginV1().Downloads(veleroNs).Create(download)
+		if err != nil {
+			return false, nil
+		}
+		return true, nil
+	})
+
 	if err != nil {
 		this.WithError(err).Errorf("CreateVolumeFromSnapshot: Failed to create Download CR for %s", peID.String())
 		return

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -163,3 +163,8 @@ const (
 const (
 	ItemSnapshotLabel              = "velero-plugin-for-vsphere/item-snapshot-blob"
 )
+
+const (
+	RetryInterval = 5
+	RetryMaximum = 5
+)


### PR DESCRIPTION
This change add retry logic to patch/create upload/download cr, when there is a network issue. 
Related bug number: https://bugzilla.eng.vmware.com/show_bug.cgi?id=2582583
                                    https://bugzilla.eng.vmware.com/show_bug.cgi?id=2560306

Precheck Test:
https://container-dp.svc.eng.vmware.com/job/Container_Precheck_Velero/316/