### PR TITLE
Removed EnableVSphereItemActionPlugin feature flag.  

### DIFF
--- a/cmd/velero-plugin-for-vsphere/main.go
+++ b/cmd/velero-plugin-for-vsphere/main.go
@@ -30,15 +30,10 @@ import (
 func main() {
 	enableFeatureFlagForVSpherePlugins()
 	veleroPluginServer := veleroplugin.NewServer()
-	// Feature flag read directly from velero server args.
-	if features.IsEnabled("EnableVSphereItemActionPlugin") {
-		veleroPluginServer = veleroPluginServer.
-			RegisterBackupItemAction("velero.io/vsphere-pvc-backupper", newPVCBackupItemAction).
-			RegisterRestoreItemAction("velero.io/vsphere-pvc-restorer", newPVCRestoreItemAction).
-			RegisterDeleteItemAction("velero.io/vsphere-pvc-deleter", newPVCDeleteItemAction)
-	} else {
-		veleroPluginServer = veleroPluginServer.RegisterVolumeSnapshotter("velero.io/vsphere", newVolumeSnapshotterPlugin)
-	}
+	veleroPluginServer = veleroPluginServer.
+		RegisterBackupItemAction("velero.io/vsphere-pvc-backupper", newPVCBackupItemAction).
+		RegisterRestoreItemAction("velero.io/vsphere-pvc-restorer", newPVCRestoreItemAction).
+		RegisterDeleteItemAction("velero.io/vsphere-pvc-deleter", newPVCDeleteItemAction)
 	veleroPluginServer.Serve()
 }
 

--- a/pkg/cmd/utils.go
+++ b/pkg/cmd/utils.go
@@ -171,13 +171,9 @@ func CreateFeatureStateConfigMap(features []string, f client.Factory, veleroNs s
 	//Always overwrite the feature flags.
 	featureData = make(map[string]string)
 	// Insert the keys with default values.
-	featureData[constants.VSphereItemActionPluginFlag] = strconv.FormatBool(true)
 	featureData[constants.VSphereLocalModeFlag] = strconv.FormatBool(false)
 	// Update the falgs based on velero feature flags.
 	featuresString := strings.Join(features[:], ",")
-	if strings.Contains(featuresString, "EnableVSphereItemActionPlugin") {
-		featureData[constants.VSphereItemActionPluginFlag] = strconv.FormatBool(true)
-	}
 	if strings.Contains(featuresString, "EnableLocalMode") {
 		featureData[constants.VSphereLocalModeFlag] = strconv.FormatBool(true)
 	}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -135,7 +135,6 @@ const (
 
 // feature flog constants
 const (
-	VSphereItemActionPluginFlag = "vsphere-item-action-plugin"
 	VSphereLocalModeFlag        = "local-mode"
 )
 

--- a/pkg/snapshotmgr/snapshot_manager.go
+++ b/pkg/snapshotmgr/snapshot_manager.go
@@ -266,7 +266,6 @@ func (this *SnapshotManager) createSnapshot(peID astrolabe.ProtectedEntityID, ta
 	var isLocalMode bool
 	if backupRepositoryName == constants.WithoutBackupRepository {
 		// This occurs only if the volume snapshotter plugin is registered
-		// && EnableVSphereItemActionPlugin is not used in feature flag.
 		// In this scenario we explicitly read the feature flags to determine local mode.
 		isLocalMode = utils.IsFeatureEnabled(constants.VSphereLocalModeFlag, false, this.FieldLogger)
 	} else if backupRepositoryName == "" {
@@ -464,7 +463,6 @@ func (this *SnapshotManager) deleteSnapshot(peID astrolabe.ProtectedEntityID, ba
 	var isLocalMode bool
 	if backupRepositoryName == constants.WithoutBackupRepository {
 		// This occurs only if the volume snapshotter plugin is registered
-		// && EnableVSphereItemActionPlugin is not used in feature flag.
 		// In this scenario we explicitly read the feature flags to determine local mode.
 		isLocalMode = utils.IsFeatureEnabled(constants.VSphereLocalModeFlag, false, this.FieldLogger)
 	} else if backupRepositoryName == "" {


### PR DESCRIPTION
This does not handle backwards compatibility with 1.0.2 plug-in yet.

Signed-off-by: Dave Smith-Uchida <dsmithuchida@vmware.com>