### PR TITLE
[Cherry-pick] DeleteSnapshot fixes. (#249)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/spf13/cobra v0.0.6
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.4.0
-	github.com/vmware-tanzu/astrolabe v0.1.2-0.20201114003729-394c01f13c75
+	github.com/vmware-tanzu/astrolabe v0.1.2-0.20201210004320-383775c81f51
 	github.com/vmware-tanzu/velero v1.5.1
 	k8s.io/api v0.18.4
 	k8s.io/apiextensions-apiserver v0.18.4

--- a/go.sum
+++ b/go.sum
@@ -787,8 +787,8 @@ github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
 github.com/vishvananda/netlink v1.0.0/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=
 github.com/vishvananda/netns v0.0.0-20171111001504-be1fbeda1936/go.mod h1:ZjcWmFBXmLKZu9Nxj3WKYEafiSqer2rnvPr0en9UNpI=
-github.com/vmware-tanzu/astrolabe v0.1.2-0.20201114003729-394c01f13c75 h1:Us8oETgxuHdH+PAyzre0p3pWqFNsaO0v5yVpU2TwkT0=
-github.com/vmware-tanzu/astrolabe v0.1.2-0.20201114003729-394c01f13c75/go.mod h1:Af9uI95FSmiaKAiyUFa21rvFAeU195hIv7dMK3XnRag=
+github.com/vmware-tanzu/astrolabe v0.1.2-0.20201210004320-383775c81f51 h1:s3wYj2c0BS7AvSdmJHRHmWOk8FZS19+34cYsi0/8XuA=
+github.com/vmware-tanzu/astrolabe v0.1.2-0.20201210004320-383775c81f51/go.mod h1:Af9uI95FSmiaKAiyUFa21rvFAeU195hIv7dMK3XnRag=
 github.com/vmware-tanzu/velero v1.5.1 h1:PMcPfrhv91AfO/NPIWJDVUEql+DUixPnTjg+LTV95yI=
 github.com/vmware-tanzu/velero v1.5.1/go.mod h1:SIyHunlEyLVeKjWR34rv0mLeNVsH5wiR/EmQuUEo1/k=
 github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=

--- a/pkg/paravirt/paravirt_protected_entity.go
+++ b/pkg/paravirt/paravirt_protected_entity.go
@@ -3,15 +3,14 @@ package paravirt
 import (
 	"context"
 	"fmt"
-	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/constants"
-	"io"
-
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/vmware-tanzu/astrolabe/pkg/astrolabe"
 	"github.com/vmware-tanzu/astrolabe/pkg/pvc"
 	backupdriverv1api "github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/apis/backupdriver/v1alpha1"
+	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/constants"
 	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/snapshotUtils"
+	"io"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -117,22 +116,17 @@ func (this ParaVirtProtectedEntity) DeleteSnapshot(
 	snapshotToDelete astrolabe.ProtectedEntitySnapshotID,
 	params map[string]map[string]interface{}) (bool, error) {
 	this.logger.Infof("ParaVirtProtectedEntity: DeleteSnapshot called on Paravirtualized Protected Entity, %v snapshotToDelete: %s", this.id.String(), snapshotToDelete.String())
-	peInfo, err := this.GetInfo(ctx)
-	if err != nil {
-		this.logger.Errorf("Failed to get info for ParaVirtProtectedEntity %v", this.id.String())
-		return false, errors.WithStack(err)
-	}
-	this.logger.Infof("ParaVirtProtectedEntity: Retrieved info id: %s, name: %s", peInfo.GetID().String(), peInfo.GetName())
-
+	var err error
 	backupRepositoryName, ok := params[astrolabe.PvcPEType]["BackupRepositoryName"].(string)
 	if !ok {
 		backupRepositoryName = "INVALID_BR_NAME"
 	}
 
+	peIDName := this.GetID().GetID()
 	// Reconstruct the snapshot-id to delete.
 	peID := astrolabe.NewProtectedEntityIDWithNamespaceAndSnapshot(
 		astrolabe.PvcPEType,
-		peInfo.GetName(),
+		peIDName,
 		this.pvpetm.svcNamespace,
 		snapshotToDelete.String())
 	this.logger.Infof("ParaVirtProtectedEntity: Reconstructed peID: %s", peID.String())

--- a/pkg/plugin/delete_pvc_action_plugin.go
+++ b/pkg/plugin/delete_pvc_action_plugin.go
@@ -101,7 +101,7 @@ func (p *NewPVCDeleteItemAction) Execute(input *velero.DeleteItemActionExecuteIn
 
 	p.Log.Info("Creating a DeleteSnapshot CR")
 
-	updatedDeleteSnapshot, err := snapshotUtils.DeleteSnapshotRef(ctx, backupdriverClient, snapshotID, pvc.Namespace, *backupRepository,
+	updatedDeleteSnapshot, err := snapshotUtils.DeleteSnapshotRef(ctx, backupdriverClient, snapshotID, veleroNs, *backupRepository,
 		[]backupdriverv1.DeleteSnapshotPhase{backupdriverv1.DeleteSnapshotPhaseCompleted, backupdriverv1.DeleteSnapshotPhaseFailed}, p.Log)
 	if err != nil {
 		p.Log.Errorf("Failed to create a DeleteSnapshot CR: %v", err)


### PR DESCRIPTION
1. Currently when you attempt to delete a backup on a fresh setup(no deployment/pvc/pv/etc) the delete fails since an attempt is made to write the delete snap crd in the same namespace as the pvc retrieved from delete item action input.
This is fixed by writing the delete snap crd in the velero namespace.

2. Deleting snapshots made in different setup was previously not possible, i.e, Backup created in Vanilla, delete attempted in Guest, and vice-versa. This change fixes that.

Testing Done:
Backup Created in Vanilla:
Delete invoked in Vanilla- PASS
Delete invoked in Guest- PASS

Backup created in Guest:
Delete invoked in Guest- PASS
Delete invoked in Vanilla- PASS

Vanilla Pre-checkins: https://container-dp.svc.eng.vmware.com/job/Container_Precheck_Velero/749/
Full Sanity tests(Guest): https://container-dp.svc.eng.vmware.com/view/CNS-DP/job/Velero-Pipeline-WCP/298/


Signed-off-by: Deepak Kinni <dkinni@vmware.com>