### PR TITLE
Add utility function to get supervisor parameters in guest cluster.

### DIFF
--- a/pkg/cmd/backupdriver/cli/server/server.go
+++ b/pkg/cmd/backupdriver/cli/server/server.go
@@ -280,6 +280,13 @@ func newServer(f client.Factory, config serverConfig, logger *logrus.Logger) (*s
 
 		// Set the mode to local as the data movement job is assigned to the supervisor cluster
 		snapshotMgrConfig[utils.VolumeSnapshotterLocalMode] = "true"
+
+		// Log supervisor namespace annotations
+		if params, err := utils.GetSupervisorParameters(svcConfig, svcNamespace, logger); err != nil {
+			logger.WithError(err).Warn("Failed to get supervisor parameters")
+		} else {
+			logger.Infof("Supervisor parameters: %v", params)
+		}
 	}
 
 	peConfigs := make(map[string]map[string]interface{})

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -138,15 +138,6 @@ const (
 	VSphereItemActionPluginFlag = "EnableVSphereItemActionPlugin"
 )
 
-// Keys for Para Virtual Cluster access for Guest Cluster
-const (
-	PvApiEndpointParamKey = "PvEndPoint"
-	PvPortParamKey        = "PvPort"
-	PvNamespaceParamKey   = "PvNamespace"
-	PvTokenParamKey       = "PvToken"
-	PvCrtFileParamKey     = "PvCrtFile"
-)
-
 // Para Virtual Cluster access for Guest Cluster
 const (
 	PvApiEndpoint       = "supervisor.default.svc" // TODO: get it from "kubectl get cm -n vmware-system-csi pvcsi-config"
@@ -161,10 +152,17 @@ const (
 )
 
 const (
-	ItemSnapshotLabel              = "velero-plugin-for-vsphere/item-snapshot-blob"
+	ItemSnapshotLabel = "velero-plugin-for-vsphere/item-snapshot-blob"
 )
 
 const (
 	RetryInterval = 5
-	RetryMaximum = 5
+	RetryMaximum  = 5
+)
+
+// Keys for supervisor cluster parameters
+const (
+	VCuuidKey                 = "vCenterUUID"
+	SupervisorClusterIdKey    = "SupervisorClusterId"
+	SupervisorResourcePoolKey = "SupervisorResourcePool"
 )

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -643,6 +643,58 @@ func SupervisorConfig(logger logrus.FieldLogger) (*rest.Config, string, error) {
 	}, string(ns), nil
 }
 
+/*
+ * Get Supervisor parameters present as annotations in the supervisor namespace for the guest.
+ * We do not return all the annotations, but only annotations required but guest cluster plugin.
+ */
+func GetSupervisorParameters(config *rest.Config, ns string, logger logrus.FieldLogger) (map[string]string, error) {
+	params := make(map[string]string)
+	var err error
+	if config == nil || ns == "" {
+		config, ns, err = SupervisorConfig(logger)
+		if err != nil {
+			logger.WithError(err).Error("Could not get supervisor config")
+			return params, err
+		}
+	}
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		logger.WithError(err).Error("Failed to get k8s clientset from the given config")
+		return params, err
+	}
+
+	nsapi, err := clientset.CoreV1().Namespaces().Get(ns, metav1.GetOptions{})
+	if err != nil {
+		logger.WithError(err).Errorf("Could not get namespace object for supervisor namespace %s", ns)
+		return params, err
+	}
+
+	nsAnnotations := nsapi.ObjectMeta.Annotations
+
+	// Resource pool
+	if resPool, ok := nsAnnotations["vmware-system-resource-pool"]; !ok {
+		logrus.Warnf("%s information is not present in supervisor namespace %s annotations", SupervisorResourcePoolKey, ns)
+	} else {
+		params[SupervisorResourcePoolKey] = resPool
+	}
+
+	// vCenter UUID and cluster ID
+	if svcClusterInfo, ok := nsAnnotations["ncp/extpoolid"]; !ok {
+		logrus.Warnf("%s and %s information is not present in supervisor namespace %s annotations", VCuuidKey, SupervisorClusterIdKey, ns)
+	} else {
+		// Format: <cluster ID>:<vCenter UUID>-ippool-<ip pool range>
+		svcClusterParts := strings.Split(svcClusterInfo, ":")
+		if len(svcClusterParts) < 2 {
+			logrus.Warnf("Invalid ncp/extpoolid %s in supervisor namespace %s annotations", svcClusterInfo, ns)
+		} else {
+			params[SupervisorClusterIdKey] = svcClusterParts[0]
+			vcIdParts := strings.Split(svcClusterParts[1], "-ippool")
+			params[VCuuidKey] = vcIdParts[0]
+		}
+	}
+	return params, nil
+}
+
 func GetBackupRepositoryFromBackupRepositoryName(backupRepositoryName string) (*backupdriverapi.BackupRepository, error) {
 	config, err := rest.InClusterConfig()
 	if err != nil {


### PR DESCRIPTION
The supervisor parameters are present in the supervisor namespace annotations
where the guest cluster is created. The following information is extracted
from the namespace annotations:
- vCenter UUID
- Supervisor cluster id
- Resource pool

Signed-off-by: Swati Gupta <swgupta@swgupta-a01.vmware.com>