### PR TITLE
Print out original error message from API server

### DIFF
--- a/pkg/backupdriver/backup_driver_controller.go
+++ b/pkg/backupdriver/backup_driver_controller.go
@@ -45,7 +45,7 @@ func (ctrl *backupDriverController) createSnapshot(snapshot *backupdriverapi.Sna
 
 	// call SnapshotMgr CreateSnapshot API
 	peID := astrolabe.NewProtectedEntityIDWithNamespace(objKind, objName, snapshot.Namespace)
-	ctrl.logger.Infof("CreateSnapshot: The initial Astrolabe PE ID: %s", peID)
+	ctrl.logger.Infof("createSnapshot: The initial Astrolabe PE ID: %s", peID)
 	if ctrl.snapManager == nil {
 		errMsg := fmt.Sprintf("snapManager is not initialized.")
 		ctrl.logger.Error(errMsg)
@@ -77,7 +77,7 @@ func (ctrl *backupDriverController) createSnapshot(snapshot *backupdriverapi.Sna
 
 	peID, svcSnapshotName, err := ctrl.snapManager.CreateSnapshotWithBackupRepository(peID, tags, brName, snapshot.Namespace+"/"+snapshot.Name, snapshot.Labels[constants.SnapshotBackupLabel])
 	if err != nil {
-		errMsg := fmt.Sprintf("failed at calling SnapshotManager CreateSnapshot from peID %v", peID)
+		errMsg := fmt.Sprintf("createSnapshot: Failed at calling SnapshotManager CreateSnapshot from peID %v: %v", peID, err)
 		ctrl.logger.Error(errMsg)
 		return err
 	}

--- a/pkg/snapshotmgr/snapshot_manager.go
+++ b/pkg/snapshotmgr/snapshot_manager.go
@@ -279,6 +279,7 @@ func (this *SnapshotManager) createSnapshot(peID astrolabe.ProtectedEntityID, ta
 	snapshotPE, err := this.Pem.GetProtectedEntity(ctx, snapshotPEID)
 	_, err = this.UploadSnapshot(snapshotPE, ctx, backupRepositoryName, snapshotRef)
 	if err != nil {
+		this.Errorf("Failed to create Upload CR for snapshot PEID %s, Supervisor Cluster snapshot name %s: %v", snapshotPEID.String(), svcSnapshotName, err)
 		return snapshotPEID, svcSnapshotName, err
 	}
 
@@ -331,7 +332,7 @@ func (this *SnapshotManager) UploadSnapshot(uploadPE astrolabe.ProtectedEntity, 
 
 	uploadName, err := uploadCRNameForSnapshotPEID(uploadSnapshotPEID)
 	if err != nil {
-		this.WithError(err).Errorf("Failed to get uploadCR")
+		this.WithError(err).Errorf("Failed to get uploadCR name for snapshot PE ID %s", uploadSnapshotPEID.String())
 		return nil, err
 	}
 	this.Infof("Creating Upload CR: %s / %s", veleroNs, uploadName)


### PR DESCRIPTION
This PR prints out original error messages from the API server to help identify the root cause of a bug.