### PR TITLE
Add a snapshot phase corresponding to upload phase UploadPhaseCleanupFailed

### DIFF
--- a/pkg/apis/backupdriver/v1/snapshot.go
+++ b/pkg/apis/backupdriver/v1/snapshot.go
@@ -41,6 +41,7 @@ const (
 	SnapshotPhaseUploadFailed   SnapshotPhase = "UploadFailed"
 	SnapshotPhaseCanceling      SnapshotPhase = "Canceling"
 	SnapshotPhaseCanceled       SnapshotPhase = "Canceled"
+	SnapshotPhaseCleanupFailed  SnapshotPhase = "CleanupAfterUploadFailed"
 )
 
 // UploadOperationProgress represents the progress of a

--- a/pkg/controller/upload_controller.go
+++ b/pkg/controller/upload_controller.go
@@ -237,6 +237,7 @@ func (c *uploadController) processUploadItem(key string) error {
 			OnStartedLeading: func(ctx context.Context) {
 				// Current node got the lease process request.
 				// Don't mutate the shared cache
+				log.Infof("Lock is acquired by current node - %s to process Upload %s.", c.nodeName, req.Name)
 				reqCopy := req.DeepCopy()
 				processErr = c.processUploadFunc(reqCopy)
 				cancel()
@@ -249,7 +250,7 @@ func (c *uploadController) processUploadItem(key string) error {
 					// Same node is trying to acquire or renew the lease, ignore.
 					return
 				}
-				log.Infof("Lock is acquired by another node %s. Current node - %s need not process the Upload.", identity, c.nodeName)
+				log.Infof("Lock is acquired by another node %s. Current node - %s need not process the Upload %s.", identity, c.nodeName, req.Name)
 				cancel()
 			},
 		},


### PR DESCRIPTION

1. Added shanshot phase SnapshotPhaseCleanupFailed to reflect the upload phase
UploadPhaseCleanupFailed.
2. In the update queue for upload and svcSnapshot, remove the check for status
change between old and new status phases. In case the pods restart and the upload
status was not reflected in the snapshot CR, the old and new upload status might
be the same and might not get reflected in the snapshot CR correctly. This change
fixes the issue.

Signed-off-by: Swati Gupta <swgupta@swgupta-a01.vmware.com>