### PR TITLE
Add backup name as label in the snapshot backupdriver CRs.

### DIFF
--- a/pkg/backupdriver/backup_driver_controller.go
+++ b/pkg/backupdriver/backup_driver_controller.go
@@ -23,6 +23,8 @@ import (
 	"io"
 	"io/ioutil"
 
+	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/utils"
+
 	"github.com/vmware-tanzu/astrolabe/pkg/astrolabe"
 	backupdriverapi "github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/apis/backupdriver/v1"
 	v1 "k8s.io/api/core/v1"
@@ -74,7 +76,7 @@ func (ctrl *backupDriverController) createSnapshot(snapshot *backupdriverapi.Sna
 		brName = br.SvcBackupRepositoryName
 	}
 
-	peID, svcSnapshotName, err := ctrl.snapManager.CreateSnapshotWithBackupRepository(peID, tags, brName, snapshot.Namespace+"/"+snapshot.Name)
+	peID, svcSnapshotName, err := ctrl.snapManager.CreateSnapshotWithBackupRepository(peID, tags, brName, snapshot.Namespace+"/"+snapshot.Name, snapshot.Labels[utils.SnapshotBackupLabel])
 	if err != nil {
 		errMsg := fmt.Sprintf("failed at calling SnapshotManager CreateSnapshot from peID %v", peID)
 		ctrl.logger.Error(errMsg)

--- a/pkg/builder/snapshot_builder.go
+++ b/pkg/builder/snapshot_builder.go
@@ -27,7 +27,7 @@ type SnapshotBuilder struct {
 	object *backupdriverv1.Snapshot
 }
 
-func ForSnapshot(ns, name string) *SnapshotBuilder {
+func ForSnapshot(ns, name string, labels map[string]string) *SnapshotBuilder {
 	return &SnapshotBuilder{
 		object: &backupdriverv1.Snapshot{
 			TypeMeta: metav1.TypeMeta{
@@ -37,6 +37,7 @@ func ForSnapshot(ns, name string) *SnapshotBuilder {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: ns,
+				Labels:    labels,
 			},
 		},
 	}

--- a/pkg/paravirt/paravirt_protected_entity.go
+++ b/pkg/paravirt/paravirt_protected_entity.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"io"
 
+	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/utils"
+
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/vmware-tanzu/astrolabe/pkg/astrolabe"
@@ -74,11 +76,14 @@ func (this ParaVirtProtectedEntity) Snapshot(ctx context.Context, params map[str
 	if !ok {
 		backupRepositoryName = "INVALID_BR_NAME"
 	}
+	labels := map[string]string{
+		utils.SnapshotBackupLabel: params[astrolabe.PvcPEType][SnapshotParamBackupName].(string),
+	}
 
 	this.logger.Info("Creating a snapshot CR")
 	backupRepository := snapshotUtils.NewBackupRepository(backupRepositoryName)
 	snapshot, err := snapshotUtils.SnapshotRef(ctx, this.pvpetm.svcBackupDriverClient, objectToSnapshot, this.pvpetm.svcNamespace,
-		*backupRepository, []backupdriverv1api.SnapshotPhase{backupdriverv1api.SnapshotPhaseSnapshotted}, this.logger)
+		*backupRepository, labels, []backupdriverv1api.SnapshotPhase{backupdriverv1api.SnapshotPhaseSnapshotted}, this.logger)
 	if err != nil {
 		this.logger.Errorf("Failed to create a snapshot CR: %v", err)
 		return astrolabe.ProtectedEntitySnapshotID{}, err

--- a/pkg/paravirt/paravirt_protected_entity_type_manager.go
+++ b/pkg/paravirt/paravirt_protected_entity_type_manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -40,6 +41,7 @@ const (
 const (
 	SnapshotParamBackupRepository = "BackupRepository"
 	SnapshotParamSvcSnapshotName  = "SvcSnapshotName"
+	SnapshotParamBackupName       = "BackupName"
 )
 
 type ParaVirtProtectedEntityTypeManager struct {

--- a/pkg/plugin/backup_pvc_action_plugin.go
+++ b/pkg/plugin/backup_pvc_action_plugin.go
@@ -105,8 +105,12 @@ func (p *NewPVCBackupItemAction) Execute(item runtime.Unstructured, backup *vele
 		Name:     pvc.Name,
 	}
 
+	labels := map[string]string{
+		utils.SnapshotBackupLabel: backup.Name,
+	}
+
 	p.Log.Info("Creating a Snapshot CR")
-	updatedSnapshot, err := snapshotUtils.SnapshotRef(ctx, backupdriverClient, objectToSnapshot, pvc.Namespace, *backupRepository,
+	updatedSnapshot, err := snapshotUtils.SnapshotRef(ctx, backupdriverClient, objectToSnapshot, pvc.Namespace, *backupRepository, labels,
 		[]backupdriverv1.SnapshotPhase{backupdriverv1.SnapshotPhaseSnapshotted, backupdriverv1.SnapshotPhaseSnapshotFailed, backupdriverv1.SnapshotPhaseUploaded, backupdriverv1.SnapshotPhaseUploading, backupdriverv1.SnapshotPhaseUploadFailed, backupdriverv1.SnapshotPhaseCanceling, backupdriverv1.SnapshotPhaseCanceled, backupdriverv1.SnapshotPhaseCleanupFailed}, p.Log)
 	if err != nil {
 		p.Log.Errorf("Failed to create a Snapshot CR: %v", err)

--- a/pkg/snapshotUtils/snapshot.go
+++ b/pkg/snapshotUtils/snapshot.go
@@ -2,8 +2,9 @@ package snapshotUtils
 
 import (
 	"context"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/builder"
 
@@ -57,6 +58,7 @@ func SnapshotRef(ctx context.Context,
 	objectToSnapshot core_v1.TypedLocalObjectReference,
 	namespace string,
 	repository BackupRepository,
+	labels map[string]string,
 	waitForPhases []backupdriverv1.SnapshotPhase,
 	logger logrus.FieldLogger) (*backupdriverv1.Snapshot, error) {
 
@@ -65,7 +67,7 @@ func SnapshotRef(ctx context.Context,
 		return nil, errors.Wrapf(err, "Could not create snapshot UUID")
 	}
 	snapshotName := "snap-" + snapshotUUID.String()
-	snapshotReq := builder.ForSnapshot(namespace, snapshotName).
+	snapshotReq := builder.ForSnapshot(namespace, snapshotName, labels).
 		BackupRepository(repository.backupRepositoryName).
 		ObjectReference(objectToSnapshot).
 		CancelState(false).Result()

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -151,7 +151,8 @@ const (
 )
 
 const (
-	ItemSnapshotLabel = "velero-plugin-for-vsphere/item-snapshot-blob"
+	ItemSnapshotLabel   = "velero-plugin-for-vsphere/item-snapshot-blob"
+	SnapshotBackupLabel = "velero.io/backup-name"
 )
 
 const (


### PR DESCRIPTION
PowerProtect relies on the vsphere plugin to take a FCD snapshot, and uses the
snapshot in its data mover code. The snapshot CR contains the FCD ID and
snapshot ID. With the backup label in the snapshot CR, partners will be
able to get a snapshot CR corresponding to the backup and extract the snapshot
and FCD ID.

Signed-off-by: Swati Gupta <swgupta@swgupta-a01.vmware.com>