### PR TITLE
Fix failed pull data manager image issue

### DIFF
--- a/pkg/cmd/datamgr/cli/install/install.go
+++ b/pkg/cmd/datamgr/cli/install/install.go
@@ -247,9 +247,11 @@ func (o *InstallOptions) CheckPluginImageRepo(f client.Factory) error {
 
 	repo := ""
 	tag := ""
+	image := ""
 	for _, container := range deployment.Spec.Template.Spec.InitContainers {
 		if strings.Contains(container.Image, utils.VeleroPluginForVsphere) {
-			repo = strings.Split(container.Image, "/")[0]
+			image = container.Image
+			repo = utils.GetRepo(container.Image)
 			tag = strings.Split(container.Image, ":")[1]
 			break
 		}
@@ -259,7 +261,7 @@ func (o *InstallOptions) CheckPluginImageRepo(f client.Factory) error {
 		o.Image = repo + "/" + utils.DataManagerForPlugin + ":" + tag
 		return nil
 	} else {
-		errMsg := fmt.Sprint("Failed to get repo and tag from velero plugin image.")
+		errMsg := fmt.Sprintf("Failed to get repo and tag from velero plugin image %s.", image)
 		return errors.New(errMsg)
 	}
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -675,3 +675,17 @@ func GetSvcSnapshotName(snapshotId string) (string, error) {
 	}
 	return snapshotIdParts[len(snapshotIdParts)-1], nil
 }
+
+// Retrieve image repository from image name here. We expect the following format
+// for image name: <repo-level1>/<repo-level2>/.../<plugin-bin-name>:<tag>. plugin-bin-name
+// and tag should not include '/'.
+func GetRepo(image string) string {
+	if image == "" {
+		return ""
+	}
+	lastIndex := strings.LastIndex(image, "/")
+	if lastIndex < 0 {
+		return ""
+	}
+	return image[:lastIndex]
+}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -326,3 +326,43 @@ func TestGetSvcSnapshotName(t *testing.T) {
 		})
 	}
 }
+
+func TestGetRepo(t *testing.T) {
+	tests := []struct {
+		name     string
+		image    string
+		expected string
+	} {
+		{
+			name:     "Top level registry",
+			image:    "harbor.mylab.local/velero-plugin-for-vsphere:1.0.1",
+			expected: "harbor.mylab.local",
+		},
+		{
+			name :    "Multiple level registry",
+			image:    "harbor.mylab.local/library/velero-plugin-for-vsphere:1.0.1",
+			expected: "harbor.mylab.local/library",
+		},
+		{
+			name :    "No / should return empty string",
+			image:    "velero-plugin-for-vsphere:1.0.1",
+			expected: "",
+		},
+		{
+			name :    "/ appears in beginning should return empty string",
+			image:    "/velero-plugin-for-vsphere:1.0.1",
+			expected: "",
+		},
+		{
+			name :    "Empty input should return empty string",
+			image:    "",
+			expected: "",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			repo := GetRepo(test.image)
+			assert.Equal(t, test.expected, repo)
+		})
+	}
+}


### PR DESCRIPTION
This change fixed the issue "failed to pull data manager image" if there are multiple slashes in the repo.

Precheck test:
https://container-dp.svc.eng.vmware.com/job/Container_Precheck_Velero/330/

Unit tests:
```
wxinyan@wxinyan-vmware:~/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/utils$ go test
PASS
ok  	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/utils	0.065s

```