### PR TITLE
Changes to create a new namespace for backup-driver in the guest.

### DIFF
--- a/pkg/cmd/backupdriver/cli/install/install.go
+++ b/pkg/cmd/backupdriver/cli/install/install.go
@@ -51,7 +51,6 @@ type InstallOptions struct {
 	PodMemRequest  string
 	PodCPULimit    string
 	PodMemLimit    string
-	PVSecret       bool
 	MasterAffinity bool
 	HostNetwork    bool
 	LocalMode      bool
@@ -92,7 +91,6 @@ func (o *InstallOptions) AsBackupDriverOptions() (*pkgInstall.PodOptions, error)
 		Image:          o.Image,
 		PodAnnotations: o.PodAnnotations.Data(),
 		PodResources:   podResources,
-		SecretAdd:      o.PVSecret,
 		MasterAffinity: o.MasterAffinity,
 		HostNetwork:    o.HostNetwork,
 		LocalMode:      o.LocalMode,
@@ -167,11 +165,6 @@ func (o *InstallOptions) Run(c *cobra.Command, f client.Factory) error {
 
 	// Check cluster flavor. Add the PV secret to pod in Guest Cluster
 	clusterFlavor, err := utils.GetClusterFlavor(nil)
-	if clusterFlavor == utils.TkgGuest {
-		fmt.Printf("Guest Cluster. Deploy pod with secret.")
-		o.PVSecret = true
-	}
-
 	// Assign master node affinity and host network to Supervisor deployment
 	if clusterFlavor == utils.Supervisor {
 		fmt.Printf("Supervisor Cluster. Assign master node affinity and enable host network.")

--- a/pkg/cmd/backupdriver/cli/server/server.go
+++ b/pkg/cmd/backupdriver/cli/server/server.go
@@ -245,7 +245,7 @@ func newServer(f client.Factory, config serverConfig, logger *logrus.Logger) (*s
 	var svcBackupdriverInformerFactory pluginInformers.SharedInformerFactory
 	var svcNamespace string
 	if clusterFlavor == utils.TkgGuest {
-		svcConfig, svcNamespace, err = utils.SupervisorConfig(logger)
+		svcConfig, svcNamespace, err = utils.GetSupervisorConfig(clientConfig, logger)
 		if err != nil {
 			logger.Error("Failed to get the supervisor config for the guest kubernetes cluster")
 			return nil, err
@@ -269,7 +269,7 @@ func newServer(f client.Factory, config serverConfig, logger *logrus.Logger) (*s
 
 		svcKubeClient, err := kubernetes.NewForConfig(svcConfig)
 		if err != nil {
-			logger.Errorf("Failed to get the kubernetes client for the supervisor cluster")
+			logger.Error("Failed to get the kubernetes client for the supervisor cluster")
 			return nil, err
 		}
 		svcKubeInformerFactory = kubeinformers.NewSharedInformerFactoryWithOptions(svcKubeClient, config.resyncPeriod,

--- a/pkg/install/deployment.go
+++ b/pkg/install/deployment.go
@@ -144,28 +144,6 @@ func Deployment(namespace string, opts ...podTemplateOption) *appsv1.Deployment 
 		},
 	}
 
-	if c.withSecret {
-		deployment.Spec.Template.Spec.Volumes = append(
-			deployment.Spec.Template.Spec.Volumes,
-			corev1.Volume{
-				Name: "pv-credentials",
-				VolumeSource: corev1.VolumeSource{
-					Secret: &corev1.SecretVolumeSource{
-						SecretName: "pvbackupdriver-provider-creds",
-					},
-				},
-			},
-		)
-
-		deployment.Spec.Template.Spec.Containers[0].VolumeMounts = append(
-			deployment.Spec.Template.Spec.Containers[0].VolumeMounts,
-			corev1.VolumeMount{
-				Name:      "pv-credentials",
-				MountPath: "/credentials",
-			},
-		)
-	}
-
 	if c.masterAffinity {
 		deployment.Spec.Template.Spec.Tolerations = append(
 			deployment.Spec.Template.Spec.Tolerations,

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -407,7 +407,6 @@ func AllBackupDriverResources(o *PodOptions, withCRDs bool) (*unstructured.Unstr
 		WithAnnotations(o.PodAnnotations),
 		WithImage(o.Image),
 		WithResources(o.PodResources),
-		WithSecret(o.SecretAdd),
 		WithMasterNodeAffinity(o.MasterAffinity),
 		WithHostNetwork(o.HostNetwork),
 		WithLocalMode(o.LocalMode),

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -99,6 +99,7 @@ const (
 const (
 	DataManagerForPlugin  string = "data-manager-for-plugin"
 	BackupDriverForPlugin string = "backup-driver"
+	BackupDriverNamespace string = "velero-vsphere-plugin-backupdriver"
 
 	VeleroPluginForVsphere string = "velero-plugin-for-vsphere"
 
@@ -140,11 +141,9 @@ const (
 
 // Para Virtual Cluster access for Guest Cluster
 const (
-	PvApiEndpoint       = "supervisor.default.svc" // TODO: get it from "kubectl get cm -n vmware-system-csi pvcsi-config"
-	PvPort              = "6443"
-	PvNamespaceLocation = "/credentials/namespace"
-	PvTokenLocation     = "/credentials/token"
-	PvCrtLocation       = "/credentials/ca.crt"
+	PvApiEndpoint = "supervisor.default.svc" // TODO: get it from "kubectl get cm -n vmware-system-csi pvcsi-config"
+	PvPort        = "6443"
+	PvSecretName  = "pvbackupdriver-provider-creds"
 )
 
 const (


### PR DESCRIPTION
The velero-app-operator in the supervisor cluster writes the permissions to
access the supervisor namespace as a secret in a fixed namespace in the guest
cluster. Since the user can deploy velero in any namespace, we create a fixed
namespace in the guest cluster where the secret gets written. When the backup
driver container in the guest is started, it creates this fixed namespace and
waits for the seccret to become available.

Precheckin test: https://container-dp.svc.eng.vmware.com/job/Container_Precheck_Velero/401/

Signed-off-by: Swati Gupta <swgupta@swgupta-a01.vmware.com>