### PR TITLE
Update docs to specify exclude resource during backup and restore of full cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ you set above with the --volume-snapshot-locations flag
 velero backup create my-backup --include-namespaces=my-namespace --snapshot-volumes --volume-snapshot-locations vsl-vsphere
 ```
 
+If attempting to backup the entire cluster please exclude the upload and download crds by using the --exclude-resources flag
+
+```bash
+velero backup create my-backup --snapshot-volumes --volume-snapshot-locations vsl-vsphere --exclude-resources upload.veleroplugin.io,download.veleroplugin.io,uploads.veleroplugin.io,downloads.veleroplugin.io
+```
+
 Your backup will complete after the local snapshots have completed and your Kubernetes metadata has been uploaded to the object
 store specified.  At this point, all of the data may not have been uploaded to your S3 object store.  Data movement happens in the
 background and may take a significant amount of time to complete.
@@ -107,6 +113,12 @@ and configured.  There are no special options to the plugin required for restore
 
 ```bash
 velero restore create --from-backup <your-backup-name>
+```
+
+If attempting to restore an entire cluster from backup then exclude the upload and download crds by using the --exclude-resources flag
+
+```bash
+velero restore create --from-backup <my-full-cluster-backup-name> --exclude-resources upload.veleroplugin.io,download.veleroplugin.io,uploads.veleroplugin.io,downloads.veleroplugin.io
 ```
 
 Please refer to the Velero documentation for usage and additional restore options.


### PR DESCRIPTION
**What this PR does / why we need it**:
1. When backing up the full cluster it's possible that upload and download crds are backed up as well.
2. This causes an issue when restoring back the full cluster and if the crds are not in the terminal stage.
3. Updating docs to indicate that these upload and download crds need to excluded.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #DPCP-431

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
None
```
Signed-off-by: Deepak Kinni <dkinni@vmware.com>