### PR TITLE
Support restore of 1.0.2 backup on 1.1.0 plugin

### DIFF
--- a/cmd/velero-plugin-for-vsphere/main.go
+++ b/cmd/velero-plugin-for-vsphere/main.go
@@ -33,7 +33,8 @@ func main() {
 	veleroPluginServer = veleroPluginServer.
 		RegisterBackupItemAction("velero.io/vsphere-pvc-backupper", newPVCBackupItemAction).
 		RegisterRestoreItemAction("velero.io/vsphere-pvc-restorer", newPVCRestoreItemAction).
-		RegisterDeleteItemAction("velero.io/vsphere-pvc-deleter", newPVCDeleteItemAction)
+		RegisterDeleteItemAction("velero.io/vsphere-pvc-deleter", newPVCDeleteItemAction).
+		RegisterVolumeSnapshotter("velero.io/vsphere", newVolumeSnapshotterPlugin)
 	veleroPluginServer.Serve()
 }
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -316,3 +316,5 @@ const (
 	ImageContainerComponent  = "Container"
 	ImageVersionComponent    = "Version"
 )
+
+const VsphereVolumeSnapshotLocationProvider = "velero.io/vsphere"

--- a/pkg/plugin/delete_pvc_action_plugin.go
+++ b/pkg/plugin/delete_pvc_action_plugin.go
@@ -54,7 +54,7 @@ func (p *NewPVCDeleteItemAction) Execute(input *velero.DeleteItemActionExecuteIn
 	// get snapshot blob from PVC annotation
 	snapshotAnnotation, ok := pvc.Annotations[constants.ItemSnapshotLabel]
 	if !ok {
-		p.Log.Infof("Skipping PVCRestoreItemAction for PVC %s/%s, PVC does not have a vSphere BackupItemAction snapshot.", pvc.Namespace, pvc.Name)
+		p.Log.Infof("Skipping PVCDeleteItemAction for PVC %s/%s, PVC does not have a vSphere BackupItemAction snapshot.", pvc.Namespace, pvc.Name)
 		return nil
 	}
 
@@ -112,7 +112,7 @@ func (p *NewPVCDeleteItemAction) Execute(input *velero.DeleteItemActionExecuteIn
 		p.Log.Error(errMsg)
 		return errors.New(errMsg)
 	}
-	p.Log.Info("Deleted Snapshot, %v, from PVC %s/%s in the backup", updatedDeleteSnapshot, pvc.Namespace, pvc.Name)
+	p.Log.Infof("Deleted Snapshot, %v, from PVC %s/%s in the backup", updatedDeleteSnapshot, pvc.Namespace, pvc.Name)
 
 	return nil
 }

--- a/pkg/plugin/restore_pvc_action_plugin.go
+++ b/pkg/plugin/restore_pvc_action_plugin.go
@@ -29,7 +29,7 @@ type NewPVCRestoreItemAction struct {
 
 // AppliesTo returns information indicating that the PVCBackupItemAction should be invoked to backup PVCs.
 func (p *NewPVCRestoreItemAction) AppliesTo() (velero.ResourceSelector, error) {
-	p.Log.Info("VSphere PVCBackupItemAction AppliesTo")
+	p.Log.Info("VSphere PVCRestoreItemAction AppliesTo")
 
 	resources := []string{"persistentvolumeclaims"}
 	for resourceToBlock, _ := range constants.ResourcesToBlock {

--- a/pkg/snapshotmgr/snapshot_manager.go
+++ b/pkg/snapshotmgr/snapshot_manager.go
@@ -859,6 +859,7 @@ func decodeSnapshotID(snapshotID astrolabe.ProtectedEntitySnapshotID, logger log
 	logger.Infof("Successfully translated snapshotID %s into pe-id: %s", snapshotID.String(), decodedPEID.String())
 	if decodedPEID.HasSnapshot() && decodedPEID.GetPeType() != astrolabe.IvdPEType {
 		logger.Infof("The translated pe-id is not ivd type, recursing for further decode")
+
 		return decodeSnapshotID(decodedPEID.GetSnapshotID(), logger)
 	}
 	return decodedPEID.GetSnapshotID().String(), nil

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -397,7 +397,7 @@ func GetS3PETMFromParamsMap(params map[string]interface{}, logger logrus.FieldLo
 
 func GetDefaultS3PETM(logger logrus.FieldLogger) (*s3repository.ProtectedEntityTypeManager, error) {
 	var s3PETM *s3repository.ProtectedEntityTypeManager
-	var params map[string]interface{}
+	params := make(map[string]interface{})
 	err := RetrieveVSLFromVeleroBSLs(params, constants.DefaultS3BackupLocation, nil, logger)
 	if err != nil {
 		logger.WithError(err).Errorf("GetDefaultS3PETM: Could not retrieve velero default backup location.")


### PR DESCRIPTION
Changes allow restoring of 1.0.2 backup.

1. CreateSnapshot is blocked in volume snapshotter plugin in 1.1.0
2. Restore in volume snapshotter plugin is supported only on vanilla.

Vanilla:
Plugin 1.1.0 - with vsl-vsphere
	Deleting 1.0.2 Backup - PASS
	Deleting 1.1.0 Backup - PASS
	Restore of 1.0.2 Backup - PASS
	Restore of 1.1.0 Backup - PASS
	Backup - PASS

Plugin 1.1.0 - without vsl-vsphere
	Deleting 1.1.0 Backup - PASS
	Deleting 1.0.2 Backup
	1. DeleteBackupRequests has error "error getting volume snapshot location vsl-vsphere:volumesnapshotlocation.velero.io "vsl-vsphere" not found"
	2. The k8s related backup files are deleted from repo
	3. On 'velero backup get', see the status as "van-bk-1-0-2-v4   Deleting"
	4. Dangling vsphere vol snapshots in repo.
	Restore of 1.1.0 Backup - PASS
	Restore of 1.0.2 Backup
	1. pvc restored but no pv.
	2. k8s resoruces restored
	3. Restore status failed with error "error executing PVAction for persistentvolumes/pvc-35e79dcd-5727-4942-8591-7ee65ff4ff68: volumesnapshotlocation.velero.io "vsl-vsphere" not found"
	Backup - PASS


Guest:

Plugin 1.1.0 - with vsl-vsphere
	Restore of 1.1.0 Backup - PASS
	Restore of 1.0.2 Backup
	1. Restore status PartiallyFailed "NotSupported: Restore of 1.0.2 vsphere volume snapshots are NOT supported in Supervisor and Guest Clusters."
	2. pvc is restored.
	3. k8s resources are restored.
	Deleting 1.1.0 Backup - PASS
	Deleting 1.0.2 Backup
	1. DeleteBackupRequests has error "NotSupported: Delete of 1.0.2 vsphere volume snapshots are NOT supported in Supervisor and Guest Clusters.""
	2. The k8s related backup files are deleted from repo
	Backup - PASS

Plugin 1.1.0 - without vsl-vsphere
	Restore of 1.1.0 Backup - PASS
	Restore of 1.0.2 Backup
	1. Restore status failed with error "error executing PVAction for persistentvolumes/pvc-35e79dcd-5727-4942-8591-7ee65ff4ff68: volumesnapshotlocation.velero.io "vsl-vsphere" not found"
	2. pvc restored but no pv.
	3. k8s resoruces restored.
	Deleting 1.1.0 Backup - PASS
	Deleting 1.0.2 Backup
	1. DeleteBackupRequests has error "error getting volume snapshot location vsl-vsphere:volumesnapshotlocation.velero.io "vsl-vsphere" not found"
	2. The k8s related backup files are deleted from repo
	3. On 'velero backup get', see the status as "van-bk-1-0-2-v4   Deleting"
	Backup - PASS

Signed-off-by: Deepak Kinni <dkinni@vmware.com>