### PR TITLE
[Cherry-pick]Update vSphere Velero Plugin to point to v0.3.0 Astrolabe (#314)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/spf13/cobra v0.0.6
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.4.0
-	github.com/vmware-tanzu/astrolabe v0.1.2-0.20210304200758-1326d2d5044f
+	github.com/vmware-tanzu/astrolabe v0.3.0
 	github.com/vmware-tanzu/velero v1.5.1
 	k8s.io/api v0.18.4
 	k8s.io/apiextensions-apiserver v0.18.4

--- a/go.sum
+++ b/go.sum
@@ -787,8 +787,8 @@ github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
 github.com/vishvananda/netlink v1.0.0/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=
 github.com/vishvananda/netns v0.0.0-20171111001504-be1fbeda1936/go.mod h1:ZjcWmFBXmLKZu9Nxj3WKYEafiSqer2rnvPr0en9UNpI=
-github.com/vmware-tanzu/astrolabe v0.1.2-0.20210304200758-1326d2d5044f h1:dbE0ZSQgFEzSgvPtTFqnUrbytgb0zMvIV19QqVMvPxw=
-github.com/vmware-tanzu/astrolabe v0.1.2-0.20210304200758-1326d2d5044f/go.mod h1:kyAPAsg0rv1h/uMEvAiu4ZgTBFJvi4VoMzV4qOGS06I=
+github.com/vmware-tanzu/astrolabe v0.3.0 h1:4mvqXNogEiy3TUjTTmnfIbf2rvrVTBHYYL6f7pXObTc=
+github.com/vmware-tanzu/astrolabe v0.3.0/go.mod h1:kyAPAsg0rv1h/uMEvAiu4ZgTBFJvi4VoMzV4qOGS06I=
 github.com/vmware-tanzu/velero v1.5.1 h1:PMcPfrhv91AfO/NPIWJDVUEql+DUixPnTjg+LTV95yI=
 github.com/vmware-tanzu/velero v1.5.1/go.mod h1:SIyHunlEyLVeKjWR34rv0mLeNVsH5wiR/EmQuUEo1/k=
 github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the plugin to point to the latest version of the Astrolabe.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
NONE
```
Signed-off-by: Deepak Kinni <dkinni@vmware.com>