### PR TITLE
Updated the version check of vSphere CSI to adapt both release and dev manifests

### DIFF
--- a/pkg/cmd/datamgr/cli/install/install.go
+++ b/pkg/cmd/datamgr/cli/install/install.go
@@ -148,7 +148,7 @@ func (o *InstallOptions) Run(c *cobra.Command, f client.Factory) error {
 	fmt.Println("The prerequisite checks for data-manager started")
 
 	// Check cluster flavor for data-manager
-	o.CheckClusterFlavorForDataManager()
+	clusterFlavor := o.CheckClusterFlavorForDataManager()
 
 	// Check feature flags for data-manager
 	_ = o.CheckFeatureFlagsForDataManager(kubeClient)
@@ -160,7 +160,7 @@ func (o *InstallOptions) Run(c *cobra.Command, f client.Factory) error {
 	}
 
 	// Check vSphere CSI driver version
-	_ = cmd.CheckVSphereCSIDriverVersion(kubeClient)
+	_ = cmd.CheckVSphereCSIDriverVersion(kubeClient, clusterFlavor)
 
 	// Check velero version
 	_ = cmd.CheckVeleroVersion(kubeClient, o.Namespace)
@@ -271,7 +271,7 @@ func (o *InstallOptions) getNumberOfNodes(kubeClient kubernetes.Interface) (int,
 	return len(nodeList.Items), nil
 }
 
-func (o *InstallOptions) CheckClusterFlavorForDataManager() {
+func (o *InstallOptions) CheckClusterFlavorForDataManager() constants.ClusterFlavor {
 	clusterFlavor, _ := utils.GetClusterFlavor(nil)
 
 	// In case of Guest or Supervisor cluster, skip installing data manager
@@ -279,6 +279,8 @@ func (o *InstallOptions) CheckClusterFlavorForDataManager() {
 		fmt.Printf("The Cluster Flavor: %s. Skipping data manager installation.\n", clusterFlavor)
 		o.SkipInstall = true
 	}
+
+	return clusterFlavor
 }
 
 func (o *InstallOptions) CheckFeatureFlagsForDataManager(kubeClient kubernetes.Interface) error {

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -99,13 +99,13 @@ const (
 )
 
 const (
-	DataManagerForPlugin  string = "data-manager-for-plugin"
-	BackupDriverForPlugin string = "backup-driver"
-	BackupDriverNamespace string = "velero-vsphere-plugin-backupdriver"
-
+	DataManagerForPlugin   string = "data-manager-for-plugin"
+	BackupDriverForPlugin  string = "backup-driver"
+	BackupDriverNamespace  string = "velero-vsphere-plugin-backupdriver"
 	VeleroPluginForVsphere string = "velero-plugin-for-vsphere"
-
-	VeleroDeployment string = "velero"
+	VeleroDeployment       string = "velero"
+	VSphereCSIController          = "vsphere-csi-controller"
+	KubeSystemNamespace           = "kube-system"
 )
 
 const (
@@ -312,6 +312,6 @@ const (
 
 const (
 	ImageRepositoryComponent = "Repository"
-	ImageContainerComponent = "Container"
-	ImageVersionComponent = "Version"
+	ImageContainerComponent  = "Container"
+	ImageVersionComponent    = "Version"
 )


### PR DESCRIPTION
Updated the version check of vSphere CSI to adapt both release and dev manifests. 

The following changes are included.

1. Run vSphere CSI version check on Vanilla cluster only, since both Supervisor and Guest only have pre-packaged CSI version.
2. Return proper log message about the version check that reflect the check result. However, on the failure of CSI version check, only warning log message will be returned while the installation of (backup-driver/data-manager)servers will not break. 
3. Add unit test cases to cover different combinations of CSI driver/sync images. 

Signed-off-by: Lintong Jiang <lintongj@vmware.com>