### PR TITLE
Remove push-pp from ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,4 +37,3 @@ jobs:
           cd src/github.com/vmware-tanzu/velero-plugin-for-vsphere
           echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
           make push
-          make push-pp


### PR DESCRIPTION
Remove `make push-pp` from ci as it's no longer supported.

Signed-off-by: Deepak Kinni <dkinni@vmware.com>