### PR TITLE
[Cherry-pick]Allow plugin to read non-default secrets (#302)

### DIFF
--- a/changelogs/unreleased/0305-dkinni
+++ b/changelogs/unreleased/0305-dkinni
@@ -1,0 +1,1 @@
+Allow plugin to read non-default secrets.

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/spf13/cobra v0.0.6
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.4.0
-	github.com/vmware-tanzu/astrolabe v0.1.2-0.20210226062805-d433214638d2
+	github.com/vmware-tanzu/astrolabe v0.1.2-0.20210304200758-1326d2d5044f
 	github.com/vmware-tanzu/velero v1.5.1
 	k8s.io/api v0.18.4
 	k8s.io/apiextensions-apiserver v0.18.4

--- a/go.sum
+++ b/go.sum
@@ -787,8 +787,8 @@ github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
 github.com/vishvananda/netlink v1.0.0/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=
 github.com/vishvananda/netns v0.0.0-20171111001504-be1fbeda1936/go.mod h1:ZjcWmFBXmLKZu9Nxj3WKYEafiSqer2rnvPr0en9UNpI=
-github.com/vmware-tanzu/astrolabe v0.1.2-0.20210226062805-d433214638d2 h1:nmAutQ5TN8C/Spf5iMZmfUeZMQ1MJxs8ow52vec8zFE=
-github.com/vmware-tanzu/astrolabe v0.1.2-0.20210226062805-d433214638d2/go.mod h1:kyAPAsg0rv1h/uMEvAiu4ZgTBFJvi4VoMzV4qOGS06I=
+github.com/vmware-tanzu/astrolabe v0.1.2-0.20210304200758-1326d2d5044f h1:dbE0ZSQgFEzSgvPtTFqnUrbytgb0zMvIV19QqVMvPxw=
+github.com/vmware-tanzu/astrolabe v0.1.2-0.20210304200758-1326d2d5044f/go.mod h1:kyAPAsg0rv1h/uMEvAiu4ZgTBFJvi4VoMzV4qOGS06I=
 github.com/vmware-tanzu/velero v1.5.1 h1:PMcPfrhv91AfO/NPIWJDVUEql+DUixPnTjg+LTV95yI=
 github.com/vmware-tanzu/velero v1.5.1/go.mod h1:SIyHunlEyLVeKjWR34rv0mLeNVsH5wiR/EmQuUEo1/k=
 github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -117,8 +117,6 @@ const (
 	VCSecretNsSupervisor   = "vmware-system-csi"
 	VCSecret               = "vsphere-config-secret"
 	VCSecretTKG            = "csi-vsphere-config"
-	VCSecretData           = "csi-vsphere.conf"
-	VCSecretDataSupervisor = "vsphere-cloud-provider.conf"
 )
 
 const (


### PR DESCRIPTION
**What this PR does / why we need it**:
During the installation of csi driver users have an option to use a non-default file name to enter vCenter config.
A secret(vsphere-config-secret) is created from the file, the 'Data' of the secret consists of key-value pairs, the key being the file name of the vCenter config.

Currently, we explicitly look for the default key(csi-vsphere.conf) in the Secret, however, if users created a non-default file name for the vc config then our plugin would fail to read the vc config.

The current change directly reads the value, since the Secret is expected to contain only 1 kv pair(confirmed this with csi team) and the file name used to create the secret is of no concern to the plugin.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://jira.eng.vmware.com/browse/DPCP-429
Current PR is a Backport of the original fix in PR #302.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
Allow plugin to read non-default CSI vSphere Secrets
```
Signed-off-by: Deepak Kinni <dkinni@vmware.com>
