### PR TITLE
Added plugin version as a backup annotation

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -158,6 +158,7 @@ const (
 
 const (
 	ItemSnapshotLabel   = "velero-plugin-for-vsphere/item-snapshot-blob"
+	PluginVersionLabel  = "velero-plugin-for-vsphere/plugin-version"
 	SnapshotBackupLabel = "velero.io/backup-name"
 )
 

--- a/pkg/plugin/backup_pvc_action_plugin.go
+++ b/pkg/plugin/backup_pvc_action_plugin.go
@@ -7,6 +7,7 @@ import (
 	"github.com/sirupsen/logrus"
 	backupdriverv1 "github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/apis/backupdriver/v1alpha1"
 	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/backuprepository"
+	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/buildinfo"
 	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/constants"
 	backupdriverTypedV1 "github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/typed/backupdriver/v1alpha1"
 	pluginUtil "github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/plugin/util"
@@ -150,6 +151,7 @@ func (p *NewPVCBackupItemAction) Execute(item runtime.Unstructured, backup *vele
 	}
 	vals := map[string]string{
 		constants.ItemSnapshotLabel: snapshotAnnotation,
+		constants.PluginVersionLabel: buildinfo.Version,
 	}
 	pluginUtil.AddAnnotations(&pvc.ObjectMeta, vals)
 


### PR DESCRIPTION
Added plugin version as a backup annotation. With the commit, the following annotation will be available in the PVC backup in object store.

```
velero-plugin-for-vsphere/plugin-version  "x.y.z"
```

Signed-off-by: Lintong Jiang <lintongj@vmware.com>