### PR TITLE
Claim BackupRepository during Restore and Delete

### DIFF
--- a/cmd/velero-plugin-for-vsphere/main.go
+++ b/cmd/velero-plugin-for-vsphere/main.go
@@ -17,13 +17,13 @@
 package main
 
 import (
+	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/constants"
 	"os"
 	"strings"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 	plugins_pkg "github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/plugin"
-	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/utils"
 	"github.com/vmware-tanzu/velero/pkg/features"
 	veleroplugin "github.com/vmware-tanzu/velero/pkg/plugin/framework"
 )
@@ -31,7 +31,7 @@ import (
 func main() {
 	enableFeatureFlagForVSpherePlugins()
 	veleroPluginServer := veleroplugin.NewServer()
-	if features.IsEnabled(utils.VSphereItemActionPluginFlag) {
+	if features.IsEnabled(constants.VSphereItemActionPluginFlag) {
 		veleroPluginServer = veleroPluginServer.
 			RegisterBackupItemAction("velero.io/vsphere-pvc-backupper", newPVCBackupItemAction).
 			RegisterRestoreItemAction("velero.io/vsphere-pvc-restorer", newPVCRestoreItemAction).

--- a/pkg/backupdriver/backup_driver_controller.go
+++ b/pkg/backupdriver/backup_driver_controller.go
@@ -20,10 +20,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/constants"
 	"io"
 	"io/ioutil"
-
-	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/utils"
 
 	"github.com/vmware-tanzu/astrolabe/pkg/astrolabe"
 	backupdriverapi "github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/apis/backupdriver/v1"
@@ -76,7 +75,7 @@ func (ctrl *backupDriverController) createSnapshot(snapshot *backupdriverapi.Sna
 		brName = br.SvcBackupRepositoryName
 	}
 
-	peID, svcSnapshotName, err := ctrl.snapManager.CreateSnapshotWithBackupRepository(peID, tags, brName, snapshot.Namespace+"/"+snapshot.Name, snapshot.Labels[utils.SnapshotBackupLabel])
+	peID, svcSnapshotName, err := ctrl.snapManager.CreateSnapshotWithBackupRepository(peID, tags, brName, snapshot.Namespace+"/"+snapshot.Name, snapshot.Labels[constants.SnapshotBackupLabel])
 	if err != nil {
 		errMsg := fmt.Sprintf("failed at calling SnapshotManager CreateSnapshot from peID %v", peID)
 		ctrl.logger.Error(errMsg)

--- a/pkg/backupdriver/backup_driver_controller_base.go
+++ b/pkg/backupdriver/backup_driver_controller_base.go
@@ -18,6 +18,7 @@ package backupdriver
 
 import (
 	"context"
+	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/backuprepository"
 	"strings"
 	"time"
 
@@ -581,7 +582,7 @@ func (ctrl *backupDriverController) syncBackupRepositoryClaimByKey(key string) e
 		var svcBackupRepositoryName string
 		// In case of guest clusters, create BackupRepositoryClaim in the supervisor namespace
 		if ctrl.svcKubeConfig != nil {
-			svcBackupRepositoryName, err = ClaimSvcBackupRepository(ctx, brc, ctrl.svcKubeConfig, ctrl.svcNamespace, ctrl.logger)
+			svcBackupRepositoryName, err = backuprepository.ClaimSvcBackupRepository(ctx, brc, ctrl.svcKubeConfig, ctrl.svcNamespace, ctrl.logger)
 			if err != nil {
 				ctrl.logger.Errorf("Failed to create Supervisor BackupRepositoryClaim")
 				return err
@@ -593,13 +594,13 @@ func (ctrl *backupDriverController) syncBackupRepositoryClaimByKey(key string) e
 		// Save the supervisor backup repository name to be passed to snapshot manager
 		ctrl.logger.Infof("syncBackupRepositoryClaimByKey: Create BackupRepository for BackupRepositoryClaim %s/%s", brc.Namespace, brc.Name)
 		// Create BackupRepository when a new BackupRepositoryClaim is added and if the BackupRepository is not already created
-		br, err := CreateBackupRepository(ctx, brc, svcBackupRepositoryName, ctrl.backupdriverClient, ctrl.logger)
+		br, err := backuprepository.CreateBackupRepository(ctx, brc, svcBackupRepositoryName, ctrl.backupdriverClient, ctrl.logger)
 		if err != nil {
 			ctrl.logger.Errorf("Failed to create BackupRepository")
 			return err
 		}
 
-		err = PatchBackupRepositoryClaim(brc, br.Name, brc.Namespace, ctrl.backupdriverClient)
+		err = backuprepository.PatchBackupRepositoryClaim(brc, br.Name, brc.Namespace, ctrl.backupdriverClient)
 		if err != nil {
 			return err
 		}

--- a/pkg/builder/backup_repository_builder.go
+++ b/pkg/builder/backup_repository_builder.go
@@ -2,7 +2,7 @@ package builder
 
 import (
 	backupdriverv1 "github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/apis/backupdriver/v1"
-	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/utils"
+	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/constants"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -40,7 +40,7 @@ func (b *BackupRepositoryBuilder) AllowedNamespaces(allowedNamespaces []string) 
 // RepositoryDriver sets the repository driver the backup repository. Currently only s3 is supported.
 func (b *BackupRepositoryBuilder) RepositoryDriver() *BackupRepositoryBuilder {
 	// TODO: Change this when other drivers are supported.
-	b.object.RepositoryDriver = utils.S3RepositoryDriver
+	b.object.RepositoryDriver = constants.S3RepositoryDriver
 	return b
 }
 

--- a/pkg/builder/backup_repository_claim_builder.go
+++ b/pkg/builder/backup_repository_claim_builder.go
@@ -2,7 +2,7 @@ package builder
 
 import (
 	backupdriverv1 "github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/apis/backupdriver/v1"
-	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/utils"
+	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/constants"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -41,7 +41,7 @@ func (b *BackupRepositoryClaimBuilder) AllowedNamespaces(allowedNamespaces []str
 // RepositoryDriver sets the repository driver the backup repository claim. Currently only s3 is supported.
 func (b *BackupRepositoryClaimBuilder) RepositoryDriver() *BackupRepositoryClaimBuilder {
 	// TODO: Change this when other drivers are supported.
-	b.object.RepositoryDriver = utils.S3RepositoryDriver
+	b.object.RepositoryDriver = constants.S3RepositoryDriver
 	return b
 }
 

--- a/pkg/cmd/backupdriver/cli/server/server.go
+++ b/pkg/cmd/backupdriver/cli/server/server.go
@@ -19,6 +19,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/constants"
 	"log"
 	"net/http"
 	"net/http/pprof"
@@ -80,7 +81,7 @@ func NewCommand(f client.Factory) *cobra.Command {
 			formatFlag:         logging.NewFormatFlag(),
 			master:             "",
 			kubeConfig:         "",
-			resyncPeriod:       utils.ResyncPeriod,
+			resyncPeriod:       constants.ResyncPeriod,
 			workers:            cmd.DefaultBackupWorkers,
 			retryIntervalStart: cmd.DefaultRetryIntervalStart,
 			retryIntervalMax:   cmd.DefaultRetryIntervalMax,
@@ -234,8 +235,8 @@ func newServer(f client.Factory, config serverConfig, logger *logrus.Logger) (*s
 
 	// Set snapshot manager configuration information
 	snapshotMgrConfig := make(map[string]string)
-	snapshotMgrConfig[utils.VolumeSnapshotterManagerLocation] = utils.VolumeSnapshotterDataServer
-	snapshotMgrConfig[utils.VolumeSnapshotterLocalMode] = strconv.FormatBool(config.localMode)
+	snapshotMgrConfig[constants.VolumeSnapshotterManagerLocation] = constants.VolumeSnapshotterDataServer
+	snapshotMgrConfig[constants.VolumeSnapshotterLocalMode] = strconv.FormatBool(config.localMode)
 
 	// If CLUSTER_FLAVOR is GUEST_CLUSTER, set up svcKubeConfig to communicate with the Supervisor Cluster
 	clusterFlavor, _ := utils.GetClusterFlavor(clientConfig)
@@ -244,7 +245,7 @@ func newServer(f client.Factory, config serverConfig, logger *logrus.Logger) (*s
 	var svcKubeInformerFactory kubeinformers.SharedInformerFactory
 	var svcBackupdriverInformerFactory pluginInformers.SharedInformerFactory
 	var svcNamespace string
-	if clusterFlavor == utils.TkgGuest {
+	if clusterFlavor == constants.TkgGuest {
 		svcConfig, svcNamespace, err = utils.GetSupervisorConfig(clientConfig, logger)
 		if err != nil {
 			logger.Error("Failed to get the supervisor config for the guest kubernetes cluster")
@@ -280,7 +281,7 @@ func newServer(f client.Factory, config serverConfig, logger *logrus.Logger) (*s
 		pvcConfig["svcNamespace"] = svcNamespace
 
 		// Set the mode to local as the data movement job is assigned to the supervisor cluster
-		snapshotMgrConfig[utils.VolumeSnapshotterLocalMode] = "true"
+		snapshotMgrConfig[constants.VolumeSnapshotterLocalMode] = "true"
 
 		// Log supervisor namespace annotations
 		if params, err := utils.GetSupervisorParameters(svcConfig, svcNamespace, logger); err != nil {

--- a/pkg/cmd/datamgr/cli/server/server.go
+++ b/pkg/cmd/datamgr/cli/server/server.go
@@ -19,6 +19,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/constants"
 	"log"
 	"net/http"
 	"net/http/pprof"
@@ -77,7 +78,7 @@ func NewCommand(f client.Factory) *cobra.Command {
 			clientBurst:        cmd.DefaultClientBurst,
 			profilerAddress:    cmd.DefaultProfilerAddress,
 			formatFlag:         logging.NewFormatFlag(),
-			port:               utils.DefaultVCenterPort,
+			port:               constants.DefaultVCenterPort,
 			insecureFlag:       cmd.DefaultInsecureFlag,
 			vcConfigFromSecret: cmd.DefaultVCConfigFromSecret,
 		}
@@ -247,7 +248,7 @@ func newServer(f client.Factory, config serverConfig, logger *logrus.Logger) (*s
 	}
 
 	snapshotMgrConfig := make(map[string]string)
-	snapshotMgrConfig[utils.VolumeSnapshotterManagerLocation] = utils.VolumeSnapshotterDataServer
+	snapshotMgrConfig[constants.VolumeSnapshotterManagerLocation] = constants.VolumeSnapshotterDataServer
 
 	peConfigs := make(map[string]map[string]interface{})
 	peConfigs["ivd"] = ivdParams // Even an empty map here will force NewSnapshotManagerFromConfig to use the default VC config
@@ -272,7 +273,7 @@ func newServer(f client.Factory, config serverConfig, logger *logrus.Logger) (*s
 	}
 	// In supervisor/guest cluster, data manager is remote
 	externalDataMgr := false
-	if clusterFlavor != utils.VSphere {
+	if clusterFlavor != constants.VSphere {
 		externalDataMgr = true
 	}
 
@@ -287,7 +288,7 @@ func newServer(f client.Factory, config serverConfig, logger *logrus.Logger) (*s
 		kubeClient:            kubeClient,
 		veleroClient:          veleroClient,
 		pluginClient:          pluginClient,
-		pluginInformerFactory: pluginInformers.NewSharedInformerFactoryWithOptions(pluginClient, utils.ResyncPeriod, pluginInformers.WithNamespace(f.Namespace())),
+		pluginInformerFactory: pluginInformers.NewSharedInformerFactoryWithOptions(pluginClient, constants.ResyncPeriod, pluginInformers.WithNamespace(f.Namespace())),
 		kubeInformerFactory:   kubeinformers.NewSharedInformerFactory(kubeClient, 0),
 		logger:                logger,
 		logLevel:              logger.Level,

--- a/pkg/cmd/utils.go
+++ b/pkg/cmd/utils.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/constants"
 	"os"
 	"strconv"
 	"strings"
@@ -27,7 +28,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/pkg/errors"
-	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/utils"
 	"github.com/vmware-tanzu/velero/pkg/client"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -141,8 +141,8 @@ func CheckCSIVersion(containers []v1.Container) (bool, bool, error) {
 		csi_driver_version = GetVersionFromImage(containers, "cloudnativestorage/vsphere-csi")
 		if csi_driver_version != "" {
 			fmt.Printf("Got pre-relase version %s from container cloudnativestorage/vsphere-csi, setting version to min version %s\n",
-				csi_driver_version, utils.CsiMinVersion)
-			csi_driver_version = utils.CsiMinVersion
+				csi_driver_version, constants.CsiMinVersion)
+			csi_driver_version = constants.CsiMinVersion
 		}
 	}
 	csi_syncer_version := GetVersionFromImage(containers, "gcr.io/cloud-provider-vsphere/csi/release/syncer")
@@ -150,11 +150,11 @@ func CheckCSIVersion(containers []v1.Container) (bool, bool, error) {
 		csi_syncer_version = GetVersionFromImage(containers, "cloudnativestorage/syncer")
 		if csi_syncer_version != "" {
 			fmt.Printf("Got pre-relase version %s from container cloudnativestorage/syncer, setting version to min version %s\n",
-				csi_syncer_version, utils.CsiMinVersion)
-			csi_syncer_version = utils.CsiMinVersion
+				csi_syncer_version, constants.CsiMinVersion)
+			csi_syncer_version = constants.CsiMinVersion
 		}
 	}
-	if CompareVersion(csi_driver_version, utils.CsiMinVersion) >= 0 && CompareVersion(csi_syncer_version, utils.CsiMinVersion) >= 0 {
+	if CompareVersion(csi_driver_version, constants.CsiMinVersion) >= 0 && CompareVersion(csi_syncer_version, constants.CsiMinVersion) >= 0 {
 		isVersionOK = true
 	}
 	return true, isVersionOK, nil

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package utils
+package constants
 
 import "time"
 

--- a/pkg/controller/download_controller_test.go
+++ b/pkg/controller/download_controller_test.go
@@ -26,11 +26,11 @@ import (
 	"github.com/vmware-tanzu/astrolabe/pkg/astrolabe"
 	v1 "github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/apis/veleroplugin/v1"
 	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/builder"
+	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/constants"
 	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/dataMover"
 	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/fake"
 	informers "github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/informers/externalversions"
 	veleroplugintest "github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/test"
-	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -44,7 +44,7 @@ import (
 )
 
 func defaultDownload() *builder.DownloadBuilder {
-	return builder.ForDownload(utils.DefaultNamespace, "download-1")
+	return builder.ForDownload(constants.DefaultNamespace, "download-1")
 }
 
 func TestProcessDownloadSkipItems(t *testing.T) {
@@ -114,7 +114,7 @@ func TestPatchDownloadByStatus(t *testing.T) {
 			key:      "velero/download-1",
 			oldPhase: v1.DownloadPhaseInProgress,
 			newPhase: v1.DownloadPhaseCompleted,
-			download: defaultDownload().Phase(v1.DownloadPhaseInProgress).Retry(utils.MIN_RETRY).Result(),
+			download: defaultDownload().Phase(v1.DownloadPhaseInProgress).Retry(constants.MIN_RETRY).Result(),
 			msg:      "Download completed",
 		},
 		{
@@ -122,7 +122,7 @@ func TestPatchDownloadByStatus(t *testing.T) {
 			key:      "velero/download-1",
 			oldPhase: v1.DownloadPhaseInProgress,
 			newPhase: v1.DownLoadPhaseRetry,
-			download: defaultDownload().Phase(v1.DownloadPhaseInProgress).Retry(utils.MIN_RETRY).Result(),
+			download: defaultDownload().Phase(v1.DownloadPhaseInProgress).Retry(constants.MIN_RETRY).Result(),
 			msg:      "Failed to download snapshot, ivd:1234:1234, from durable object storage.",
 		},
 		{
@@ -131,7 +131,7 @@ func TestPatchDownloadByStatus(t *testing.T) {
 			oldPhase:      v1.DownloadPhaseInProgress,
 			newPhase:      v1.DownLoadPhaseRetry,
 			expectedPhase: v1.DownloadPhaseFailed,
-			download:      defaultDownload().Phase(v1.DownloadPhaseInProgress).Retry(utils.DOWNLOAD_MAX_RETRY + 1).Result(),
+			download:      defaultDownload().Phase(v1.DownloadPhaseInProgress).Retry(constants.DOWNLOAD_MAX_RETRY + 1).Result(),
 			msg:           "Failed to download snapshot, ivd:1234:1234, from durable object storage.",
 		},
 	}
@@ -245,11 +245,11 @@ func TestPatchDownloadByStatus(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, test.msg, res.Status.Message)
 			if test.oldPhase == v1.DownloadPhaseNew {
-				require.Equal(t, int32(utils.MIN_RETRY), res.Status.RetryCount)
+				require.Equal(t, int32(constants.MIN_RETRY), res.Status.RetryCount)
 			}
 			if test.newPhase == v1.DownLoadPhaseRetry {
 				newRetry := res.Status.RetryCount
-				if newRetry > utils.DOWNLOAD_MAX_RETRY {
+				if newRetry > constants.DOWNLOAD_MAX_RETRY {
 					test.newPhase = test.expectedPhase
 				} else {
 					require.Equal(t, oldRetry+1, newRetry)
@@ -278,7 +278,7 @@ func TestProcessedDownloadItem(t *testing.T) {
 		{
 			name:          "Invalid peID should fail download ",
 			key:           "velero/download-1",
-			download:      defaultDownload().Phase(v1.DownloadPhaseNew).SnapshotID("ivd:invalid").Retry(utils.MIN_RETRY).Result(),
+			download:      defaultDownload().Phase(v1.DownloadPhaseNew).SnapshotID("ivd:invalid").Retry(constants.MIN_RETRY).Result(),
 			expectedPhase: v1.DownLoadPhaseRetry,
 			expectedErr:   errors.New("Failed to get PEID from SnapshotID, ivd:invalid"),
 		},

--- a/pkg/controller/upload_controller_test.go
+++ b/pkg/controller/upload_controller_test.go
@@ -26,12 +26,12 @@ import (
 	"github.com/vmware-tanzu/astrolabe/pkg/astrolabe"
 	v1 "github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/apis/veleroplugin/v1"
 	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/builder"
+	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/constants"
 	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/dataMover"
 	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/fake"
 	informers "github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/informers/externalversions"
 	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/snapshotmgr"
 	veleroplugintest "github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/test"
-	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -45,7 +45,7 @@ import (
 )
 
 func defaultUpload() *builder.UploadBuilder {
-	return builder.ForUpload(utils.DefaultNamespace, "upload-1")
+	return builder.ForUpload(constants.DefaultNamespace, "upload-1")
 }
 
 func TestProcessUploadNonProcessedItems(t *testing.T) {
@@ -211,7 +211,7 @@ func TestPatchUploadByStatus(t *testing.T) {
 			key:      "velero/upload-1",
 			oldPhase: v1.UploadPhaseInProgress,
 			newPhase: v1.UploadPhaseCompleted,
-			upload:   defaultUpload().Phase(v1.UploadPhaseInProgress).Retry(utils.MIN_RETRY).Result(),
+			upload:   defaultUpload().Phase(v1.UploadPhaseInProgress).Retry(constants.MIN_RETRY).Result(),
 			msg:      "Upload completed",
 		},
 		{
@@ -219,7 +219,7 @@ func TestPatchUploadByStatus(t *testing.T) {
 			key:      "velero/upload-1",
 			oldPhase: v1.UploadPhaseInProgress,
 			newPhase: v1.UploadPhaseUploadError,
-			upload:   defaultUpload().Phase(v1.UploadPhaseInProgress).Retry(utils.MIN_RETRY).Result(),
+			upload:   defaultUpload().Phase(v1.UploadPhaseInProgress).Retry(constants.MIN_RETRY).Result(),
 			msg:      "Failed to upload snapshot, ivd:1234:1234, to durable object storage.",
 		},
 		{
@@ -227,7 +227,7 @@ func TestPatchUploadByStatus(t *testing.T) {
 			key:      "velero/upload-1",
 			oldPhase: v1.UploadPhaseInProgress,
 			newPhase: v1.UploadPhaseCleanupFailed,
-			upload:   defaultUpload().Phase(v1.UploadPhaseInProgress).Retry(utils.MIN_RETRY).Result(),
+			upload:   defaultUpload().Phase(v1.UploadPhaseInProgress).Retry(constants.MIN_RETRY).Result(),
 			msg:      "Failed to clean up local snapshot after uploading snapshot, ivd:1234:1234",
 		},
 		{
@@ -235,7 +235,7 @@ func TestPatchUploadByStatus(t *testing.T) {
 			key:      "velero/upload-1",
 			oldPhase: v1.UploadPhaseInProgress,
 			newPhase: v1.UploadPhaseUploadError,
-			upload:   defaultUpload().Phase(v1.UploadPhaseInProgress).Retry(utils.RETRY_WARNING_COUNT).Result(),
+			upload:   defaultUpload().Phase(v1.UploadPhaseInProgress).Retry(constants.RETRY_WARNING_COUNT).Result(),
 			msg:      "Failed to upload snapshot, ivd:1234:1234, to durable object storage.",
 		},
 		{
@@ -369,12 +369,12 @@ func TestPatchUploadByStatus(t *testing.T) {
 			require.Equal(t, test.newPhase, res.Status.Phase)
 			require.Equal(t, test.msg, res.Status.Message)
 			if test.oldPhase == v1.UploadPhaseNew {
-				require.Equal(t, int32(utils.MIN_RETRY), res.Status.RetryCount)
+				require.Equal(t, int32(constants.MIN_RETRY), res.Status.RetryCount)
 			}
 			if test.newPhase == v1.UploadPhaseUploadError {
 				newRetry := res.Status.RetryCount
 				require.Equal(t, oldRetry+1, newRetry)
-				require.LessOrEqual(t, res.Status.CurrentBackOff, int32(utils.UPLOAD_MAX_BACKOFF))
+				require.LessOrEqual(t, res.Status.CurrentBackOff, int32(constants.UPLOAD_MAX_BACKOFF))
 			}
 		})
 	}
@@ -392,7 +392,7 @@ func TestUploadErrorRetry(t *testing.T) {
 		{
 			name:          "Test retry for upload with uploaderror",
 			key:           "velero/upload-1",
-			retry:         utils.MIN_RETRY,
+			retry:         constants.MIN_RETRY,
 			upload:        defaultUpload().Phase(v1.UploadPhaseInProgress).SnapshotID("ivd:1234:1234").Retry(0).Result(),
 			expectedPhase: v1.UploadPhaseCompleted,
 			expectedErr:   errors.New("Failed to upload snapshot, ivd:1234:1234, to durable object storage. Failed at copying to remote repository"),

--- a/pkg/dataMover/data_mover.go
+++ b/pkg/dataMover/data_mover.go
@@ -18,6 +18,7 @@ package dataMover
 
 import (
 	"context"
+	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/constants"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -53,7 +54,7 @@ func NewDataMoverFromCluster(params map[string]interface{}, externalDataMgr bool
 	// using the BackupRepositories
 	var s3PETM *s3repository.ProtectedEntityTypeManager
 	if !externalDataMgr {
-		err := utils.RetrieveVSLFromVeleroBSLs(params, utils.DefaultS3BackupLocation, nil, logger)
+		err := utils.RetrieveVSLFromVeleroBSLs(params, constants.DefaultS3BackupLocation, nil, logger)
 		if err != nil {
 			logger.WithError(err).Errorf("Could not retrieve velero default backup location.")
 			return nil, err
@@ -93,7 +94,7 @@ func NewDataMoverFromCluster(params map[string]interface{}, externalDataMgr bool
 }
 
 func (this *DataMover) CopyToRepo(peID astrolabe.ProtectedEntityID) (astrolabe.ProtectedEntityID, error) {
-	backupRepository := builder.ForBackupRepository(utils.WithoutBackupRepository).Result()
+	backupRepository := builder.ForBackupRepository(constants.WithoutBackupRepository).Result()
 	return this.copyToRepo(peID, backupRepository)
 }
 
@@ -116,7 +117,7 @@ func (this *DataMover) copyToRepo(peID astrolabe.ProtectedEntityID, backupReposi
 	this.RegisterOngoingUpload(peID, cancelFunc)
 
 	log.Debugf("Ready to call s3 PETM copy API for local PE")
-	if backupRepository.Name != utils.WithoutBackupRepository {
+	if backupRepository.Name != constants.WithoutBackupRepository {
 		repoPETM, err := utils.GetRepositoryFromBackupRepository(backupRepository, log)
 		if err != nil {
 			log.WithError(err).Errorf("Failed to get S3 repository from backup repository %s", backupRepository.Name)
@@ -139,7 +140,7 @@ func (this *DataMover) copyToRepo(peID astrolabe.ProtectedEntityID, backupReposi
 }
 
 func (this *DataMover) CopyFromRepo(peID astrolabe.ProtectedEntityID, targetPEID astrolabe.ProtectedEntityID, options astrolabe.CopyCreateOptions) (astrolabe.ProtectedEntityID, error) {
-	backupRepository := builder.ForBackupRepository(utils.WithoutBackupRepository).Result()
+	backupRepository := builder.ForBackupRepository(constants.WithoutBackupRepository).Result()
 	return this.copyFromRepo(peID, targetPEID, backupRepository, options)
 }
 
@@ -150,7 +151,7 @@ func (this *DataMover) CopyFromRepoWithBackupRepository(peID astrolabe.Protected
 func (this *DataMover) copyFromRepo(peID astrolabe.ProtectedEntityID, targetPEID astrolabe.ProtectedEntityID, backupRepository *backupdriverv1.BackupRepository, options astrolabe.CopyCreateOptions) (astrolabe.ProtectedEntityID, error) {
 	log := this.WithField("Remote PEID", peID.String())
 	log.Infof("Copying the snapshot from remote repository to local. Copy options: %d", options)
-	if backupRepository.Name != utils.WithoutBackupRepository {
+	if backupRepository.Name != constants.WithoutBackupRepository {
 		repoPETM, err := utils.GetRepositoryFromBackupRepository(backupRepository, log)
 		if err != nil {
 			log.WithError(err).Errorf("Failed to get S3 repository from backup repository %s", backupRepository.Name)

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -18,12 +18,12 @@ package install
 
 import (
 	"fmt"
+	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/constants"
 	"io"
 	"strings"
 	"time"
 
 	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/crds"
-	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/utils"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 
@@ -67,14 +67,14 @@ var CRDsList = []string{
 
 // DefaultImage is the default image to use for the Velero deployment and restic daemonset containers.
 var (
-	DefaultDatamgrImage          = imageRegistry() + "/" + utils.DataManagerForPlugin + ":" + imageVersion()
+	DefaultDatamgrImage          = imageRegistry() + "/" + constants.DataManagerForPlugin + ":" + imageVersion()
 	DefaultDatamgrImageLocalMode = imageLocalMode()
 	DefaultDatamgrPodCPURequest  = "0"
 	DefaultDatamgrPodMemRequest  = "0"
 	DefaultDatamgrPodCPULimit    = "0"
 	DefaultDatamgrPodMemLimit    = "0"
 
-	DefaultBackupDriverImage          = imageRegistry() + "/" + utils.BackupDriverForPlugin + ":" + imageVersion()
+	DefaultBackupDriverImage          = imageRegistry() + "/" + constants.BackupDriverForPlugin + ":" + imageVersion()
 	DefaultBackupDriverImageLocalMode = imageLocalMode()
 	DefaultBackupDriverPodCPURequest  = "0"
 	DefaultBackupDriverPodMemRequest  = "0"

--- a/pkg/paravirt/paravirt_protected_entity.go
+++ b/pkg/paravirt/paravirt_protected_entity.go
@@ -2,9 +2,8 @@ package paravirt
 
 import (
 	"context"
+	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/constants"
 	"io"
-
-	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/utils"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -77,7 +76,7 @@ func (this ParaVirtProtectedEntity) Snapshot(ctx context.Context, params map[str
 		backupRepositoryName = "INVALID_BR_NAME"
 	}
 	labels := map[string]string{
-		utils.SnapshotBackupLabel: params[astrolabe.PvcPEType][SnapshotParamBackupName].(string),
+		constants.SnapshotBackupLabel: params[astrolabe.PvcPEType][SnapshotParamBackupName].(string),
 	}
 
 	this.logger.Info("Creating a snapshot CR")

--- a/pkg/paravirt/paravirt_protected_entity_type_manager.go
+++ b/pkg/paravirt/paravirt_protected_entity_type_manager.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/constants"
+	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/utils"
 
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
@@ -16,7 +18,6 @@ import (
 	backupdriverv1 "github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/apis/backupdriver/v1"
 	backupdriverTypedV1 "github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/typed/backupdriver/v1"
 	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/snapshotUtils"
-	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/utils"
 	v1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -195,13 +196,13 @@ func (this *ParaVirtProtectedEntityTypeManager) CreateFromMetadata(ctx context.C
 
 	// Get backupRepository from Guest, set backRepositoryName to backupRepositoryObj.SvcBackupRepositoryName
 	var backupRepo *snapshotUtils.BackupRepository
-	if backupRepositoryName != "" && backupRepositoryName != utils.WithoutBackupRepository {
+	if backupRepositoryName != "" && backupRepositoryName != constants.WithoutBackupRepository {
 		backupRepositoryCR, err := utils.GetBackupRepositoryFromBackupRepositoryName(backupRepositoryName)
 		if err != nil {
 			this.logger.Errorf("Failed to get BackupRepository from BackupRepositoryName %s: %v", backupRepositoryName, err)
 			return nil, errors.Wrapf(err, "failed to retrieve backupRepository")
 		}
-		if backupRepositoryCR.SvcBackupRepositoryName != "" && backupRepositoryCR.SvcBackupRepositoryName != utils.WithoutBackupRepository {
+		if backupRepositoryCR.SvcBackupRepositoryName != "" && backupRepositoryCR.SvcBackupRepositoryName != constants.WithoutBackupRepository {
 			this.logger.Info("BackupRepositoryName in Supervisor: %s", backupRepositoryCR.SvcBackupRepositoryName)
 			backupRepositoryName = backupRepositoryCR.SvcBackupRepositoryName
 		}

--- a/pkg/plugin/volume_snapshotter_plugin.go
+++ b/pkg/plugin/volume_snapshotter_plugin.go
@@ -20,8 +20,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/vmware-tanzu/astrolabe/pkg/astrolabe"
+	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/constants"
 	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/snapshotmgr"
-	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/utils"
 	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -50,7 +50,7 @@ func (p *NewVolumeSnapshotter) Init(config map[string]string) error {
 	if config == nil {
 		config = make(map[string]string)
 	}
-	config[utils.VolumeSnapshotterManagerLocation] = utils.VolumeSnapshotterPlugin
+	config[constants.VolumeSnapshotterManagerLocation] = constants.VolumeSnapshotterPlugin
 	var err error
 	params := make(map[string]interface{})
 	p.snapMgr, err = snapshotmgr.NewSnapshotManagerFromCluster(params, config, p.FieldLogger)
@@ -98,7 +98,7 @@ func (p *NewVolumeSnapshotter) GetVolumeInfo(volumeID, volumeAZ string) (string,
 	p.Infof("GetVolumeInfo called with volumeID %s, volumeAZ %s", volumeID, volumeAZ)
 	var iops int64
 	iops = 100 // dummy iops is applied
-	return utils.CnsBlockVolumeType, &iops, nil
+	return constants.CnsBlockVolumeType, &iops, nil
 }
 
 // IsVolumeReady Check if the volume is ready.

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -19,6 +19,7 @@ package utils
 import (
 	"context"
 	"fmt"
+	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/constants"
 	"os"
 	"strings"
 	"testing"
@@ -156,7 +157,7 @@ func TestCreateRepositoryFromBackupRepository(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "default",
 				},
-				RepositoryDriver:     S3RepositoryDriver,
+				RepositoryDriver:     constants.S3RepositoryDriver,
 				RepositoryParameters: map1,
 			},
 			expectedErr: errors.New("Missing region param, cannot initialize S3 PETM"),
@@ -172,7 +173,7 @@ func TestCreateRepositoryFromBackupRepository(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "default",
 				},
-				RepositoryDriver:     S3RepositoryDriver,
+				RepositoryDriver:     constants.S3RepositoryDriver,
 				RepositoryParameters: map2,
 			},
 			expectedErr: errors.New("Missing bucket param, cannot initialize S3 PETM"),
@@ -378,7 +379,7 @@ func Test_waitForPvSecret(t *testing.T) {
 			APIVersion: "v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: PvSecretName,
+			Name: constants.PvSecretName,
 		},
 	}
 
@@ -389,17 +390,17 @@ func Test_waitForPvSecret(t *testing.T) {
 	formatter.FullTimestamp = true
 	logger.SetFormatter(formatter)
 
-	err = clientSet.CoreV1().Secrets(BackupDriverNamespace).Delete(context.TODO(), testSecret.Name, metav1.DeleteOptions{})
+	err = clientSet.CoreV1().Secrets(constants.BackupDriverNamespace).Delete(context.TODO(), testSecret.Name, metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Delete error = %v\n", err)
 	}
-	writtenSnapshot, err := clientSet.CoreV1().Secrets(BackupDriverNamespace).Create(context.TODO(), &testSecret, metav1.CreateOptions{})
+	writtenSnapshot, err := clientSet.CoreV1().Secrets(constants.BackupDriverNamespace).Create(context.TODO(), &testSecret, metav1.CreateOptions{})
 
 	testSecret.ObjectMeta = writtenSnapshot.ObjectMeta
 
 	timeoutContext, cancelFunc := context.WithDeadline(context.Background(), time.Now().Add(time.Second*10))
 	defer cancelFunc()
-	createdSecret, err := waitForPvSecret(timeoutContext, clientSet, BackupDriverNamespace, logger)
+	createdSecret, err := waitForPvSecret(timeoutContext, clientSet, constants.BackupDriverNamespace, logger)
 	if err != nil {
 		t.Fatalf("waitForPvSecret returned err = %v\n", err)
 	} else {


### PR DESCRIPTION
1. During restore/delete operation on a new cluster, the backup repository are not claimed.
2. This change explicitly re-creates br/brc when a restore/delete occurs.
3. If there is a pre-existing br/brc that match the credentials, they will be picked up.
4. Refactor to get rid of circular dependencies. 

Signed-off-by: Deepak Kinni <dkinni@vmware.com>