### PR TITLE
Check for the correct local mode feature flag when starting data mananager pod.

### DIFF
--- a/pkg/cmd/datamgr/cli/install/install.go
+++ b/pkg/cmd/datamgr/cli/install/install.go
@@ -153,8 +153,8 @@ func (o *InstallOptions) Run(c *cobra.Command, f client.Factory) error {
 		fmt.Printf("Failed to decipher velero feature flags: %v, assuming none.\n", err)
 	}
 	features.Enable(featureFlags...)
-	if features.IsEnabled(constants.VSphereLocalModeFlag) {
-		fmt.Printf("Detected %s feature flag, setting local mode \n", constants.VSphereLocalModeFlag)
+	if features.IsEnabled(constants.VSphereLocalModeFeature) {
+		fmt.Printf("Detected %s feature flag, setting local mode \n", constants.VSphereLocalModeFeature)
 		skipDataMgr = true
 	}
 

--- a/pkg/cmd/utils.go
+++ b/pkg/cmd/utils.go
@@ -174,7 +174,7 @@ func CreateFeatureStateConfigMap(features []string, f client.Factory, veleroNs s
 	featureData[constants.VSphereLocalModeFlag] = strconv.FormatBool(false)
 	// Update the falgs based on velero feature flags.
 	featuresString := strings.Join(features[:], ",")
-	if strings.Contains(featuresString, "EnableLocalMode") {
+	if strings.Contains(featuresString, constants.VSphereLocalModeFeature) {
 		featureData[constants.VSphereLocalModeFlag] = strconv.FormatBool(true)
 	}
 	featureConfigMap.Data = featureData

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -136,6 +136,7 @@ const (
 // feature flog constants
 const (
 	VSphereLocalModeFlag        = "local-mode"
+	VSphereLocalModeFeature     = "EnableLocalMode"
 )
 
 const (


### PR DESCRIPTION
On the vanilla cluster, the data manager install code checks for the feature
flag to determine if data manager pods need to be initialized. We were checking
for the wrong flag (local-mode) instead of the new EnableLocalMode flag. This
change fixes this issue.

Testing: Manual test with local mode on vanilla setup.

Signed-off-by: Swati Gupta <swgupta@vmware.com>