### PR TITLE
Fixed the issue with generating backup-driver image from hierarchical pluing image

### DIFF
--- a/pkg/cmd/backupdriver/cli/install/install.go
+++ b/pkg/cmd/backupdriver/cli/install/install.go
@@ -222,12 +222,14 @@ func (o *InstallOptions) CheckPluginImageRepo(f client.Factory) error {
 		return errors.New(errMsg)
 	}
 
-	repo := ""
-	tag := ""
+	var repo string
+	var tag string
+	var image string
 	for _, container := range deployment.Spec.Template.Spec.InitContainers {
 		if strings.Contains(container.Image, constants.VeleroPluginForVsphere) {
-			repo = strings.Split(container.Image, "/")[0]
-			tag = strings.Split(container.Image, ":")[1]
+			image = container.Image
+			repo = utils.GetRepo(image)
+			tag = strings.Split(image, ":")[1]
 			break
 		}
 	}
@@ -236,7 +238,7 @@ func (o *InstallOptions) CheckPluginImageRepo(f client.Factory) error {
 		o.Image = repo + "/" + constants.BackupDriverForPlugin + ":" + tag
 		return nil
 	} else {
-		errMsg := fmt.Sprint("Failed to get repo and tag from velero plugin image.")
+		errMsg := fmt.Sprintf("Failed to get repo and tag from velero plugin image %s.", image)
 		return errors.New(errMsg)
 	}
 }


### PR DESCRIPTION
The simillar issue in data manager was fixed the PR https://github.com/vmware-tanzu/velero-plugin-for-vsphere/pull/157. 

In this PR, the issue in backup driver will be fixed.

Signed-off-by: Lintong Jiang <lintongj@vmware.com>