### PR TITLE
Change deletesvcsnapshot input

### DIFF
--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -454,7 +454,10 @@ func TestDeleteSvcSnapshot(t *testing.T) {
 				return backupdriverClient, nil
 			})
 			defer patches.Reset()
-			result := DeleteSvcSnapshot(test.gcSnapshot, test.config, test.svcSnapshot.Namespace, logger)
+			patches.ApplyFunc(GetSupervisorConfig, func(_ *rest.Config, _ logrus.FieldLogger) (*rest.Config, string, error) {
+				return &rest.Config{}, test.svcSnapshot.Namespace, nil
+			})
+			result := DeleteSvcSnapshot(test.gcSnapshot.Status.SvcSnapshotName, test.gcSnapshot.Namespace, test.gcSnapshot.Name, test.config, logger)
 			if test.expectedErr {
 				require.NotNil(t, result)
 			} else {


### PR DESCRIPTION
Based on discussion with Swati, it is better to take svcSnapshotName and guest config as input here so that it will be easier to use.  So make a simple change here to do some update for DeleteSvcSnapshot which is merged in https://github.com/vmware-tanzu/velero-plugin-for-vsphere/pull/216.
