### PR TITLE
[Cherry-pick]Update astrolabe to point to 0.2 (#265)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/spf13/cobra v0.0.6
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.4.0
-	github.com/vmware-tanzu/astrolabe v0.1.2-0.20201210004320-383775c81f51
+	github.com/vmware-tanzu/astrolabe v0.2.0
 	github.com/vmware-tanzu/velero v1.5.1
 	k8s.io/api v0.18.4
 	k8s.io/apiextensions-apiserver v0.18.4

--- a/go.sum
+++ b/go.sum
@@ -789,6 +789,8 @@ github.com/vishvananda/netlink v1.0.0/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJ
 github.com/vishvananda/netns v0.0.0-20171111001504-be1fbeda1936/go.mod h1:ZjcWmFBXmLKZu9Nxj3WKYEafiSqer2rnvPr0en9UNpI=
 github.com/vmware-tanzu/astrolabe v0.1.2-0.20201210004320-383775c81f51 h1:s3wYj2c0BS7AvSdmJHRHmWOk8FZS19+34cYsi0/8XuA=
 github.com/vmware-tanzu/astrolabe v0.1.2-0.20201210004320-383775c81f51/go.mod h1:Af9uI95FSmiaKAiyUFa21rvFAeU195hIv7dMK3XnRag=
+github.com/vmware-tanzu/astrolabe v0.2.0 h1:P2/4hAp9msdOaZs6cy6HuMrR4h6GTTZBFBAkXiJNTqI=
+github.com/vmware-tanzu/astrolabe v0.2.0/go.mod h1:Af9uI95FSmiaKAiyUFa21rvFAeU195hIv7dMK3XnRag=
 github.com/vmware-tanzu/velero v1.5.1 h1:PMcPfrhv91AfO/NPIWJDVUEql+DUixPnTjg+LTV95yI=
 github.com/vmware-tanzu/velero v1.5.1/go.mod h1:SIyHunlEyLVeKjWR34rv0mLeNVsH5wiR/EmQuUEo1/k=
 github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=


### PR DESCRIPTION
1. Point to the latest astrolabe version.
2. 
Cherry-pick: https://github.com/vmware-tanzu/velero-plugin-for-vsphere/pull/265

Signed-off-by: Deepak Kinni <dkinni@vmware.com>