### PR TITLE
Changed CRD parsing mechanism to not rely on SelfLink 

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -175,6 +175,10 @@ const (
 	SupervisorResourcePoolKey = "SupervisorResourcePool"
 )
 
+// We are currently translating Group + Kind -> the names below.  This involves
+// a singular to plural conversion.  When adding new resources, ensure that they
+// work with the singular to plural rule of words ending in "y" the "y" becomes "ies" and other
+// words get an "s" attached.
 var ResourcesToBlock = map[string]bool{
 	// Kubernetes with vSphere Supervisor Cluster resources
 	"agentinstalls.installers.tmc.cloud.vmware.com":           true,

--- a/pkg/utils/utils_unit_test.go
+++ b/pkg/utils/utils_unit_test.go
@@ -18,6 +18,9 @@ package utils
 
 import (
 	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/constants"
+	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/plugin/util"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/rest"
 	"strings"
 	"testing"
@@ -344,4 +347,38 @@ func TestGetComponentFromImage(t *testing.T) {
 			assert.Equal(t, actualVersion, test.expectedVersion)
 		})
 	}
+}
+
+func Test_ItemToCRDName(t *testing.T) {
+	accessor := meta.NewAccessor()
+
+	backupUnstructuredMock := unstructured.Unstructured{}
+	accessor.SetKind(&backupUnstructuredMock, "Backup")
+	accessor.SetAPIVersion(&backupUnstructuredMock,"velero.io/v1")
+
+	backupCRDName, err := util.UnstructuredToCRDName(&backupUnstructuredMock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, backupCRDName, "backups.velero.io")
+
+	repositoryUnstructuredMock := unstructured.Unstructured{}
+	accessor.SetKind(&repositoryUnstructuredMock, "ResticRepository")
+	accessor.SetAPIVersion(&repositoryUnstructuredMock,"velero.io/v1")
+
+	repositoryCRDName, err := util.UnstructuredToCRDName(&repositoryUnstructuredMock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, repositoryCRDName, "resticrepositories.velero.io")
+
+	pvcUnstructuredMock:= unstructured.Unstructured{}
+	accessor.SetKind(&pvcUnstructuredMock, "PersistentVolumeClaim")
+	accessor.SetAPIVersion(&pvcUnstructuredMock,"v1")
+
+	pvcCRDName, err := util.UnstructuredToCRDName(&pvcUnstructuredMock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, pvcCRDName, "persistentvolumeclaims")
 }


### PR DESCRIPTION
(remove in K8S 1.21).  Now uses Group/Version to

generate name for checking against blocked resources in vSphere Supervisor Cluster.

Fixes Jira DPCP-426

Signed-off-by: Dave Smith-Uchida <dsmithuchida@vmware.com>

Fixes: https://github.com/vmware-tanzu/velero-plugin-for-vsphere/issues/290

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE
```release-note

```
