### PR TITLE
[Cherry-Pick] Fail restore early if StorageClassName is not set (#224)

### DIFF
--- a/pkg/backupdriver/backup_driver_controller.go
+++ b/pkg/backupdriver/backup_driver_controller.go
@@ -215,6 +215,13 @@ func (ctrl *backupDriverController) cloneFromSnapshot(cloneFromSnapshot *backupd
 		ctrl.logger.Errorf("Error extracting metadata into PVC: %v", err)
 		return err
 	}
+	if pvc.Spec.StorageClassName != nil {
+		ctrl.logger.Infof("StorageClassName is %s for PVC %s/%s", *pvc.Spec.StorageClassName, pvc.Namespace, pvc.Name)
+	} else {
+		errMsg := fmt.Sprintf("cloneFromSnapshot failed for PVC %s/%s because StorageClassName is not set", pvc.Namespace, pvc.Name)
+		ctrl.logger.Error(errMsg)
+		return errors.New(errMsg)
+	}
 	ctrl.logger.Infof("cloneFromSnapshot: retrieved PVC %s/%s from metadata. %+v", pvc.Namespace, pvc.Name, pvc)
 
 	// cloneFromSnapshot.Spec.Kind should be "PersistentVolumeClaim" for now

--- a/pkg/paravirt/paravirt_protected_entity_type_manager.go
+++ b/pkg/paravirt/paravirt_protected_entity_type_manager.go
@@ -343,8 +343,13 @@ func (this *ParaVirtProtectedEntityTypeManager) getSuperPVCandGuestPVCName(metad
 	svcStorageClassName := ""
 	if svcPVC.Spec.StorageClassName != nil {
 		svcStorageClassName = *svcPVC.Spec.StorageClassName
+	} else {
+		this.logger.Errorf("Failed to restore PVC %s/%s in Supervisor Cluster because StorageClassName is not set", svcPVC.Namespace, svcPVC.Name)
+		return nil, "", "", errors.Wrapf(err, "failed to restore PVC %s/%s in Supervisor Cluster because StorageClassName is not set",
+			svcPVC.Namespace, svcPVC.Name)
 	}
-	this.logger.Infof("StorageClassName is %s in Supervisor PVC: %s/%s", svcStorageClassName, svcPVC.Name, svcPVC.Namespace)
+
+	this.logger.Infof("StorageClassName is %s in Supervisor PVC: %s/%s", svcStorageClassName, svcPVC.Namespace, svcPVC.Name)
 
 	return &svcPVC, gcPVCNamespace, gcPVCName, nil
 }

--- a/pkg/plugin/backup_pvc_action_plugin.go
+++ b/pkg/plugin/backup_pvc_action_plugin.go
@@ -59,7 +59,14 @@ func (p *NewPVCBackupItemAction) Execute(item runtime.Unstructured, backup *vele
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(item.UnstructuredContent(), &pvc); err != nil {
 		return nil, nil, errors.WithStack(err)
 	}
-	p.Log.Infof("VSphere PVCBackupItemAction for PVC %s/%s started", pvc.Namespace, pvc.Name)
+	storageClassName := ""
+	if pvc.Spec.StorageClassName != nil {
+		storageClassName = *pvc.Spec.StorageClassName
+	} else {
+		p.Log.Infof("VSphere PVCBackupItemAction: StorageClass is not set for PVC %s/%s", pvc.Namespace, pvc.Name)
+	}
+	p.Log.Infof("VSphere PVCBackupItemAction for PVC %s/%s started. Storage Class Name: %s", pvc.Namespace, pvc.Name, storageClassName)
+
 	defer func() {
 		p.Log.Infof("VSphere PVCBackupItemAction for PVC %s/%s completed with err: %v", pvc.Namespace, pvc.Name, err)
 	}()


### PR DESCRIPTION
This PR is a cherry-pick from https://github.com/vmware-tanzu/velero-plugin-for-vsphere/pull/224
It fails restore early if StorageClassName is not set and prints out messages.

Signed-off-by: xing-yang <xingyang105@gmail.com>