### PR TITLE
Change Snapshot/DeleteSnapshot Phase to Failed on Sanpshot/DeleteSnapshot errors

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -278,3 +278,9 @@ const VeleroExcludeLabel = "velero.io/exclude-from-backup"
 
 // Default time window to clean up CR which is in terminal state
 const DefaultCRCleanUpWindow = 24
+
+const (
+	SnapshotParamBackupName       = "BackupName"
+	SnapshotParamSvcSnapshotName  = "SvcSnapshotName"
+	SnapshotParamBackupRepository = "BackupRepository"
+)

--- a/pkg/paravirt/paravirt_protected_entity_type_manager.go
+++ b/pkg/paravirt/paravirt_protected_entity_type_manager.go
@@ -38,12 +38,6 @@ const (
 	ParaVirtEntityTypePersistentService ParaVirtEntityType = "ps"
 )
 
-const (
-	SnapshotParamBackupRepository = "BackupRepository"
-	SnapshotParamSvcSnapshotName  = "SvcSnapshotName"
-	SnapshotParamBackupName       = "BackupName"
-)
-
 type ParaVirtProtectedEntityTypeManager struct {
 	entityType            ParaVirtEntityType
 	gcKubeClientSet       *kubernetes.Clientset

--- a/pkg/snapshotmgr/snapshot_manager.go
+++ b/pkg/snapshotmgr/snapshot_manager.go
@@ -224,8 +224,8 @@ func (this *SnapshotManager) createSnapshot(peID astrolabe.ProtectedEntityID, ta
 	snapshotParams := make(map[string]map[string]interface{})
 	guestSnapshotParams := make(map[string]interface{})
 	// Pass the backup repository name as snapshot param.
-	guestSnapshotParams[paravirt.SnapshotParamBackupRepository] = backupRepositoryName
-	guestSnapshotParams[paravirt.SnapshotParamBackupName] = backupName
+	guestSnapshotParams[constants.SnapshotParamBackupRepository] = backupRepositoryName
+	guestSnapshotParams[constants.SnapshotParamBackupName] = backupName
 
 	snapshotParams[peID.GetPeType()] = guestSnapshotParams
 
@@ -253,8 +253,8 @@ func (this *SnapshotManager) createSnapshot(peID astrolabe.ProtectedEntityID, ta
 
 	// Set the supervisor snapshot name is exists
 	svcSnapshotName := ""
-	if _, ok := guestSnapshotParams[paravirt.SnapshotParamSvcSnapshotName]; ok {
-		svcSnapshotName = fmt.Sprintf("%v", guestSnapshotParams[paravirt.SnapshotParamSvcSnapshotName])
+	if _, ok := guestSnapshotParams[constants.SnapshotParamSvcSnapshotName]; ok {
+		svcSnapshotName = fmt.Sprintf("%v", guestSnapshotParams[constants.SnapshotParamSvcSnapshotName])
 		this.Infof("Supervisor snapshot is created, %s", svcSnapshotName)
 	}
 
@@ -411,7 +411,7 @@ func (this *SnapshotManager) deleteSnapshot(peID astrolabe.ProtectedEntityID, ba
 		}
 		uploadName := "upload-" + snapIDDecoded
 		log.Infof("Searching for Upload CR: %s", uploadName)
-		uploadCR, err := pluginClient.DatamoverV1alpha1().Uploads(veleroNs).Get(context.TODO(), uploadName, metav1.GetOptions{})
+		uploadCR, err := pluginClient.DatamoverV1alpha1().Uploads(veleroNs).Get(ctx, uploadName, metav1.GetOptions{})
 		if err != nil {
 			log.WithError(err).Errorf(" Error while retrieving the upload CR %v", uploadName)
 			if k8serrors.IsNotFound(err) {
@@ -464,6 +464,7 @@ func (this *SnapshotManager) deleteSnapshot(peID astrolabe.ProtectedEntityID, ba
 	}
 	if clusterFlavor == constants.TkgGuest {
 		log.Infof("Guest Cluster detected during delete snapshot, nothing more to do.")
+		return nil
 	}
 	// Trigger remote snapshot deletion in Supervisor/Vanilla setup.
 	var isLocalMode bool


### PR DESCRIPTION
1. Currently on Snapshot/DeleteSnapshot error the Snapshot/DeleteSnapshot CRD is not moved to "failed" state.
2. This change moves it to "Failed" State.

Testing:
Emulated Snapshot failure by temporarily changing astrolabe and verified that the snapshot CRD moved to SnapshotFailed state.
Verified it on Guest/Supervisor
Vanilla Pre-checkins: https://container-dp.svc.eng.vmware.com/job/CNSDP-CI/263/

Signed-off-by: Deepak Kinni <dkinni@vmware.com>