### PR TITLE
[Cherry-pick]Log Supervisor DeleteSnapshot record created from Guest (#259)

### DIFF
--- a/pkg/backupdriver/backup_driver_controller.go
+++ b/pkg/backupdriver/backup_driver_controller.go
@@ -164,7 +164,7 @@ func (ctrl *backupDriverController) deleteSnapshot(deleteSnapshot *backupdrivera
 	}
 
 	deleteSnapshotStatusFields := make(map[string]interface{})
-	err = ctrl.snapManager.DeleteSnapshotWithBackupRepository(peID, brName)
+	err = ctrl.snapManager.DeleteSnapshotWithBackupRepository(peID, brName, deleteSnapshot.Name)
 	if err != nil {
 		errMsg := fmt.Sprintf("Failed at calling SnapshotManager DeleteSnapshot for peID %v, error: %v", peID, err)
 		ctrl.logger.Errorf(errMsg)

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -154,6 +154,7 @@ const (
 
 const (
 	WithoutBackupRepository = "without-backup-repository"
+	WithoutDeleteSnapshot   = "without-delete-snapshot"
 )
 
 const (

--- a/pkg/paravirt/paravirt_protected_entity.go
+++ b/pkg/paravirt/paravirt_protected_entity.go
@@ -121,6 +121,10 @@ func (this ParaVirtProtectedEntity) DeleteSnapshot(
 	if !ok {
 		backupRepositoryName = "INVALID_BR_NAME"
 	}
+	deleteSnapshotName, ok := params[astrolabe.PvcPEType]["DeleteSnapshotName"].(string)
+	if !ok {
+		deleteSnapshotName = "INVALID_DELETE_SNAPSHOT_NAME"
+	}
 
 	peIDName := this.GetID().GetID()
 	// Reconstruct the snapshot-id to delete.
@@ -132,12 +136,14 @@ func (this ParaVirtProtectedEntity) DeleteSnapshot(
 	this.logger.Infof("ParaVirtProtectedEntity: Reconstructed peID: %s", peID.String())
 
 	backupRepository := snapshotUtils.NewBackupRepository(backupRepositoryName)
-	_, err = snapshotUtils.DeleteSnapshotRef(ctx, this.pvpetm.svcBackupDriverClient, peID.String(), this.pvpetm.svcNamespace, *backupRepository,
+	svcDeleteSnap, err := snapshotUtils.DeleteSnapshotRef(ctx, this.pvpetm.svcBackupDriverClient, peID.String(), this.pvpetm.svcNamespace, *backupRepository,
 		[]backupdriverv1api.DeleteSnapshotPhase{backupdriverv1api.DeleteSnapshotPhaseCompleted, backupdriverv1api.DeleteSnapshotPhaseFailed}, this.logger)
 	if err != nil {
 		this.logger.Errorf("Failed to create a DeleteSnapshot CR: %v", err)
 		return false, err
 	}
+	this.logger.Infof("Created Supervisor DeleteSnapshot: %s for " +
+		"Guest DeleteSnapshot: %s", svcDeleteSnap.Name, deleteSnapshotName)
 	return true, nil
 }
 

--- a/pkg/snapshotmgr/snapshot_manager.go
+++ b/pkg/snapshotmgr/snapshot_manager.go
@@ -365,16 +365,18 @@ func (this *SnapshotManager) UploadSnapshot(uploadPE astrolabe.ProtectedEntity, 
 	return retUpload, err
 }
 
-func (this *SnapshotManager) DeleteSnapshotWithBackupRepository(peID astrolabe.ProtectedEntityID, backupRepository string) error {
+func (this *SnapshotManager) DeleteSnapshotWithBackupRepository(peID astrolabe.ProtectedEntityID,
+	backupRepository string, deleteSnapshotCRName string) error {
 	this.WithField("peID", peID.String()).Info("SnapshotManager.DeleteSnapshotWithBackupRepository was called.")
-	return this.deleteSnapshot(peID, backupRepository)
+	return this.deleteSnapshot(peID, backupRepository, deleteSnapshotCRName)
 }
 
 func (this *SnapshotManager) DeleteSnapshot(peID astrolabe.ProtectedEntityID) error {
-	return this.deleteSnapshot(peID, constants.WithoutBackupRepository)
+	return this.deleteSnapshot(peID, constants.WithoutBackupRepository, constants.WithoutDeleteSnapshot)
 }
 
-func (this *SnapshotManager) deleteSnapshot(peID astrolabe.ProtectedEntityID, backupRepositoryName string) error {
+func (this *SnapshotManager) deleteSnapshot(peID astrolabe.ProtectedEntityID, backupRepositoryName string,
+	deleteSnapshotName string) error {
 	log := this.WithField("peID", peID.String())
 	log.Info("SnapshotManager.deleteSnapshot was called.")
 	ctx := context.Background()
@@ -471,6 +473,7 @@ func (this *SnapshotManager) deleteSnapshot(peID astrolabe.ProtectedEntityID, ba
 	guestSnapshotParams := make(map[string]interface{})
 	// Pass the backup repository name as snapshot param.
 	guestSnapshotParams["BackupRepositoryName"] = backupRepositoryName
+	guestSnapshotParams["DeleteSnapshotName"] = deleteSnapshotName
 	snapshotParams[peID.GetPeType()] = guestSnapshotParams
 	log.Infof("Step 1: Deleting the local snapshot")
 	delSnapshotStatus, err := pe.DeleteSnapshot(ctx, pe.GetID().GetSnapshotID(), snapshotParams)


### PR DESCRIPTION
1. Added log message to indicate the supervisor delete snapshot CR created from guest.

Testing:
Invoked delete from guest and verified the log message exists

time="2020-12-11T22:55:34Z" level=info msg="Successfully created Supervisor DeleteSnapshot: delete-1a386832-26ca-4b24-a193-393836b4ac94 for Guest DeleteSnapshot: delete-660103cd-b1c4-4ec2-aca8-49d46800b310" logSource="/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/paravirt/paravirt_protected_entity.go:145"

Invoked delete on vanilla and verified that there was no regression.

Signed-off-by: Deepak Kinni <dkinni@vmware.com>