### PR TITLE
Set basePE in DataManagerProtectedEntityTypeManager GetProtectedEntity

### DIFF
--- a/pkg/snapshotmgr/data_manager_protected_entity_type_manager.go
+++ b/pkg/snapshotmgr/data_manager_protected_entity_type_manager.go
@@ -29,7 +29,7 @@ func NewDataManagerProtectedEntityTypeManager(sourcePETM astrolabe.ProtectedEnti
 }
 
 func (this DataManagerProtectedEntityTypeManager) GetProtectedEntity(ctx context.Context, id astrolabe.ProtectedEntityID) (astrolabe.ProtectedEntity, error) {
-	basePE, err := this.GetProtectedEntity(ctx, id)
+	basePE, err := this.ProtectedEntityTypeManager.GetProtectedEntity(ctx, id)
 	if err != nil {
 		return nil, errors.Wrapf(err, "GetProtectedEntity from base PETM failed for PEID %s", id.String())
 	}


### PR DESCRIPTION
This PR sets basePE in DataManagerProtectedEntityTypeManager GetProtectedEntity.
This fixes a crash in the backupdriver.  This fix was on my local branch when I tested restore, but somehow got missed in the submitted code.