### PR TITLE
Fixed the broken links in the issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -18,7 +18,7 @@ about: Tell us about a problem you are experiencing
 
 **Troubleshooting Information**
 
-[Please refer to the [Troubleshooting](../../docs/troubleshooting.md) page and collect the required information]
+[Please refer to the [Troubleshooting](https://github.com/vmware-tanzu/velero-plugin-for-vsphere/blob/main/docs/troubleshooting.md) page and collect the required information]
 
 **Screenshots**
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -21,4 +21,4 @@ about: Suggest an idea for this project
 
 **Environment:**
 
-[Provide the [required environment information](../../docs/troubleshooting.md#environment)]
+[Provide the [required environment information](https://github.com/vmware-tanzu/velero-plugin-for-vsphere/blob/main/docs/troubleshooting.md#environment)]


### PR DESCRIPTION
Signed-off-by: Lintong Jiang <lintongj@vmware.com>

**What this PR does / why we need it**:

There are links with relative path included in commits in https://github.com/vmware-tanzu/velero-plugin-for-vsphere/pull/295.

**Which issue(s) this PR fixes**: 

Updated relative path to absolute path.



<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #: N/A

**Special notes for your reviewer**: N/A 

**Does this PR introduce a user-facing change?**: N/A
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note

```
