### PR TITLE
Backport changes about gvddk spinning-off

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,9 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: src/github.com/vmware-tanzu/velero-plugin-for-vsphere
-      - name: Check out the code of astrolabe
-        uses: actions/checkout@v2
-        with:
-          repository: vmware-tanzu/astrolabe
-          path: src/github.com/vmware-tanzu/astrolabe
       - name: Download essential GVDDK libraries
         run: |
-          cd src/github.com/vmware-tanzu/astrolabe/vendor/github.com/vmware/gvddk
+          cd src/github.com/vmware-tanzu/velero-plugin-for-vsphere && mkdir .libs && cd .libs
           wget --quiet https://gvddk-libs.s3-us-west-1.amazonaws.com/VMware-vix-disklib-7.0.0-15832853.x86_64.tar.gz
           tar xzf VMware-vix-disklib-7.0.0-15832853.x86_64.tar.gz
           chmod 644 $(find vmware-vix-disklib-distrib/lib64/ -type f)

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .go
+.libs
 .idea
 _output
 .container-*

--- a/changelogs/unreleased/0303-lintongj
+++ b/changelogs/unreleased/0303-lintongj
@@ -1,0 +1,1 @@
+Updated plugin Makefile and CI script to adapt the latest change in astrolabe that spin off the gvddk component to be an independent project, vmware/virtual-disks.

--- a/changelogs/unreleased/0304-lintongj
+++ b/changelogs/unreleased/0304-lintongj
@@ -1,0 +1,1 @@
+Updated Makefile to support compile with local change in astrolabe and also updated description and error msg about the virtual-disks dependency

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/spf13/cobra v0.0.6
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.4.0
-	github.com/vmware-tanzu/astrolabe v0.2.0
+	github.com/vmware-tanzu/astrolabe v0.1.2-0.20210226062805-d433214638d2
 	github.com/vmware-tanzu/velero v1.5.1
 	k8s.io/api v0.18.4
 	k8s.io/apiextensions-apiserver v0.18.4
@@ -23,8 +23,6 @@ require (
 	k8s.io/klog v1.0.0
 	k8s.io/utils v0.0.0-20200619165400-6e3d28b6ed19
 )
-
-replace github.com/vmware/gvddk => ../astrolabe/vendor/github.com/vmware/gvddk
 
 replace k8s.io/api => k8s.io/api v0.18.4
 

--- a/go.sum
+++ b/go.sum
@@ -787,13 +787,15 @@ github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
 github.com/vishvananda/netlink v1.0.0/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=
 github.com/vishvananda/netns v0.0.0-20171111001504-be1fbeda1936/go.mod h1:ZjcWmFBXmLKZu9Nxj3WKYEafiSqer2rnvPr0en9UNpI=
-github.com/vmware-tanzu/astrolabe v0.2.0 h1:P2/4hAp9msdOaZs6cy6HuMrR4h6GTTZBFBAkXiJNTqI=
-github.com/vmware-tanzu/astrolabe v0.2.0/go.mod h1:Af9uI95FSmiaKAiyUFa21rvFAeU195hIv7dMK3XnRag=
+github.com/vmware-tanzu/astrolabe v0.1.2-0.20210226062805-d433214638d2 h1:nmAutQ5TN8C/Spf5iMZmfUeZMQ1MJxs8ow52vec8zFE=
+github.com/vmware-tanzu/astrolabe v0.1.2-0.20210226062805-d433214638d2/go.mod h1:kyAPAsg0rv1h/uMEvAiu4ZgTBFJvi4VoMzV4qOGS06I=
 github.com/vmware-tanzu/velero v1.5.1 h1:PMcPfrhv91AfO/NPIWJDVUEql+DUixPnTjg+LTV95yI=
 github.com/vmware-tanzu/velero v1.5.1/go.mod h1:SIyHunlEyLVeKjWR34rv0mLeNVsH5wiR/EmQuUEo1/k=
 github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
 github.com/vmware/govmomi v0.22.2-0.20200329013745-f2eef8fc745f h1:6LIYlihC1/LDUhZ7zYVp1WOEY5owzsvogiaHBqvBzPU=
 github.com/vmware/govmomi v0.22.2-0.20200329013745-f2eef8fc745f/go.mod h1:Y+Wq4lst78L85Ge/F8+ORXIWiKYqaro1vhAulACy9Lc=
+github.com/vmware/virtual-disks v0.0.2 h1:zDlvkj2MIBYeujBBYNr9zCaMAcTnP4mAgdIBcHmmaeM=
+github.com/vmware/virtual-disks v0.0.2/go.mod h1:GrUXFHPgc8MovXpbn3YduOIbRfzpKNNTagwjoY2bfAI=
 github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728/go.mod h1:x9oS4Wk2s2u4tS29nEaDLdzvuHdB19CvSGJjPgkZJNk=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
 github.com/xdg/stringprep v0.0.0-20180714160509-73f8eece6fdc/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=


### PR DESCRIPTION
**What this PR does / why we need it**:

Backport changes about gvddk spinning-off. 

Original PR:
- https://github.com/vmware-tanzu/velero-plugin-for-vsphere/pull/303
- https://github.com/vmware-tanzu/velero-plugin-for-vsphere/pull/304

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

n/a

**Special notes for your reviewer**:

n/a

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
There is no user-facing change. But for developers, the place to put the VDDK libraries is changed with this PR. Please follow the prompt from the make command.
```
