### PR TITLE
Added the parsed name of the nsxlbmonitors.vmware.com CRD to the block list on restore

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -113,10 +113,10 @@ const (
 )
 
 const (
-	VCSecretNs             = "kube-system"
-	VCSecretNsSupervisor   = "vmware-system-csi"
-	VCSecret               = "vsphere-config-secret"
-	VCSecretTKG            = "csi-vsphere-config"
+	VCSecretNs           = "kube-system"
+	VCSecretNsSupervisor = "vmware-system-csi"
+	VCSecret             = "vsphere-config-secret"
+	VCSecretTKG          = "csi-vsphere-config"
 )
 
 const (
@@ -201,7 +201,7 @@ var ResourcesToBlock = map[string]bool{
 	"haproxyloadbalancerconfigs.netoperator.vmware.com":       true,
 	"httproutes.networking.x-k8s.io":                          true,
 	"imagedisks.imagecontroller.vmware.com":                   true,
-	"images.imagecontroller.vmware.com":                       true,
+	//"images.imagecontroller.vmware.com":                     true, // DO NOT ADD IT BACK
 	"installoptions.appplatform.wcp.vmware.com":               true,
 	"installrequirements.appplatform.wcp.vmware.com":          true,
 	"ipamblocks.crd.projectcalico.org":                        true,
@@ -227,8 +227,8 @@ var ResourcesToBlock = map[string]bool{
 	"networkinterfaces.netoperator.vmware.com":                true,
 	"networks.netoperator.vmware.com":                         true,
 	"nsxerrors.nsx.vmware.com":                                true,
-	"nsxlbmonitors.vmware.com":                                true,
-	"nsxloadbalancermonitors.vmware.com":                      true,
+	//"nsxlbmonitors.vmware.com":                              true, // DO NOT ADD IT BACK
+	//"nsxloadbalancermonitors.vmware.com":                    true, // DO NOT ADD IT BACK
 	"nsxlocks.nsx.vmware.com":                                 true,
 	"nsxnetworkinterfaces.nsx.vmware.com":                     true,
 	"orders.acme.cert-manager.io":                             true,
@@ -277,16 +277,26 @@ var ResourcesToBlock = map[string]bool{
 var ResourcesToBlockOnRestore = map[string]bool{
 	// Kubernetes with vSphere Supervisor Cluster resources
 
-	// The image resource is backed up everytime when a container
-	// is backed up on Supervisor Cluster.
-	// We should skip it at restore time.
-	"images.imagecontroller.vmware.com": true,
-
 	// We need to remove some metadata from the Pod resource on
 	// Supervisor Cluster, i.e., annotation "vmware-system-vm-uuid"
 	// before the restore as the existing VM UUID is associated with
 	// the old VM that does not exist any more
 	"pods": true,
+
+	// The following resources are backed up everytime when a container
+	// is backed up on Supervisor Cluster.
+	// We should skip it at restore time.
+	"images.imagecontroller.vmware.com": true,
+
+	// "nsxlbmonitors.vmware.com" is the real name for this resource,
+	// however, our existing name parsing mechanism for resource matches
+	// with the parsed name. Adding both of them to the list.
+	// The real name will be used to make sure the resource is
+	// picked up in the AppliesTo func of item action plugin, while
+	// the parsed name will be used to skip restoring the resource
+	// in the Execute func of item action plugin.
+	"nsxlbmonitors.vmware.com":           true, // real name
+	"nsxloadbalancermonitors.vmware.com": true, // parsed name
 }
 
 var ResourcesToHandle = map[string]bool{

--- a/pkg/plugin/backup_pvc_action_plugin.go
+++ b/pkg/plugin/backup_pvc_action_plugin.go
@@ -53,8 +53,7 @@ func (p *NewPVCBackupItemAction) Execute(item runtime.Unstructured, backup *vele
 	}
 
 	if blocked {
-		p.Log.Infof("Resource CRD %s is blocked, skipping", crdName)
-		return nil, nil, nil
+		return nil, nil, errors.Errorf("Resource CRD %s is blocked in backup, skipping", crdName)
 	}
 
 	var pvc corev1.PersistentVolumeClaim


### PR DESCRIPTION
**What this PR does / why we need it**:

We need to skip the vSphere-specific CRD `nsxlbmonitors.vmware.com` on velero restore. Otherwise, restore will end up to PartiallyFailed. 

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

n/a

**Special notes for your reviewer**:

With this change, `nsxlbmonitors.vmware.com` resource will be skipped as expected in the restore. Below are expected log messages.

```
time="2021-04-08T01:21:13Z" level=info msg="Restoring resource 'nsxlbmonitors.vmware.com' into namespace 'test-cns-dp-wcp-ns-mushcik'" logSource="pkg/restore/restore.go:716" restore=velero/restore-manual-backup-0407-002
time="2021-04-08T01:21:13Z" level=info msg="Getting client for vmware.com/v1alpha1, Kind=NSXLoadBalancerMonitor" logSource="pkg/restore/restore.go:760" restore=velero/restore-manual-backup-0407-002
time="2021-04-08T01:21:13Z" level=info msg="Executing item action for nsxlbmonitors.vmware.com" logSource="pkg/restore/restore.go:983" restore=velero/restore-manual-backup-0407-002
time="2021-04-08T01:21:13Z" level=info msg="Restoring resource nsxloadbalancermonitors.vmware.com: blocked = true" cmd=/plugins/velero-plugin-for-vsphere logSource="/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/plugin/restore_pvc_action_plugin.go:60" pluginName=velero-plugin-for-vsphere restore=velero/restore-manual-backup-0407-002
time="2021-04-08T01:21:13Z" level=info msg="Skipping resource nsxloadbalancermonitors.vmware.com on restore" cmd=/plugins/velero-plugin-for-vsphere logSource="/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/plugin/restore_pvc_action_plugin.go:67" pluginName=velero-plugin-for-vsphere restore=velero/restore-manual-backup-0407-002
time="2021-04-08T01:21:13Z" level=info msg="Skipping restore of NSXLoadBalancerMonitor: test-cns-dp-wcp-ns-mushcik because a registered plugin discarded it" logSource="pkg/restore/restore.go:996" restore=velero/restore-manual-backup-0407-002
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
Skipped the restore of the vSphere-with-Tanzu specific resource, nsxlbmonitors.vmware.com by adding related resource names to the block list on restore
```
