### PR TITLE
Remove instances where the velero namespace is hard coded.

### DIFF
--- a/pkg/cmd/backupdriver/cli/install/install.go
+++ b/pkg/cmd/backupdriver/cli/install/install.go
@@ -19,8 +19,9 @@ package install
 import (
 	"context"
 	"fmt"
-	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/constants"
 	"strings"
+
+	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/constants"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -147,7 +148,7 @@ func (o *InstallOptions) Run(c *cobra.Command, f client.Factory) error {
 	}
 
 	// Check velero version
-	veleroVersion, err := cmd.GetVeleroVersion(f)
+	veleroVersion, err := cmd.GetVeleroVersion(f, o.Namespace)
 	if err != nil || veleroVersion == "" {
 		fmt.Println("Failed to get velero version.")
 	} else {

--- a/pkg/cmd/datamgr/cli/install/install.go
+++ b/pkg/cmd/datamgr/cli/install/install.go
@@ -19,8 +19,9 @@ package install
 import (
 	"context"
 	"fmt"
-	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/constants"
 	"strings"
+
+	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/constants"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
@@ -169,7 +170,7 @@ func (o *InstallOptions) Run(c *cobra.Command, f client.Factory) error {
 	}
 
 	// Check velero version
-	veleroVersion, err := cmd.GetVeleroVersion(f)
+	veleroVersion, err := cmd.GetVeleroVersion(f, o.Namespace)
 	if err != nil || veleroVersion == "" {
 		fmt.Println("Failed to get velero version.")
 	} else {

--- a/pkg/cmd/utils.go
+++ b/pkg/cmd/utils.go
@@ -19,10 +19,11 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/constants"
 	"os"
 	"strconv"
 	"strings"
+
+	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/constants"
 
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -71,13 +72,13 @@ func GetVersionFromImage(containers []v1.Container, imageName string) string {
 	}
 }
 
-func GetVeleroVersion(f client.Factory) (string, error) {
+func GetVeleroVersion(f client.Factory, ns string) (string, error) {
 	clientset, err := f.KubeClient()
 	if err != nil {
 		fmt.Println("Failed to get kubeclient.")
 		return "", err
 	}
-	deploymentList, err := clientset.AppsV1().Deployments("velero").List(context.TODO(), metav1.ListOptions{})
+	deploymentList, err := clientset.AppsV1().Deployments(ns).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		fmt.Println("Failed to get deployment for velero namespace.")
 		return "", err


### PR DESCRIPTION
In the install codepath for the backup driver and the data manager, we hard
code the "velero" namespace. With this fix, we pass the parameter that
contains the namespace where velero is deployed.

Signed-off-by: Swati Gupta <swgupta@swgupta-a01.vmware.com>