### PR TITLE
[Backport to release 1.1] Fixed bugs in image parsing util function and added unit test cases

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/evanphx/json-patch v4.5.0+incompatible
 	github.com/google/uuid v1.1.1
 	github.com/hashicorp/go-hclog v0.8.0 // indirect
+	github.com/hashicorp/go-version v1.2.1
 	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect
 	github.com/mitchellh/go-testing-interface v1.0.0 // indirect
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -460,6 +460,8 @@ github.com/hashicorp/go-hclog v0.8.0/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrj
 github.com/hashicorp/go-plugin v0.0.0-20190610192547-a1bc61569a26 h1:sADP8l/FAtMyWJ9GIcQT/04Ae80ZZ75ogOrtW0DIZhc=
 github.com/hashicorp/go-plugin v0.0.0-20190610192547-a1bc61569a26/go.mod h1:++UyYGoz3o5w9ZzAdZxtQKrWWP+iqPBn3cQptSMzBuY=
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
+github.com/hashicorp/go-version v1.2.1 h1:zEfKbn2+PDgroKdiOzqiE8rsmLqU2uwi5PB5pBJ3TkI=
+github.com/hashicorp/go-version v1.2.1/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru v0.0.0-20180201235237-0fb14efe8c47/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=

--- a/pkg/cmd/utils_test.go
+++ b/pkg/cmd/utils_test.go
@@ -17,64 +17,72 @@ limitations under the License.
 package cmd
 
 import (
+	"context"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/constants"
+	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/install"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubeclientfake "k8s.io/client-go/kubernetes/fake"
+	"strconv"
 	"testing"
-	v1 "k8s.io/api/core/v1"
 )
 
 func TestGetVersionFromImage(t *testing.T) {
 	tests := []struct {
 		name       string
 		key        string
-		containers []v1.Container
+		containers []corev1.Container
 		expected   string
-	} {
+	}{
 		{
-			name:       "Valid image string should return non-empty version",
-			key:        "cloud-provider-vsphere/csi/release/driver",
-			containers: []v1.Container{
+			name: "Valid image string should return non-empty version",
+			key:  "cloud-provider-vsphere/csi/release/driver",
+			containers: []corev1.Container{
 				{
-					Image: "gcr.io/cloud-provider-vsphere/csi/release/driver:v1.0.1",
+					Image: "gcr.io/cloud-provider-vsphere/csi/release/driver:corev1.0.1",
 				},
 			},
-			expected:   "v1.0.1",
+			expected: "corev1.0.1",
 		},
 		{
-			name:       "Valid image string should return non-empty version",
-			key:        "cloud-provider-vsphere/csi/release/driver",
-			containers: []v1.Container{
+			name: "Valid image string should return non-empty version",
+			key:  "cloud-provider-vsphere/csi/release/driver",
+			containers: []corev1.Container{
 				{
 					Image: "cloud-provider-vsphere/csi/release/driver:v2.0.0",
 				},
 			},
-			expected:   "v2.0.0",
+			expected: "v2.0.0",
 		},
 		{
-			name:       "Valid image string should return non-empty version",
-			key:        "cloud-provider-vsphere/csi/release/driver",
-			containers: []v1.Container{
+			name: "Valid image string should return non-empty version",
+			key:  "cloud-provider-vsphere/csi/release/driver",
+			containers: []corev1.Container{
 				{
 					Image: "myregistry/cloud-provider-vsphere/csi/release/driver:v2.0.0",
 				},
 			},
-			expected:   "v2.0.0",
+			expected: "v2.0.0",
 		},
 		{
-			name:       "Valid image string should return non-empty version",
-			key:        "cloud-provider-vsphere/csi/release/driver",
-			containers: []v1.Container{
+			name: "Valid image string should return non-empty version",
+			key:  "cloud-provider-vsphere/csi/release/driver",
+			containers: []corev1.Container{
 				{
 					Image: "myregistry/level1/level2/cloud-provider-vsphere/csi/release/driver:v2.0.0",
 				},
 			},
-			expected:   "v2.0.0",
+			expected: "v2.0.0",
 		},
 		{
-			name:     "Invalid image name should return empty string",
-			key:      "cloud-provider-vsphere/csi/release/driver",
-			containers: []v1.Container{
+			name: "Invalid image name should return empty string",
+			key:  "cloud-provider-vsphere/csi/release/driver",
+			containers: []corev1.Container{
 				{
-					Image: "gcr.io/csi/release/driver:v1.0.1",
+					Image: "gcr.io/csi/release/driver:corev1.0.1",
 				},
 			},
 			expected: "",
@@ -84,6 +92,493 @@ func TestGetVersionFromImage(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			version := GetVersionFromImage(test.containers, test.key)
 			assert.Equal(t, test.expected, version)
+		})
+	}
+}
+
+func TestGetCompatibleRepoAndTagFromPluginImage(t *testing.T) {
+	tests := []struct {
+		name             string
+		veleroDeployment *appsv1.Deployment
+		targetContainer  string
+		expectedImage    string
+		expectedError    error
+	}{
+		{
+			name: "ExpectedPluginImageFromDockerhub",
+			veleroDeployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "velero",
+					Name:      constants.VeleroDeployment,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							InitContainers: []corev1.Container{
+								{
+									Name:  "velero-plugin-for-vsphere",
+									Image: "vsphereveleroplugin/velero-plugin-for-vsphere:1.1.0-rc2",
+								},
+							},
+						},
+					},
+				},
+			},
+			targetContainer: constants.BackupDriverForPlugin,
+			expectedImage:   "vsphereveleroplugin/" + constants.BackupDriverForPlugin + ":1.1.0-rc2",
+			expectedError:   nil,
+		},
+		{
+			name: "UnexpectedDeployment",
+			veleroDeployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "xyz",
+					Name:      "not-velero",
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							InitContainers: []corev1.Container{
+								{
+									Name:  "velero-plugin-for-vsphere",
+									Image: "vsphereveleroplugin/velero-plugin-for-vsphere:1.1.0-rc2",
+								},
+							},
+						},
+					},
+				},
+			},
+			targetContainer: constants.BackupDriverForPlugin,
+			expectedImage:   "",
+			expectedError:   errors.Errorf("Failed to get velero deployment in namespace %s", "xyz"),
+		},
+		{
+			name: "NoExpectedPluginImageAvailable",
+			veleroDeployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "velero",
+					Name:      constants.VeleroDeployment,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							InitContainers: []corev1.Container{
+								{
+									Name:  "velero-plugin-for-aws",
+									Image: "velero/velero-plugin-for-aws:1.1.0",
+								},
+							},
+						},
+					},
+				},
+			},
+			targetContainer: constants.BackupDriverForPlugin,
+			expectedImage:   "",
+			expectedError:   errors.New("The plugin, velero-plugin-for-vsphere, was not added as an init container of Velero deployment"),
+		},
+		{
+			name: "ExpectedPluginImageFromOnPremRegistry",
+			veleroDeployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "velero",
+					Name:      constants.VeleroDeployment,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							InitContainers: []corev1.Container{
+								{
+									Name:  "velero-plugin-for-vsphere",
+									Image: "xyz-repo.opq.abc:8888/one/two/velero-plugin-for-vsphere:1.1.0-rc2",
+								},
+							},
+						},
+					},
+				},
+			},
+			targetContainer: constants.BackupDriverForPlugin,
+			expectedImage:   "xyz-repo.opq.abc:8888/one/two/" + constants.BackupDriverForPlugin + ":1.1.0-rc2",
+			expectedError:   nil,
+		},
+		{
+			name: "ExpectedPluginImageWithoutTag",
+			veleroDeployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "velero",
+					Name:      constants.VeleroDeployment,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							InitContainers: []corev1.Container{
+								{
+									Name:  "velero-plugin-for-vsphere",
+									Image: "xyz-repo.opq.abc:8888/one/two/velero-plugin-for-vsphere",
+								},
+							},
+						},
+					},
+				},
+			},
+			targetContainer: constants.DataManagerForPlugin,
+			expectedImage:   "xyz-repo.opq.abc:8888/one/two/" + constants.DataManagerForPlugin,
+			expectedError:   nil,
+		},
+		{
+			name: "ExpectedPluginImageWithoutRepo",
+			veleroDeployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "velero",
+					Name:      constants.VeleroDeployment,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							InitContainers: []corev1.Container{
+								{
+									Name:  "velero-plugin-for-vsphere",
+									Image: "velero-plugin-for-vsphere:1.1.0-rc2",
+								},
+							},
+						},
+					},
+				},
+			},
+			targetContainer: constants.DataManagerForPlugin,
+			expectedImage:   constants.DataManagerForPlugin + ":1.1.0-rc2",
+			expectedError:   nil,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			kubeClient := kubeclientfake.NewSimpleClientset(test.veleroDeployment)
+			actualImage, actualError := GetCompatibleRepoAndTagFromPluginImage(kubeClient, test.veleroDeployment.Namespace, test.targetContainer)
+			assert.Equal(t, test.expectedImage, actualImage)
+			assert.Equal(t, test.expectedError == nil, actualError == nil)
+			if actualError != nil {
+				assert.Equal(t, test.expectedError.Error(), actualError.Error())
+			}
+		})
+	}
+}
+
+func TestGetVeleroFeatureFlags(t *testing.T) {
+	tests := []struct {
+		name                 string
+		veleroDeployment     *appsv1.Deployment
+		expectedFeatureFlags []string
+		expectedError        error
+	}{
+		{
+			name: "ExpectedSingleFeatureFlag",
+			veleroDeployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "velero",
+					Name:      constants.VeleroDeployment,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "velero",
+									Image: "velero/velero:v1.5.1",
+									Args: []string{
+										"server",
+										"--features=EnableVSphereItemActionPlugin",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedFeatureFlags: []string{"EnableVSphereItemActionPlugin"},
+			expectedError:        nil,
+		},
+		{
+			name: "ExpectedMultipleFeatureFlags",
+			veleroDeployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "velero",
+					Name:      constants.VeleroDeployment,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "velero",
+									Image: "velero/velero:v1.5.1",
+									Args: []string{
+										"server",
+										"--features=EnableVSphereItemActionPlugin,EnableLocalMode",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedFeatureFlags: []string{"EnableVSphereItemActionPlugin", "EnableLocalMode"},
+			expectedError:        nil,
+		},
+		{
+			name: "ExpectedMultipleFeatureFlagsWithOtherArgs",
+			veleroDeployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "velero",
+					Name:      constants.VeleroDeployment,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "velero",
+									Image: "velero/velero:v1.5.1",
+									Args: []string{
+										"server",
+										"--features=EnableVSphereItemActionPlugin,EnableLocalMode",
+										"--metrics-address=:0",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedFeatureFlags: []string{"EnableVSphereItemActionPlugin", "EnableLocalMode"},
+			expectedError:        nil,
+		},
+		{
+			name: "ExpectedMultipleFeatureFlagsFromUnexpectedContainer",
+			veleroDeployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "velero",
+					Name:      constants.VeleroDeployment,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "non-velero",
+									Image: "velero/velero:v1.5.1",
+									Args: []string{
+										"server",
+										"--features=EnableVSphereItemActionPlugin,EnableLocalMode",
+										"--metrics-address=:0",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedFeatureFlags: []string{},
+			expectedError:        nil,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			kubeClient := kubeclientfake.NewSimpleClientset(test.veleroDeployment)
+			actualFeatureFlags, actualError := GetVeleroFeatureFlags(kubeClient, test.veleroDeployment.Namespace)
+			assert.Equal(t, test.expectedError == nil, actualError == nil)
+			assert.Equal(t, test.expectedFeatureFlags, actualFeatureFlags)
+		})
+	}
+}
+
+func TestCreateFeatureStateConfigMap(t *testing.T) {
+	tests := []struct {
+		name                    string
+		featureConfigMap        *corev1.ConfigMap
+		features                []string
+		namespace               string
+		expectedLocalModeStatus bool
+		expectedError           error
+	}{
+		{
+			name:                    "ExpectedCreateConfigMapCase",
+			featureConfigMap:        &corev1.ConfigMap{},
+			features:                []string{"EnableVSphereItemActionPlugin", constants.VSphereLocalModeFeature},
+			namespace:               "velero",
+			expectedLocalModeStatus: true,
+			expectedError:           nil,
+		},
+		{
+			name:                    "ExpectedCreateConfigMapCaseTurnOff",
+			featureConfigMap:        &corev1.ConfigMap{},
+			features:                []string{"EnableVSphereItemActionPlugin"},
+			namespace:               "velero",
+			expectedLocalModeStatus: false,
+			expectedError:           nil,
+		},
+		{
+			name: "ExpectedUpdateConfigMapCase",
+			featureConfigMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      constants.VSpherePluginFeatureStates,
+					Namespace: "velero",
+				},
+				Data: map[string]string{
+					constants.VSphereLocalModeFlag: "false",
+				},
+			},
+			features:                []string{"EnableVSphereItemActionPlugin", constants.VSphereLocalModeFeature},
+			namespace:               "velero",
+			expectedLocalModeStatus: true,
+			expectedError:           nil,
+		},
+		{
+			name: "ExpectedUpdateConfigMapCaseTurnOff",
+			featureConfigMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      constants.VSpherePluginFeatureStates,
+					Namespace: "velero",
+				},
+				Data: map[string]string{
+					constants.VSphereLocalModeFlag: "true",
+				},
+			},
+			features:                []string{"EnableVSphereItemActionPlugin"},
+			namespace:               "velero",
+			expectedLocalModeStatus: false,
+			expectedError:           nil,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			kubeClient := kubeclientfake.NewSimpleClientset(test.featureConfigMap)
+			actualError := CreateFeatureStateConfigMap(kubeClient, test.features, test.namespace)
+			assert.Equal(t, test.expectedError == nil, actualError == nil)
+			featureConfigMap, _ := kubeClient.CoreV1().ConfigMaps(test.namespace).Get(context.Background(), constants.VSpherePluginFeatureStates, metav1.GetOptions{})
+			assert.NotNil(t, featureConfigMap)
+			assert.Equal(t, strconv.FormatBool(test.expectedLocalModeStatus), featureConfigMap.Data[constants.VSphereLocalModeFlag])
+		})
+	}
+}
+
+func TestCheckPluginImageRepo(t *testing.T) {
+	tests := []struct {
+		name             string
+		veleroDeployment *appsv1.Deployment
+		defaultImage     string
+		serverType       string
+		expectedImage    string
+		expectedError    error
+	}{
+		{
+			name: "ExpectedOfficialPluginImage",
+			veleroDeployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "velero",
+					Name:      constants.VeleroDeployment,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							InitContainers: []corev1.Container{
+								{
+									Name:  "velero-plugin-for-vsphere",
+									Image: "vsphereveleroplugin/velero-plugin-for-vsphere:1.1.0-rc2",
+								},
+							},
+						},
+					},
+				},
+			},
+			defaultImage:  install.DefaultBackupDriverImage,
+			serverType:    constants.BackupDriverForPlugin,
+			expectedImage: "vsphereveleroplugin/" + constants.BackupDriverForPlugin + ":1.1.0-rc2",
+			expectedError: nil,
+		},
+		{
+			name: "ExpectedCustomizedPluginImage",
+			veleroDeployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "velero",
+					Name:      constants.VeleroDeployment,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							InitContainers: []corev1.Container{
+								{
+									Name:  "velero-plugin-for-vsphere",
+									Image: "xyz.io:9999/one/two/velero-plugin-for-vsphere:1.1.0-rc2",
+								},
+							},
+						},
+					},
+				},
+			},
+			defaultImage:  install.DefaultBackupDriverImage,
+			serverType:    constants.BackupDriverForPlugin,
+			expectedImage: "xyz.io:9999/one/two/" + constants.BackupDriverForPlugin + ":1.1.0-rc2",
+			expectedError: nil,
+		},
+		{
+			name: "NoExpectedPluginImageAvailable",
+			veleroDeployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "velero",
+					Name:      constants.VeleroDeployment,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							InitContainers: []corev1.Container{
+								{
+									Name:  "velero-plugin-for-aws",
+									Image: "velero/velero-plugin-for-aws:1.1.0",
+								},
+							},
+						},
+					},
+				},
+			},
+			defaultImage:  install.DefaultBackupDriverImage,
+			serverType:    constants.BackupDriverForPlugin,
+			expectedImage: install.DefaultBackupDriverImage,
+			expectedError: errors.New("The plugin, velero-plugin-for-vsphere, was not added as an init container of Velero deployment"),
+		},
+		{
+			name: "UnexpectedDeployment",
+			veleroDeployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "xyz",
+					Name:      "not-velero",
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							InitContainers: []corev1.Container{
+								{
+									Name:  "velero-plugin-for-vsphere",
+									Image: "vsphereveleroplugin/velero-plugin-for-vsphere:1.1.0-rc2",
+								},
+							},
+						},
+					},
+				},
+			},
+			defaultImage:  install.DefaultBackupDriverImage,
+			serverType:    constants.BackupDriverForPlugin,
+			expectedImage: install.DefaultBackupDriverImage,
+			expectedError: errors.Errorf("Failed to get velero deployment in namespace %s", "xyz"),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			kubeClient := kubeclientfake.NewSimpleClientset(test.veleroDeployment)
+			actualImage, actualError := CheckPluginImageRepo(kubeClient, test.veleroDeployment.Namespace, test.defaultImage, test.serverType)
+			assert.Equal(t, test.expectedImage, actualImage)
+			assert.Equal(t, test.expectedError == nil, actualError == nil)
+			if actualError != nil {
+				assert.Equal(t, test.expectedError.Error(), actualError.Error())
+			}
 		})
 	}
 }

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -297,3 +297,9 @@ const (
 	// This label key is used to identify the ConfigMap as config for a plugin.
 	PluginConfigLabelKey = "velero.io/plugin-config"
 )
+
+const (
+	ImageRepositoryComponent = "Repository"
+	ImageContainerComponent = "Container"
+	ImageVersionComponent = "Version"
+)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -750,18 +750,34 @@ func GetSupervisorParameters(config *rest.Config, ns string, logger logrus.Field
 	return params, nil
 }
 
-// Retrieve image repository from image name here. We expect the following format
-// for image name: <repo-level1>/<repo-level2>/.../<plugin-bin-name>:<tag>. plugin-bin-name
-// and tag should not include '/'.
-func GetRepo(image string) string {
+func GetComponentFromImage(image string, component string) string {
+	components := GetComponentsFromImage(image)
+	return components[component]
+}
+
+func GetComponentsFromImage(image string) map[string]string {
+	components := make(map[string]string)
+
 	if image == "" {
-		return ""
+		return components
 	}
+
+	var taggedContainer string
 	lastIndex := strings.LastIndex(image, "/")
 	if lastIndex < 0 {
-		return ""
+		taggedContainer = image
+	} else {
+		components[constants.ImageRepositoryComponent] = image[:lastIndex]
+		taggedContainer = image[lastIndex+1:]
 	}
-	return image[:lastIndex]
+
+	parts := strings.SplitN(taggedContainer, ":", 2)
+	if len(parts) == 2 {
+		components[constants.ImageVersionComponent] = parts[1]
+	}
+	components[constants.ImageContainerComponent] = parts[0]
+
+	return components
 }
 
 /*

--- a/pkg/utils/utils_e2e_test.go
+++ b/pkg/utils/utils_e2e_test.go
@@ -1,0 +1,172 @@
+/*
+Copyright 2020 the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"context"
+	"fmt"
+	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/constants"
+	"os"
+	"testing"
+	"time"
+
+	k8sv1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	backupdriverTypedV1 "github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/typed/backupdriver/v1alpha1"
+	"github.com/vmware-tanzu/velero/pkg/generated/clientset/versioned"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+func TestRetrieveParamsFromBSL(t *testing.T) {
+	path := os.Getenv("KUBECONFIG")
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		t.Skipf("The KubeConfig file, %v, is not exist", path)
+	}
+
+	config, err := clientcmd.BuildConfigFromFlags("", path)
+	if err != nil {
+		t.Fatalf("Failed to build k8s config from kubeconfig file: %+v ", err)
+	}
+
+	// Setup Logger
+	logger := logrus.New()
+	formatter := new(logrus.TextFormatter)
+	formatter.TimestampFormat = time.RFC3339Nano
+	formatter.FullTimestamp = true
+	logger.SetFormatter(formatter)
+	logger.SetLevel(logrus.DebugLevel)
+
+	// using velero ns for testing.
+	veleroNs := "velero"
+
+	veleroClient, err := versioned.NewForConfig(config)
+	if err != nil {
+		t.Fatalf("Failed to retrieve veleroClient")
+	}
+
+	_, err = backupdriverTypedV1.NewForConfig(config)
+	if err != nil {
+		t.Fatalf("Failed to retrieve backupdriverClient from config: %v", config)
+	}
+
+	backupStorageLocationList, err := veleroClient.VeleroV1().BackupStorageLocations(veleroNs).List(context.TODO(), metav1.ListOptions{})
+	if err != nil || len(backupStorageLocationList.Items) <= 0 {
+		t.Fatalf("RetrieveVSLFromVeleroBSLs: Failed to list Velero default backup storage location")
+	}
+	for _, item := range backupStorageLocationList.Items {
+		repositoryParameters := make(map[string]string)
+		bslName := item.Name
+		err := RetrieveParamsFromBSL(repositoryParameters, bslName, config, logger)
+		if err != nil {
+			logger.Errorf("Retrieve Failed %v", err)
+			t.Fatalf("RetrieveParamsFromBSL failed!")
+		}
+		logger.Infof("Repository Parameters: %v", repositoryParameters)
+	}
+}
+
+
+
+
+func createClientSet() (*kubernetes.Clientset, error) {
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	// if you want to change the loading rules (which files in which order), you can do so here
+
+	configOverrides := &clientcmd.ConfigOverrides{}
+	// if you want to change override values or bind them to flags, there are methods to help you
+
+	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
+	config, err := kubeConfig.ClientConfig()
+	if err != nil {
+		return nil, NewClientConfigNotFoundError("Could not create client config")
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+
+	if err != nil {
+		return nil, errors.Wrap(err, "Could not create clientset")
+	}
+	return clientset, err
+}
+
+type ClientConfigNotFoundError struct {
+	errMsg string
+}
+
+func (this ClientConfigNotFoundError) Error() string {
+	return this.errMsg
+}
+
+func NewClientConfigNotFoundError(errMsg string) ClientConfigNotFoundError {
+	err := ClientConfigNotFoundError{
+		errMsg: errMsg,
+	}
+	return err
+}
+
+/*
+ * For this test, set KUBECONFIG to point to a valid setup, with a BackupDriverNamespace created.
+ */
+func Test_waitForPvSecret(t *testing.T) {
+	clientSet, err := createClientSet()
+
+	if err != nil {
+		_, ok := err.(ClientConfigNotFoundError)
+		if ok {
+			t.Skip(err)
+		}
+		t.Fatal(err)
+	}
+	testSecret := k8sv1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: constants.PvSecretName,
+		},
+	}
+
+	// set up logger
+	logger := logrus.New()
+	formatter := new(logrus.TextFormatter)
+	formatter.TimestampFormat = time.RFC3339
+	formatter.FullTimestamp = true
+	logger.SetFormatter(formatter)
+
+	err = clientSet.CoreV1().Secrets(constants.BackupDriverNamespace).Delete(context.TODO(), testSecret.Name, metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Delete error = %v\n", err)
+	}
+	writtenSnapshot, err := clientSet.CoreV1().Secrets(constants.BackupDriverNamespace).Create(context.TODO(), &testSecret, metav1.CreateOptions{})
+
+	testSecret.ObjectMeta = writtenSnapshot.ObjectMeta
+
+	timeoutContext, cancelFunc := context.WithDeadline(context.Background(), time.Now().Add(time.Second*10))
+	defer cancelFunc()
+	createdSecret, err := waitForPvSecret(timeoutContext, clientSet, constants.BackupDriverNamespace, logger)
+	if err != nil {
+		t.Fatalf("waitForPvSecret returned err = %v\n", err)
+	} else {
+		fmt.Printf("waitForPvSecret secret created %s in namespace %s\n", createdSecret.Name, createdSecret.Namespace)
+	}
+
+}


### PR DESCRIPTION
[Backport to release 1.1] Fixed bugs in image parsing util function and added unit test cases

Signed-off-by: Lintong Jiang <lintongj@vmware.com>

Testing:

1. Unit Test: Passed (i.e., run make test or make ci)
2. Precheckin:
   - Guest Cluster: Passed (Job: Velero-Pipeline-WCP 232)
   - Supervisor Cluster: Passed (Job: Velero-Pipeline-WCP 231)
   - Vanilla: Passed (Job: Container_Precheck_Velero 697).

Note: the CI/CD Jenkins pipeline failed due to the ImagePullBackOff/ErrImagePull error due to the recent dockerhub rate limiting mechanism.

