### PR TITLE
Delete existing old data manager daemonset when updating plugin image

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -100,6 +100,7 @@ const (
 	DataManagerForPlugin  string = "data-manager-for-plugin"
 	BackupDriverForPlugin string = "backup-driver"
 	BackupDriverNamespace string = "velero-vsphere-plugin-backupdriver"
+	DataManagerDaemonset string = "datamgr-for-vsphere-plugin"
 
 	VeleroPluginForVsphere string = "velero-plugin-for-vsphere"
 


### PR DESCRIPTION
Currently to upgrade plugin, i.e., use new plugin w/ updated data manager in velero, we need to delete data manager daemonset manually. Otherwise, the running data manager will not be upgraded as well. 
This change improves the installation of velero plugin by checking whether there is existing old data manager daemonset for old image when installing data manager, if so, will delete the old one first.

Manually tests with image and make sure the old data manager is deleted and a new one created.