### PR TITLE
Remove Local Mode Implementation.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,6 @@ ARCH ?= linux-amd64
 ifndef VERSION
 VERSION := $(shell echo `git rev-parse --abbrev-ref HEAD`-`git log -1 --pretty=format:%h`-`date "+%d.%b.%Y.%H.%M.%S"`)
 endif
-LOCALMODE ?= false
 
 # set git sha and tree state
 GIT_SHA = $(shell git rev-parse HEAD)
@@ -103,7 +102,6 @@ _output/bin/$(GOOS)/$(GOARCH)/$(BIN): build-dirs
 		GOARCH=$(GOARCH) \
 		REGISTRY=$(REGISTRY) \
 		VERSION=$(VERSION) \
-		LOCALMODE=$(LOCALMODE) \
 		PKG=$(PKG) \
 		BIN=$(BIN) \
 		GIT_SHA=$(GIT_SHA) \
@@ -210,9 +208,6 @@ push-backup-driver: backup-driver-container
 	docker push $(BACKUPDRIVER_IMAGE):$(VERSION)
 
 push: push-datamgr push-plugin push-backup-driver
-
-push-pp:
-	$(MAKE) push-plugin push-backup-driver LOCALMODE=true VERSION=$(VERSION)-pp
 
 QUALIFIED_TAG ?=
 RELEASE_TAG ?= latest

--- a/cmd/velero-plugin-for-vsphere/main.go
+++ b/cmd/velero-plugin-for-vsphere/main.go
@@ -17,7 +17,6 @@
 package main
 
 import (
-	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/constants"
 	"os"
 	"strings"
 
@@ -31,7 +30,8 @@ import (
 func main() {
 	enableFeatureFlagForVSpherePlugins()
 	veleroPluginServer := veleroplugin.NewServer()
-	if features.IsEnabled(constants.VSphereItemActionPluginFlag) {
+	// Feature flag read directly from velero server args.
+	if features.IsEnabled("EnableVSphereItemActionPlugin") {
 		veleroPluginServer = veleroPluginServer.
 			RegisterBackupItemAction("velero.io/vsphere-pvc-backupper", newPVCBackupItemAction).
 			RegisterRestoreItemAction("velero.io/vsphere-pvc-restorer", newPVCRestoreItemAction).

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.4.0
-	github.com/vmware-tanzu/astrolabe v0.1.2-0.20200902012446-e69f9550d091
+	github.com/vmware-tanzu/astrolabe v0.1.2-0.20201002235134-f9517cab32a4
 	github.com/vmware-tanzu/velero v1.5.0-beta.1
 	k8s.io/api v0.18.4
 	k8s.io/apiextensions-apiserver v0.18.4

--- a/go.sum
+++ b/go.sum
@@ -738,8 +738,8 @@ github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
 github.com/vishvananda/netlink v1.0.0/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=
 github.com/vishvananda/netns v0.0.0-20171111001504-be1fbeda1936/go.mod h1:ZjcWmFBXmLKZu9Nxj3WKYEafiSqer2rnvPr0en9UNpI=
-github.com/vmware-tanzu/astrolabe v0.1.2-0.20200902012446-e69f9550d091 h1:dc1Ip32d7fFY60w99yLjVzqqOrNsXxuxvVhm7BBZNbI=
-github.com/vmware-tanzu/astrolabe v0.1.2-0.20200902012446-e69f9550d091/go.mod h1:Af9uI95FSmiaKAiyUFa21rvFAeU195hIv7dMK3XnRag=
+github.com/vmware-tanzu/astrolabe v0.1.2-0.20201002235134-f9517cab32a4 h1:lStKHeOBunC/Ir3mnMEBtpT8K7aJIi7QQQjvmX6+Rl0=
+github.com/vmware-tanzu/astrolabe v0.1.2-0.20201002235134-f9517cab32a4/go.mod h1:Af9uI95FSmiaKAiyUFa21rvFAeU195hIv7dMK3XnRag=
 github.com/vmware-tanzu/velero v1.5.0-beta.1 h1:k71SIO30rJmiVofI67QzbvZvkr64fnDDlk0pmKGypOY=
 github.com/vmware-tanzu/velero v1.5.0-beta.1/go.mod h1:gKej3kghIWuJJ8cmdb4Gwfqb6/rE6t2e7VcMcy5sQFc=
 github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -42,10 +42,6 @@ if [ -z "${REGISTRY}" ]; then
     echo "REGISTRY must be set"
     exit 1
 fi
-if [ -z "${LOCALMODE}" ]; then
-    echo "LOCALMODE must be set"
-    exit 1
-fi
 if [ -z "${GIT_SHA}" ]; then
     echo "GIT_SHA must be set"
     exit 1
@@ -62,7 +58,6 @@ fi
 
 LDFLAGS="-X ${PKG}/pkg/buildinfo.Version=${VERSION}"
 LDFLAGS="${LDFLAGS} -X ${PKG}/pkg/buildinfo.Registry=${REGISTRY}"
-LDFLAGS="${LDFLAGS} -X ${PKG}/pkg/buildinfo.LocalMode=${LOCALMODE}"
 LDFLAGS="${LDFLAGS} -X ${PKG}/pkg/buildinfo.GitSHA=${GIT_SHA}"
 LDFLAGS="${LDFLAGS} -X ${PKG}/pkg/buildinfo.GitTreeState=${GIT_TREE_STATE}"
 

--- a/pkg/backupdriver/backup_driver_controller_base.go
+++ b/pkg/backupdriver/backup_driver_controller_base.go
@@ -135,7 +135,6 @@ func NewBackupDriverController(
 	backupdriverInformerFactory backupdriverinformers.SharedInformerFactory,
 	svcInformerFactory informers.SharedInformerFactory,
 	svcBackupdriverInformerFactory backupdriverinformers.SharedInformerFactory,
-	localMode bool,
 	snapManager *snapshotmgr.SnapshotManager,
 	rateLimiter workqueue.RateLimiter) BackupDriverController {
 
@@ -173,7 +172,7 @@ func NewBackupDriverController(
 
 	// Configure supervisor cluster queues and caches in the guest
 	// We watch supervisor snapshot CRs for the upload status. If local mode is set, we do not have to watch for upload status
-	if svcKubeConfig != nil && !localMode {
+	if svcKubeConfig != nil {
 		svcSnapshotMap = make(map[string]string)
 		svcSnapshotInformer := svcBackupdriverInformerFactory.Backupdriver().V1().Snapshots()
 
@@ -276,7 +275,7 @@ func NewBackupDriverController(
 	)
 
 	// Configure supervisor cluster informers in the guest
-	if svcKubeConfig != nil && !localMode {
+	if svcKubeConfig != nil {
 		svcSnapshotInformer := svcBackupdriverInformerFactory.Backupdriver().V1().Snapshots()
 		svcSnapshotInformer.Informer().AddEventHandlerWithResyncPeriod(
 			cache.ResourceEventHandlerFuncs{

--- a/pkg/buildinfo/version.go
+++ b/pkg/buildinfo/version.go
@@ -28,9 +28,6 @@ var (
 	// Registry is the current registry of image of Velero plugins, set by the go linker's -X flag at build time.
 	Registry string
 
-	// LocalMode is the flag to control whether to enable the data manager feature or not, set by the go linker's -X flag at build time.
-	LocalMode string
-
 	// GitSHA is the actual commit that is being built, set by the go linker's -X flag at build time.
 	GitSHA string
 

--- a/pkg/cmd/datamgr/cli/server/server.go
+++ b/pkg/cmd/datamgr/cli/server/server.go
@@ -260,7 +260,7 @@ func newServer(f client.Factory, config serverConfig, logger *logrus.Logger) (*s
 	s3RepoParams := make(map[string]interface{})
 
 	configInfo := astrolabeServer.NewConfigInfo(peConfigs, s3Config)
-	snapshotmgr, err := snapshotmgr.NewSnapshotManagerFromConfig(configInfo, s3RepoParams, snapshotMgrConfig,
+	snapshotMgr, err := snapshotmgr.NewSnapshotManagerFromConfig(configInfo, s3RepoParams, snapshotMgrConfig,
 		clientConfig, logger)
 	if err != nil {
 		return nil, err
@@ -277,7 +277,7 @@ func newServer(f client.Factory, config serverConfig, logger *logrus.Logger) (*s
 		externalDataMgr = true
 	}
 
-	dataMover, err := dataMover.NewDataMoverFromCluster(ivdParams, externalDataMgr, logger)
+	clusterDataMover, err := dataMover.NewDataMoverFromCluster(ivdParams, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -293,8 +293,8 @@ func newServer(f client.Factory, config serverConfig, logger *logrus.Logger) (*s
 		logger:                logger,
 		logLevel:              logger.Level,
 		config:                config,
-		dataMover:             dataMover,
-		snapManager:           snapshotmgr,
+		dataMover:             clusterDataMover,
+		snapManager:           snapshotMgr,
 		externalDataMgr:       externalDataMgr,
 	}
 	return s, nil

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -129,14 +129,18 @@ type ClusterFlavor string
 const (
 	Unknown    ClusterFlavor = "Unknown"
 	Supervisor               = "Supervisor Cluster"
-	TkgGuest                 = "TGK Guest Cluster"
+	TkgGuest                 = "TKG Guest Cluster"
 	VSphere                  = "vSphere Kubernetes Cluster"
 )
 
 // feature flog constants
 const (
-	// VSphereItemActionPluginFlag is the feature flag string that defines whether or not vSphere ItemActionPlugin features are being used.
-	VSphereItemActionPluginFlag = "EnableVSphereItemActionPlugin"
+	VSphereItemActionPluginFlag = "vsphere-item-action-plugin"
+	VSphereLocalModeFlag        = "local-mode"
+)
+
+const (
+	VSpherePluginFeatureStates = "velero-vsphere-plugin-feature-states"
 )
 
 // Para Virtual Cluster access for Guest Cluster

--- a/pkg/install/daemonset.go
+++ b/pkg/install/daemonset.go
@@ -35,7 +35,6 @@ type podTemplateConfig struct {
 	withSecret     bool
 	masterAffinity bool
 	hostNetwork    bool
-	localMode      bool
 }
 
 func WithImage(image string) podTemplateOption {
@@ -77,12 +76,6 @@ func WithMasterNodeAffinity(affinity bool) podTemplateOption {
 func WithHostNetwork(hostNetwork bool) podTemplateOption {
 	return func(c *podTemplateConfig) {
 		c.hostNetwork = hostNetwork
-	}
-}
-
-func WithLocalMode(localMode bool) podTemplateOption {
-	return func(c *podTemplateConfig) {
-		c.localMode = localMode
 	}
 }
 

--- a/pkg/install/deployment.go
+++ b/pkg/install/deployment.go
@@ -168,10 +168,6 @@ func Deployment(namespace string, opts ...podTemplateOption) *appsv1.Deployment 
 		deployment.Spec.Template.Spec.HostNetwork = true
 	}
 
-	if c.localMode {
-		deployment.Spec.Template.Spec.Containers[0].Args = append(deployment.Spec.Template.Spec.Containers[0].Args, "--local-mode")
-	}
-
 	deployment.Spec.Template.Spec.Containers[0].Env = append(deployment.Spec.Template.Spec.Containers[0].Env, c.envVars...)
 
 	return deployment

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -68,14 +68,12 @@ var CRDsList = []string{
 // DefaultImage is the default image to use for the Velero deployment and restic daemonset containers.
 var (
 	DefaultDatamgrImage          = imageRegistry() + "/" + constants.DataManagerForPlugin + ":" + imageVersion()
-	DefaultDatamgrImageLocalMode = imageLocalMode()
 	DefaultDatamgrPodCPURequest  = "0"
 	DefaultDatamgrPodMemRequest  = "0"
 	DefaultDatamgrPodCPULimit    = "0"
 	DefaultDatamgrPodMemLimit    = "0"
 
 	DefaultBackupDriverImage          = imageRegistry() + "/" + constants.BackupDriverForPlugin + ":" + imageVersion()
-	DefaultBackupDriverImageLocalMode = imageLocalMode()
 	DefaultBackupDriverPodCPURequest  = "0"
 	DefaultBackupDriverPodMemRequest  = "0"
 	DefaultBackupDriverPodCPULimit    = "0"
@@ -94,7 +92,7 @@ type PodOptions struct {
 	SecretAdd      bool
 	MasterAffinity bool
 	HostNetwork    bool
-	LocalMode      bool
+	Features	   []string
 }
 
 // Use "latest" if the build process didn't supply a version
@@ -110,13 +108,6 @@ func imageRegistry() string {
 		return "dpcpinternal"
 	}
 	return buildinfo.Registry
-}
-
-func imageLocalMode() string {
-	if buildinfo.LocalMode == "" {
-		return "false"
-	}
-	return buildinfo.LocalMode
 }
 
 func labels() map[string]string {
@@ -409,7 +400,6 @@ func AllBackupDriverResources(o *PodOptions, withCRDs bool) (*unstructured.Unstr
 		WithResources(o.PodResources),
 		WithMasterNodeAffinity(o.MasterAffinity),
 		WithHostNetwork(o.HostNetwork),
-		WithLocalMode(o.LocalMode),
 	)
 	appendUnstructured(resources, deploy)
 

--- a/pkg/plugin/backup_pvc_action_plugin.go
+++ b/pkg/plugin/backup_pvc_action_plugin.go
@@ -9,7 +9,6 @@ import (
 	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/backuprepository"
 	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/constants"
 	backupdriverTypedV1 "github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/typed/backupdriver/v1"
-	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/install"
 	pluginUtil "github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/plugin/util"
 	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/snapshotUtils"
 	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/utils"
@@ -87,7 +86,7 @@ func (p *NewPVCBackupItemAction) Execute(item runtime.Unstructured, backup *vele
 
 	// Do not claim a backup repository in local mode
 	var backupRepositoryName string
-	isLocalMode := utils.GetBool(install.DefaultBackupDriverImageLocalMode, false)
+	isLocalMode := utils.IsFeatureEnabled(constants.VSphereLocalModeFlag, false, p.Log)
 	if !isLocalMode {
 		p.Log.Info("Claiming backup repository during backup")
 		bslName := backup.Spec.StorageLocation
@@ -97,6 +96,7 @@ func (p *NewPVCBackupItemAction) Execute(item runtime.Unstructured, backup *vele
 			return nil, nil, errors.WithStack(err)
 		}
 	}
+
 	backupRepository := snapshotUtils.NewBackupRepository(backupRepositoryName)
 
 	objectToSnapshot := corev1.TypedLocalObjectReference{

--- a/pkg/plugin/delete_pvc_action_plugin.go
+++ b/pkg/plugin/delete_pvc_action_plugin.go
@@ -9,7 +9,6 @@ import (
 	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/backuprepository"
 	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/constants"
 	backupdriverTypedV1 "github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/typed/backupdriver/v1"
-	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/install"
 	pluginItem "github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/plugin/util"
 	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/snapshotUtils"
 	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/utils"
@@ -89,7 +88,7 @@ func (p *NewPVCDeleteItemAction) Execute(input *velero.DeleteItemActionExecuteIn
 	bslName := input.Backup.Spec.StorageLocation
 
 	var backupRepositoryName string
-	isLocalMode := utils.GetBool(install.DefaultBackupDriverImageLocalMode, false)
+	isLocalMode := utils.IsFeatureEnabled(constants.VSphereLocalModeFlag, false, p.Log)
 	if !isLocalMode {
 		p.Log.Info("Claiming backup repository during delete")
 		backupRepositoryName, err = backuprepository.RetrieveBackupRepositoryFromBSL(ctx, bslName, pvc.Namespace, veleroNs, backupdriverClient, restConfig, p.Log)

--- a/pkg/plugin/restore_pvc_action_plugin.go
+++ b/pkg/plugin/restore_pvc_action_plugin.go
@@ -11,7 +11,6 @@ import (
 	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/backuprepository"
 	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/constants"
 	backupdriverTypedV1 "github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/typed/backupdriver/v1"
-	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/install"
 	pluginItem "github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/plugin/util"
 	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/snapshotUtils"
 	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/utils"
@@ -134,6 +133,7 @@ func (p *NewPVCRestoreItemAction) Execute(input *velero.RestoreItemActionExecute
 		p.Log.Errorf("Failed to get the rest config in k8s cluster: %v", err)
 		return nil, errors.WithStack(err)
 	}
+
 	backupdriverClient, err := backupdriverTypedV1.NewForConfig(restConfig)
 	if err != nil {
 		return nil, errors.WithStack(err)
@@ -151,7 +151,7 @@ func (p *NewPVCRestoreItemAction) Execute(input *velero.RestoreItemActionExecute
 		return nil, errors.WithStack(err)
 	}
 	var backupRepositoryName string
-	isLocalMode := utils.GetBool(install.DefaultBackupDriverImageLocalMode, false)
+	isLocalMode := utils.IsFeatureEnabled(constants.VSphereLocalModeFlag, false, p.Log)
 	if !isLocalMode {
 		p.Log.Info("Claiming backup repository during restore")
 		backupRepositoryName, err = backuprepository.RetrieveBackupRepositoryFromBSL(ctx, bslName, pvc.Namespace, veleroNs, backupdriverClient, restConfig, p.Log)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -15,5 +15,5 @@
 # limitations under the License.
 
 cp /plugins/* /target/.
-/backup-driver install --features EnableVSphereItemActionPlugin
+/backup-driver install
 /data-manager-for-plugin install


### PR DESCRIPTION
1. This change eliminates specifying local mode as a compile-time option.
2. During plugin install the feature flags are explicitly read from velero deployment.
3. The feature flags are used to create a config map in the velero namespace during backup driver installation.
4. The config map is read explicitly during backup/restore/delete to determine if we are in local mode.
5. During data manager installation the feature flags are read from velero deployment to determine if we must proceed with the installation.

Pre-Check: https://container-dp.svc.eng.vmware.com/job/Container_Precheck_Velero/519/

Signed-off-by: Deepak Kinni <dkinni@vmware.com>