### PR TITLE
Change plugin dockerfile and datamgr dockerfile to use ubuntu focal

### DIFF
--- a/Dockerfile-backup-driver
+++ b/Dockerfile-backup-driver
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:bionic
+FROM ubuntu:focal
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates wget bzip2 && \
     apt-get remove -y wget bzip2 && \

--- a/Dockerfile-datamgr
+++ b/Dockerfile-datamgr
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:bionic
+FROM ubuntu:focal
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates wget bzip2 && \
     apt-get remove -y wget bzip2 && \

--- a/Dockerfile-plugin
+++ b/Dockerfile-plugin
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:stretch-slim
+FROM ubuntu:focal
 RUN mkdir /plugins
 RUN mkdir /scripts
 ADD /bin/linux/amd64/velero-* /plugins/


### PR DESCRIPTION
A one line change to make plugin and datamgr use the same image which velero use in dockerfile.

Precheck:
https://container-dp.svc.eng.vmware.com/job/Container_Precheck_Velero/345/

Manually ran backup and restore tests.