### PR TITLE
Minor fixes to prevent nil ptr dereference and error check removal.

### DIFF
--- a/pkg/backupdriver/backup_driver_controller.go
+++ b/pkg/backupdriver/backup_driver_controller.go
@@ -218,10 +218,6 @@ func (ctrl *backupDriverController) cloneFromSnapshot(cloneFromSnapshot *backupd
 
 	// cloneFromSnapshot.Spec.Kind should be "PersistentVolumeClaim" for now
 	peId = astrolabe.NewProtectedEntityIDWithNamespace(cloneFromSnapshot.Spec.Kind, pvc.Name, pvc.Namespace)
-	if err != nil {
-		ctrl.logger.WithError(err).Errorf("Fail to construct new PE ID for %s/%s", pvc.Namespace, pvc.Name)
-		return err
-	}
 	ctrl.logger.Infof("cloneFromSnapshot: Generated PE ID: %s", peId.String())
 
 	returnPeId, err = ctrl.snapManager.CreateVolumeFromSnapshotWithMetadata(peId, cloneFromSnapshot.Spec.Metadata,

--- a/pkg/paravirt/paravirt_protected_entity_type_manager.go
+++ b/pkg/paravirt/paravirt_protected_entity_type_manager.go
@@ -206,8 +206,8 @@ func (this *ParaVirtProtectedEntityTypeManager) CreateFromMetadata(ctx context.C
 			this.logger.Info("BackupRepositoryName in Supervisor: %s", backupRepositoryCR.SvcBackupRepositoryName)
 			backupRepositoryName = backupRepositoryCR.SvcBackupRepositoryName
 		}
-		backupRepo = snapshotUtils.NewBackupRepository(backupRepositoryName)
 	}
+	backupRepo = snapshotUtils.NewBackupRepository(backupRepositoryName)
 
 	// sourceSnapshotID from CloneFromSnapshot in Guest is in this format:
 	// pvc:test-ns-xtayual/test-pvc:cGFyYXZpcnQtcHY6cHZjLTE1ZDBhYzhmLTQxOGYtNGU1ZC05OWMxLWIxMjcyNjNlMjA1ODphWFprT2pGbE5EWmlZalJrTFdJelpqQXROREJrTlMwNVkyRTRMVE5pWVdVMlpqVTVOVGsxTlRwa01tVXlNamN4TmkwNVlUWXhMVFEyT0dFdFlqQmhZeTB4T1RKa01tSmtNV0kzWmpV


### PR DESCRIPTION
1. backupRepo is passed to CloneSnapshotRef, it cannot be nil, in the current code if the backupRepositoryName is "" or "without-backup-repository" backupRepo is nil, when passed to CloneSnapshotRef it dereferenced, this will cause a crash. If the name is ""/"without-backup-repository" we can still create backupRepo, the lower stack know how to deal with this.

2. NewProtectedEntityIDWithNamespace does not return an error, no need for an error check.

Signed-off-by: Deepak Kinni <dkinni@vmware.com>