### PR TITLE
Disconnected vCenter reconciliation

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -335,9 +335,9 @@ func GetIVDPETMFromParamsMap(params map[string]interface{}, logger logrus.FieldL
 
 	ivdPETM, err := ivd.NewIVDProtectedEntityTypeManager(params, s3Config, logger)
 	if err != nil {
-		logger.WithError(err).Errorf("Error at creating new IVD PETM from vc params: %v, s3Config: %v",
+		logger.WithError(err).Errorf("Error initializing new IVD PETM from vc params: %v, s3Config: %v",
 			params, s3Config)
-		return nil, err
+		logger.Warnf("Registering uninitialized IVD PETM, will retry connection on access..")
 	}
 
 	return ivdPETM, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
During the data-manager and backupdriver startup an attempt is made to initialize ivd petm.
Prior to the fix, the ivd petm would not be registered if there were errors while establishing vCenter connection.
Even if the vc comes back online there was no mechanism to re-register ivd petm.
With this fix the ivd petm is registered even if there were errors while initializing ivd petm.


Please refer:
https://confluence.eng.vmware.com/display/~dkinni/Disconnected+VC+Connection+Reconciliation+Velero+vSphere+Plugin

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes DPCP-433

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
None.
```
Signed-off-by: Deepak Kinni <dkinni@vmware.com>