### PR TITLE
Add contentsourcebindings.vmoperator.vmware.com to block list

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -194,6 +194,7 @@ var ResourcesToBlock = map[string]bool{
 	"cnsvolumemetadatas.cns.vmware.com":                       true,
 	"compatibilities.run.tanzu.vmware.com":                    true,
 	"contentlibraryproviders.vmoperator.vmware.com":           true,
+	"contentsourcebindings.vmoperator.vmware.com":             true,
 	"contentsources.vmoperator.vmware.com":                    true,
 	"gatewayclasses.networking.x-k8s.io":                      true,
 	"gateways.networking.x-k8s.io":                            true,


### PR DESCRIPTION
Signed-off-by: wxinyan <wxinyan@wxinyan-a01.vmware.com>

**What this PR does / why we need it**:
This is a follow up for PR #327 . Add new crd contentsourcebindings.vmoperator.vmware.com to block list.
**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note

```
