### PR TITLE
Change data manager to remove upload/download CR which reaches terminal state

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -275,3 +275,6 @@ const VMwareSystemVMUUID = "vmware-system-vm-uuid"
 
 // Label to set for Velero to ignore resources
 const VeleroExcludeLabel = "velero.io/exclude-from-backup"
+
+// Default time window to clean up CR which is in terminal state
+const DefaultCRCleanUpWindow = 24

--- a/pkg/controller/upload_controller.go
+++ b/pkg/controller/upload_controller.go
@@ -107,13 +107,24 @@ func (c *uploadController) enqueueUploadItem(obj interface{}) {
 
 	switch req.Status.Phase {
 	case "", pluginv1api.UploadPhaseNew, pluginv1api.UploadPhaseInProgress, pluginv1api.UploadPhaseUploadError, pluginv1api.UploadPhaseCanceling:
-		// Process New and InProgress and UploadError Uploads
+		// Process New and InProgress and UploadError and UploadCanceling Uploads
 	case pluginv1api.UploadPhaseCanceled:
 		// The upload was canceled, nothing to do.
 		log.Debug("The upload request was canceled")
 		return
+	case pluginv1api.UploadPhaseCompleted:
+		// If Upload CR status reaches terminal state, Upload CR should be deleted after clean up window
+		now := c.clock.Now()
+		if now.After(req.Status.CompletionTimestamp.Add(constants.DefaultCRCleanUpWindow * time.Hour)) {
+			log.Infof("Upload CR %s has been in phase %v more than %v hours, deleting this CR.", req.Name, req.Status.Phase, constants.DefaultCRCleanUpWindow)
+			err := c.uploadClient.Uploads(req.Namespace).Delete(context.TODO(), req.Name, metav1.DeleteOptions{})
+			if err != nil {
+				log.WithError(err).Errorf("Failed to delete Upload CR which is in %v phase.", req.Status.Phase)
+			}
+		}
+		return
 	default:
-		log.Debug("Upload CR is not New or InProgress or UploadError, skipping")
+		log.Debug("Upload CR is not New or InProgress or UploadError or UploadCanceling, skipping")
 		return
 	}
 


### PR DESCRIPTION
Remove upload/download CR when its state reaches:
-UploadPhaseCompleted
-DownloadPhaseCompleted
for more than 24 hours.

Precheck: https://container-dp.svc.eng.vmware.com/job/Container_Precheck_Velero/569/
```
time="2020-09-16T07:03:22Z" level=info msg="Upload CR upload-dfa433ec-c926-48ca-a3f1-11611298a5f1 reaches phase Completed more than 1 hour, deleting this CR." controller=upload generation=3 logSource="/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/controller/upload_controller.go:118" name=upload-dfa433ec-c926-48ca-a3f1-11611298a5f1 namespace=velero phase=Completed snapshotID="ivd:c66ade9f-3d40-4b62-a293-864312a7cd6d:dfa433ec-c926-48ca-a3f1-11611298a5f1"
time="2020-09-16T07:04:22Z" level=info msg="Upload CR upload-0a63384a-4871-4ebc-b6ce-c6f60bc181ab reaches phase Completed more than 1 hour, deleting this CR." controller=upload generation=3 logSource="/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/controller/upload_controller.go:118" name=upload-0a63384a-4871-4ebc-b6ce-c6f60bc181ab namespace=velero phase=Completed snapshotID="ivd:f8a037f7-9ab2-45a5-baa0-810378e1c188:0a63384a-4871-4ebc-b6ce-c6f60bc181ab"
```
```
time="2020-09-16T07:51:52Z" level=info msg="Download CR download-1da0deb0-e106-49fe-88f4-223e66af73c2-e3a4788b-5226-45b9-85d6-97853666073f reaches phase Completed more than 1 hour, deleting this CR." controller=download generation=3 logSource="/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/controller/download_controller.go:106" name=download-1da0deb0-e106-49fe-88f4-223e66af73c2-e3a4788b-5226-45b9-85d6-97853666073f namespace=velero phase=Completed
time="2020-09-16T07:52:22Z" level=info msg="Download CR download-009da04b-8a17-44c9-a39c-b9f48134bdbe-16640b89-1d6d-4c93-b87a-ade0d48e3008 reaches phase Completed more than 1 hour, deleting this CR." controller=download generation=3 logSource="/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/controller/download_controller.go:106" name=download-009da04b-8a17-44c9-a39c-b9f48134bdbe-16640b89-1d6d-4c93-b87a-ade0d48e3008 namespace=velero phase=Completed
```