### PR TITLE
Removed unused vendor directory from docker volumes for build container.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,6 @@ shell: build-dirs
 		-i $(TTY) \
 		--rm \
 		-u $$(id -u):$$(id -g) \
-		-v "$$(pwd)/vendor/k8s.io/api:/go/src/k8s.io/api:delegated" \
 		-v $$(pwd)/.go/pkg:/go/pkg:delegated \
 		-v $$(pwd)/.go/src:/go/src:delegated \
 		-v $$(pwd)/.go/std:/go/std:delegated \


### PR DESCRIPTION
Fixes issue with Goland getting confused by empty vendor directory and then
not able to correctly index.

Signed-off-by: Dave Smith-Uchida <dsmithuchida@vmware.com>