### PR TITLE
Cherry-pick: Mapping from non storage class to a new storage class (#231)

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -296,6 +296,11 @@ const (
 	ChangeStorageClassLabelKey = "velero.io/change-storage-class"
 	// This label key is used to identify the ConfigMap as config for a plugin.
 	PluginConfigLabelKey = "velero.io/plugin-config"
+	// This is the reserved name used to map from a non storage class to a new storage class
+	// at restore time. Storage class is required for restore. If no storage class is specified
+	// in the PVC during backup, user can specify "com.vmware.cnsdp.emptystorageclass" as the
+	// old storage class name to map to a new existing storage class name at restore time.
+	EmptyStorageClass = "com.vmware.cnsdp.emptystorageclass"
 )
 
 const (


### PR DESCRIPTION
This is cherry pick from https://github.com/vmware-tanzu/velero-plugin-for-vsphere/pull/231.

Currently user needs to make sure that Storage Class exists before they do restore. This change updates restore_pvc_action_plugin to handle the case that when using storage class mapping config map to update storage class, user can map from non storage class to a new storage class.

Manually tested on vanilla/supervisor/guest cluster.
Precheck: https://container-dp.svc.eng.vmware.com/job/Container_Precheck_Velero/704/
https://container-dp.svc.eng.vmware.com/view/CNS-DP/job/Velero-Pipeline-WCP/208/
https://container-dp.svc.eng.vmware.com/view/CNS-DP/job/Velero-Pipeline-WCP/212/

Signed-off-by: wxinyan <wxinyan@wxinyan-a01.vmware.com>

Co-authored-by: wxinyan <wxinyan@wxinyan-a01.vmware.com>