### PR TITLE
Support use velero-plugin-for-vsphere with a storage provider secured by a self-signed certificate

### DIFF
--- a/changelogs/unreleased/0302-wxinyan
+++ b/changelogs/unreleased/0302-wxinyan
@@ -1,0 +1,1 @@
+Updated velero-plugin-for-vsphere plugin to support user to use a storage provider secured by a self-signed certificate.

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -304,6 +304,10 @@ func RetrieveVSLFromVeleroBSLs(params map[string]interface{}, bslName string, co
 	params["s3Url"] = backupStorageLocation.Spec.Config["s3Url"]
 	params["profile"] = backupStorageLocation.Spec.Config["profile"]
 
+	if backupStorageLocation.Spec.ObjectStorage.CACert != nil {
+		params["caCert"] = string(backupStorageLocation.Spec.ObjectStorage.CACert)
+	}
+
 	return nil
 }
 
@@ -341,28 +345,12 @@ func GetS3PETMFromParamsMap(params map[string]interface{}, logger logrus.FieldLo
 		return nil, errors.New("Missing bucket param, cannot initialize S3 PETM")
 	}
 
-	// If the credentials are explicitly provided in params, use it.
-	// else let aws API pick the default credential provider.
-	var sess *session.Session
-	if _, ok := params[constants.AWS_ACCESS_KEY_ID]; ok {
-		s3AccessKeyId, ok := GetStringFromParamsMap(params, constants.AWS_ACCESS_KEY_ID, logger)
-		if !ok {
-			return nil, errors.New("Failed to retrieve S3 Access Key.")
-		}
-		s3SecretAccessKey, ok := GetStringFromParamsMap(params, constants.AWS_SECRET_ACCESS_KEY, logger)
-		if !ok {
-			return nil, errors.New("Failed to retrieve S3 Secret Access Key.")
-		}
-		logger.Infof("Using explicitly found credentials for S3 repository access.")
-		sess = session.Must(session.NewSession(&aws.Config{
-			Region:      aws.String(region),
-			Credentials: credentials.NewStaticCredentials(s3AccessKeyId, s3SecretAccessKey, ""),
-		}))
-	} else {
-		sess = session.Must(session.NewSession(&aws.Config{
-			Region: aws.String(region),
-		}))
+	sessionOption, err := GetS3SessionOptionsFromParamsMap(params, logger)
+	if err != nil {
+		logger.WithError(err).Error("Failed to get s3 session option from params.")
+		return nil, err
 	}
+	sess := session.Must(session.NewSessionWithOptions(sessionOption))
 
 	s3Url, ok := GetStringFromParamsMap(params, "s3Url", logger)
 	if ok {
@@ -394,6 +382,34 @@ func GetS3PETMFromParamsMap(params map[string]interface{}, logger logrus.FieldLo
 	return s3PETM, nil
 }
 
+func GetS3SessionOptionsFromParamsMap(params map[string]interface{}, logger logrus.FieldLogger) (session.Options, error) {
+	region, _ := GetStringFromParamsMap(params, "region", logger)
+	// If the credentials are explicitly provided in params, use it.
+	// else let aws API pick the default credential provider.
+	sessionOptions := session.Options{Config: aws.Config{
+		Region:      aws.String(region),
+	}}
+	var credential *credentials.Credentials
+	if _, ok := params[constants.AWS_ACCESS_KEY_ID]; ok {
+		s3AccessKeyId, ok := GetStringFromParamsMap(params, constants.AWS_ACCESS_KEY_ID, logger)
+		if !ok {
+			return session.Options{}, errors.New("Failed to retrieve S3 Access Key.")
+		}
+		s3SecretAccessKey, ok := GetStringFromParamsMap(params, constants.AWS_SECRET_ACCESS_KEY, logger)
+		if !ok {
+			return session.Options{}, errors.New("Failed to retrieve S3 Secret Access Key.")
+		}
+		logger.Infof("Using explicitly found credentials for S3 repository access.")
+		credential = credentials.NewStaticCredentials(s3AccessKeyId, s3SecretAccessKey, "")
+		sessionOptions.Config.Credentials = credential
+	}
+	caCert, ok := GetStringFromParamsMap(params, "caCert", logger)
+	if ok && len(caCert) > 0 {
+		sessionOptions.CustomCABundle = strings.NewReader(caCert)
+	}
+	return sessionOptions, nil
+}
+
 func GetDefaultS3PETM(logger logrus.FieldLogger) (*s3repository.ProtectedEntityTypeManager, error) {
 	var s3PETM *s3repository.ProtectedEntityTypeManager
 	params := make(map[string]interface{})
@@ -423,7 +439,7 @@ func GetStringFromParamsMap(params map[string]interface{}, key string, logger lo
 		}
 		return value, ok
 	} else {
-		logger.Errorf("No such key %s in params map", key)
+		logger.Infof("No such key %s in params map", key)
 		return "", ok
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Velero starts to support installing default BackupStorageLocation with self-signed certificate from v1.4.2. Our plugin should be also able to use S3 API with self-signed cert.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<291>`, or `Fixes https://github.com/vmware-tanzu/velero-plugin-for-vsphere/issues/291`.
-->
Fixes #291

**Special notes for your reviewer**:
Documentation: https://confluence.eng.vmware.com/display/~wxinyan/Use+velero-plugin-for-vsphere+with+a+storage+provider+secured+by+a+self-signed+certificate
Currently this feature is not supported on supervisor cluster.

E2E Test 
Vanilla cluster
Positive case: Use correct certificate bundle during installing velero. Expected successful backup and restore.
1.Trusting a self-signed certificate during velero installation
```
BUCKET=velero-minio
REGION=minio
S3URL=https://csm-minio.eng.vmware.com
CACERT=./certs/public.crt
velero install --provider aws \
                --bucket $BUCKET \
                --secret-file ./credentials-velero \
                --plugins velero/velero-plugin-for-aws:v1.0.0 \
                --snapshot-location-config region=$REGION \
                --backup-location-config region=$REGION,s3ForcePathStyle="true",s3Url=$S3URL \
                --cacert $CACERT
```
2.Add plugin and backup
```
velero add <plugin-image>
velero backup create self-signed-test --include-namespaces=my-namespace
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note

```
