### PR TITLE
Update velero-vsphere-operator-cli.md

### DIFF
--- a/docs/velero-vsphere-operator-cli.md
+++ b/docs/velero-vsphere-operator-cli.md
@@ -10,6 +10,7 @@
 ## Prerequisites
 
 * `Velero vSphere Operator` supervisor service is expected to be **enabled** before running any CLI command.
+* download `vsphere-velero` cli from [velero-plugin-for-vsphere release v1.1.0]('releases/download/v1.1.0/velero-vsphere-1.1.0-linux-amd64.tar.gz')
 
 ## Install Velero & Plugins
 


### PR DESCRIPTION
give location to download vsphere-velero cli

**What this PR does / why we need it**:
hi,
it might takes time to search the exact version of `velero-plugin-for-vsphere` release where the `vsphere-velero` cli is included. this patch is to help users to guide the exact location of the cli.
thanks

