### PR TITLE
Avoid access key logging during BR/BRC workflows

### DIFF
--- a/pkg/backupdriver/backup_driver_controller_base.go
+++ b/pkg/backupdriver/backup_driver_controller_base.go
@@ -610,7 +610,7 @@ func (ctrl *backupDriverController) syncBackupRepositoryClaimByKey(key string) e
 
 // enqueueBackupRepositoryClaimWork adds BackupRepositoryClaim to given work queue.
 func (ctrl *backupDriverController) enqueueBackupRepositoryClaim(obj interface{}) {
-	ctrl.logger.Debugf("enqueueBackupRepositoryClaim: %+v", obj)
+	ctrl.logger.Debugf("Entering enqueueBackupRepositoryClaim")
 
 	// Beware of "xxx deleted" events
 	if unknown, ok := obj.(cache.DeletedFinalStateUnknown); ok && unknown.Obj != nil {
@@ -628,7 +628,7 @@ func (ctrl *backupDriverController) enqueueBackupRepositoryClaim(obj interface{}
 }
 
 func (ctrl *backupDriverController) dequeBackupRepositoryClaim(obj interface{}) {
-	ctrl.logger.Debugf("dequeBackupRepositoryClaim: Remove BackupRepositoryClaim %v from queue", obj)
+	ctrl.logger.Debugf("Entering dequeBackupRepositoryClaim: Remove BackupRepositoryClaim from queue")
 
 	var key string
 	var err error

--- a/pkg/backuprepository/backup_repository.go
+++ b/pkg/backuprepository/backup_repository.go
@@ -210,8 +210,8 @@ func checkIfBackupRepositoryClaimIsReferenced(
 			}
 		}
 	} else {
-		logger.Infof("Received BackupRepositoryClaim with no BackupRepository reference, ignoring it now, as it"+
-			"is expected to be patched later, BackupRepositoryClaim: %v", backupRepositoryClaim)
+		logger.Infof("Received BackupRepositoryClaim: %s/%s with no BackupRepository reference, ignoring it now, as it"+
+			"is expected to be patched later", backupRepositoryClaim.Namespace, backupRepositoryClaim.Name)
 	}
 }
 
@@ -267,7 +267,7 @@ func compareBackupRepositoryClaim(repositoryDriver string,
 	backupRepositoryClaim *backupdriverv1.BackupRepositoryClaim,
 	logger logrus.FieldLogger) bool {
 	// Compare the params. RepositoryDriver is always same.
-	logger.Infof("Comparing BRC: %v", backupRepositoryClaim)
+	logger.Infof("Comparing BRC: %s/%s", backupRepositoryClaim.Namespace, backupRepositoryClaim.Name)
 	equal := reflect.DeepEqual(repositoryParameters, backupRepositoryClaim.RepositoryParameters)
 	if !equal {
 		logger.Infof("repositoryParameters not matched")


### PR DESCRIPTION
1. Remove log statements.

Signed-off-by: Deepak Kinni <dkinni@vmware.com>