### PR TITLE
Deferred stopping of goroutine to prevent the issue of goroutine leak

### DIFF
--- a/pkg/snapshotUtils/clonefromsnapshot.go
+++ b/pkg/snapshotUtils/clonefromsnapshot.go
@@ -130,6 +130,8 @@ func WaitForClonePhases(ctx context.Context, clientSet *v1.BackupdriverV1Client,
 		},
 	)
 	stop := make(chan struct{})
+	defer close(stop)
+
 	go controller.Run(stop)
 	select {
 	case <-ctx.Done():

--- a/pkg/snapshotUtils/delete_snapshot.go
+++ b/pkg/snapshotUtils/delete_snapshot.go
@@ -110,6 +110,8 @@ func WaitForDeleteSnapshotPhases(ctx context.Context,
 		},
 	)
 	stop := make(chan struct{})
+	defer close(stop)
+
 	go controller.Run(stop)
 	select {
 	case <-ctx.Done():

--- a/pkg/snapshotUtils/snapshot.go
+++ b/pkg/snapshotUtils/snapshot.go
@@ -132,6 +132,8 @@ func WaitForPhases(ctx context.Context, clientSet *v1.BackupdriverV1Client, snap
 		},
 	)
 	stop := make(chan struct{})
+	defer close(stop)
+
 	go controller.Run(stop)
 	select {
 	case <-ctx.Done():


### PR DESCRIPTION
A simple change to defer stopping of goroutine to prevent the issue of goroutine leak. 

Signed-off-by: Lintong Jiang <lintongj@vmware.com>

Hold off this change until test code gets changed properly and verify this commit not introduce any regression.