### PR TITLE
Added the prerequisite of downloading velero vsphere operator cli in supervisor docs

### DIFF
--- a/docs/supervisor.md
+++ b/docs/supervisor.md
@@ -22,6 +22,11 @@
   * SupervisorServices.Manage
   * Namespaces.Manage
   * Namespaces.Configure
+* Download `Velero vSphere Operator` CLI [from here](https://github.com/vmware-tanzu/velero-plugin-for-vsphere/releases/download/v1.1.0/velero-vsphere-1.1.0-linux-amd64.tar.gz).
+
+## vSphere with Tanzu notes
+
+Please read [vSphere with Tanzu notes](supervisor-notes.md) before moving forward with the following sections.
 
 ## Install
 
@@ -29,17 +34,13 @@ In a **vSphere with Tanzu** Supervisor cluster, users are supposed to leverage `
 [Installing Velero on Supervisor cluster](velero-vsphere-operator-user-manual.md#installing-velero-on-supervisor-cluster)
 for the detail.
 
-**Note**: `Velero vSphere Operator` CLI that comes with `Velero vSphere Operator` aims to provide a similar user experience as the Velero CLI in install and uninstall operations. For other Velero operations, users must continue to use the Velero CLI.
+**Note**: `Velero vSphere Operator` CLI that comes with `Velero vSphere Operator` aims to provide a similar user experience as the Velero CLI in install and uninstall operations. For other Velero operations, users must continue to use the Velero CLI. Please download `Velero vSphere Operator` CLI [from here](https://github.com/vmware-tanzu/velero-plugin-for-vsphere/releases/download/v1.1.0/velero-vsphere-1.1.0-linux-amd64.tar.gz) if you haven't done so.
 
 ## Uninstall
 
 In a vSphere with Tanzu Supervisor cluster, users should use `Velero vSphere Operator` CLI to uninstall [Uninstalling Velero on Supervisor cluster](velero-vsphere-operator-user-manual.md#uninstalling-velero-on-supervisor-cluster).
 
 **Note**: Disabling the `Velero vSphere Operator` Supervisor Service will also uninstall Velero as well as the ```velero-plugin-for-vsphere``` in the Supervisor cluster. However, as a best practice, it is recommended to uninstall velero and velero-plugin-for-vsphere using `Velero vSphere Operator CLI`.
-
-## vSphere with Tanzu notes
-
-Please read this section before doing backup and restore in vSphere with Tanzu Supervisor Cluster. The details are documented at [vSphere with Tanzu notes](supervisor-notes.md).
 
 ## Backup
 

--- a/docs/velero-vsphere-operator-cli.md
+++ b/docs/velero-vsphere-operator-cli.md
@@ -10,6 +10,8 @@
 ## Prerequisites
 
 * `Velero vSphere Operator` supervisor service is expected to be **enabled** before running any CLI command.
+* Download `Velero vSphere Operator` CLI [from here](https://github.com/vmware-tanzu/velero-plugin-for-vsphere/releases/download/v1.1.0/velero-vsphere-1.1.0-linux-amd64.tar.gz).
+
 
 ## Install Velero & Plugins
 

--- a/docs/velero-vsphere-operator-user-manual.md
+++ b/docs/velero-vsphere-operator-user-manual.md
@@ -7,7 +7,7 @@ Users here are expected to be vSphere users with access to:
 
 ## Installing Velero on Supervisor cluster
 
-1. Enable `Velero vSphere Operator` Supervisor Service via vSphere UI.
+1. Enable `Velero vSphere Operator` Supervisor Service via vSphere UI. If you do not see any of the Supervisor Services as shown below, please double check the [compatibility](supervisor.md#compatibility) matrix.
     ![How to enable `Velero vSphere Operator` supervisor service](how-to-enable-supervisor-service.png)
 
 2. Create a supervisor namespace for Velero instance via vSphere UI.


### PR DESCRIPTION

**What this PR does / why we need it**:

Updated supervisor docs to make users much easier to know where to download `Velero vSphere Operator` CLI.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

N/A

**Special notes for your reviewer**:

N/A

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
None
```
