### PR TITLE
Enhance RestoreItemAction to accept user-specified StorageClass mapping (#221)

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -284,3 +284,15 @@ const (
 	SnapshotParamSvcSnapshotName  = "SvcSnapshotName"
 	SnapshotParamBackupRepository = "BackupRepository"
 )
+
+// These label keys are used to identify configMap used for storage class mapping, format:
+// velero.io/plugin-config: ""
+// velero.io/change-storage-class: RestoreItemAction
+const (
+	// Plugin kind name
+	PluginKindRestoreItemAction = "RestoreItemAction"
+	// This label key is used to identify the name and kind of plugin that configMap is for
+	ChangeStorageClassLabelKey = "velero.io/change-storage-class"
+	// This label key is used to identify the ConfigMap as config for a plugin.
+	PluginConfigLabelKey = "velero.io/plugin-config"
+)


### PR DESCRIPTION
Velero can change the storage class of persistent volumes and persistent volume claims during restores by configuring a storage class mapping. This PR updates plugin to enhance RestoreItemAction to accept user-specified StorageClass mapping.

This change introduces two functions: RetrieveStorageClassMapping and UpdateSnapshotWithNewStorageClass, to update old storage class name with new storage class name during restore.

Manually tested cases:
No configMap:
```
time="2020-11-05T02:27:43Z" level=info msg="Retrieving storage class mapping information from configMap" cmd=/plugins/velero-plugin-for-vsphere logSource="/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/plugin/restore_pvc_action_plugin.go:143" pluginName=velero-plugin-for-vsphere restore=velero/zqzztoj
time="2020-11-05T02:27:43Z" level=info msg="No config map for storage class mapping exists." cmd=/plugins/velero-plugin-for-vsphere logSource="/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/plugin/util/util.go:154" pluginName=velero-plugin-for-vsphere restore=velero/zqzztoj
time="2020-11-05T02:27:43Z" level=info msg="Found Backup Storage Location default for the Backup vihmxxt" cmd=/plugins/velero-plugin-for-vsphere logSource="/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/utils/utils.go:239" pluginName=velero-plugin-for-vsphere restore=velero/zqzztoj
```
No new storage mapping:
```
time="2020-11-05T03:49:29Z" level=info msg="Retrieving storage class mapping information from configMap" cmd=/plugins/velero-plugin-for-vsphere logSource="/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/plugin/restore_pvc_action_plugin.go:143" pluginName=velero-plugin-for-vsphere restore=velero/qe-backup-multi-namespace-vyxnbcg-20201104194928
time="2020-11-05T03:49:29Z" level=info msg="Updating target PVC storage class based on the storage class mapping" cmd=/plugins/velero-plugin-for-vsphere logSource="/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/plugin/restore_pvc_action_plugin.go:151" pluginName=velero-plugin-for-vsphere restore=velero/qe-backup-multi-namespace-vyxnbcg-20201104194928
time="2020-11-05T03:49:29Z" level=info msg="Updating storage class name for old storage class: test-gc-storage-profile-eqgqzej" cmd=/plugins/velero-plugin-for-vsphere logSource="/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/plugin/util/util.go:180" pluginName=velero-plugin-for-vsphere restore=velero/qe-backup-multi-namespace-vyxnbcg-20201104194928
time="2020-11-05T03:49:29Z" level=info msg="No mapping found for storage class test-gc-storage-profile-eqgqzej" cmd=/plugins/velero-plugin-for-vsphere logSource="/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/plugin/util/util.go:183" pluginName=velero-plugin-for-vsphere restore=velero/qe-backup-multi-namespace-vyxnbcg-20201104194928
time="2020-11-05T03:49:29Z" level=info msg="Found Backup Storage Location default for the Backup qe-backup-multi-namespace-vyxnbcg" cmd=/plugins/velero-plugin-for-vsphere logSource="/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/utils/utils.go:239" pluginName=velero-plugin-for-vsphere restore=velero/qe-backup-multi-namespace-vyxnbcg-20201104194928
```