### PR TITLE
Updated supervisor doc about adding the prerequisite for restoring workloads in supervisor cluster

### DIFF
--- a/docs/supervisor.md
+++ b/docs/supervisor.md
@@ -47,4 +47,9 @@ The backup workflow in a vSphere with Tanzu Supervisor cluster is the same as th
 
 ## Restore
 
-The restore workflow in a vSphere with Tanzu Supervisor cluster is the same as that in Vanilla Kubernetes cluster. Please refer to [Restore](vanilla.md#restore) in Vanilla Kubernetes Cluster document.
+In a vSphere with Tanzu Supervisor cluster, users need to take extra steps via either vSphere UI or VMware [DCLI](https://code.vmware.com/web/tool/3.0.0/vmware-datacenter-cli) before restoring a workload.
+
+1. Create a namespace in Supervisor cluster.
+2. Configure the Storage policy in the namespace.
+
+The rest of restore workflow in a vSphere with Tanzu Supervisor cluster is the same as that in Vanilla Kubernetes cluster. Please refer to [Restore](vanilla.md#restore) in Vanilla Kubernetes Cluster document.


### PR DESCRIPTION

Signed-off-by: Lintong Jiang <lintongj@vmware.com>

**What this PR does / why we need it**: 

Adding the prerequisite for restoring workloads in supervisor cluster, which is slightly different from the restore workflow in a Vanilla K8s cluster.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # 

**Special notes for your reviewer**: n/a

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
NONE
```
