### PR TITLE
Updated pre-upload check for new uploads.

### DIFF
--- a/changelogs/unreleased/pr-crocswearer
+++ b/changelogs/unreleased/pr-crocswearer
@@ -1,0 +1,1 @@
+Log skipped uploads.


### PR DESCRIPTION
Signed-off-by: Peter Grant <pegrant@vmware.com>

**What this PR does / why we need it**: Uploads are being skipped with no visibility.

**Does this PR introduce a user-facing change?**: NONE

```release-note
Log skipped uploads.
```
