### PR TITLE
Replaced rest.InClusterConfig with a helper that load k8s client config with default rules

### DIFF
--- a/pkg/backuprepository/backup_repository.go
+++ b/pkg/backuprepository/backup_repository.go
@@ -300,9 +300,9 @@ func GetRepositoryFromBackupRepository(backupRepository *backupdriverv1.BackupRe
 }
 
 func GetBackupRepositoryFromBackupRepositoryName(backupRepositoryName string) (*backupdriverv1.BackupRepository, error) {
-	config, err := rest.InClusterConfig()
+	config, err := utils.GetKubeClientConfig()
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to get k8s inClusterConfig")
+		return nil, errors.Wrap(err, "Failed to get k8s client config")
 	}
 	pluginClient, err := versioned.NewForConfig(config)
 	if err != nil {

--- a/pkg/cmd/backupdriver/cli/install/install.go
+++ b/pkg/cmd/backupdriver/cli/install/install.go
@@ -31,10 +31,8 @@ import (
 	"github.com/vmware-tanzu/velero/pkg/client"
 	"github.com/vmware-tanzu/velero/pkg/cmd/util/flag"
 	"github.com/vmware-tanzu/velero/pkg/cmd/util/output"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-
 	"io/ioutil"
+	"k8s.io/client-go/kubernetes"
 	"os"
 
 	kubeutil "github.com/vmware-tanzu/velero/pkg/util/kube"
@@ -205,9 +203,9 @@ func (o *InstallOptions) Complete(args []string, f client.Factory) error {
 	}
 	namespace := string(content)
 
-	config, err := rest.InClusterConfig()
+	config, err := utils.GetKubeClientConfig()
 	if err != nil {
-		fmt.Println("Failed to get k8s inClusterConfig")
+		fmt.Println("Failed to get k8s client config")
 		return errors.WithStack(err)
 	}
 	clientset, err := kubernetes.NewForConfig(config)

--- a/pkg/cmd/datamgr/cli/install/install.go
+++ b/pkg/cmd/datamgr/cli/install/install.go
@@ -30,11 +30,9 @@ import (
 	"github.com/vmware-tanzu/velero/pkg/cmd/util/flag"
 	"github.com/vmware-tanzu/velero/pkg/cmd/util/output"
 	"github.com/vmware-tanzu/velero/pkg/features"
+	"io/ioutil"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -240,9 +238,9 @@ func (o *InstallOptions) Complete(args []string, f client.Factory) error {
 	}
 	namespace := string(content)
 
-	config, err := rest.InClusterConfig()
+	config, err := utils.GetKubeClientConfig()
 	if err != nil {
-		fmt.Println("Failed to get k8s inClusterConfig")
+		fmt.Println("Failed to get k8s client config")
 		return errors.WithStack(err)
 	}
 	clientset, err := kubernetes.NewForConfig(config)

--- a/pkg/plugin/backup_pvc_action_plugin.go
+++ b/pkg/plugin/backup_pvc_action_plugin.go
@@ -18,7 +18,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/rest"
 	"os"
 )
 
@@ -32,7 +31,7 @@ func (p *NewPVCBackupItemAction) AppliesTo() (velero.ResourceSelector, error) {
 	p.Log.Info("VSphere PVCBackupItemAction AppliesTo")
 
 	return velero.ResourceSelector{
-		IncludedResources: utils.GetResources(),
+		IncludedResources: pluginUtil.GetResources(),
 	}, nil
 }
 
@@ -46,7 +45,7 @@ func (p *NewPVCBackupItemAction) Execute(item runtime.Unstructured, backup *vele
 		return item, nil, nil
 	}
 
-	blocked, crdName, err := utils.IsObjectBlocked(item)
+	blocked, crdName, err := pluginUtil.IsObjectBlocked(item)
 
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "Failed during IsObjectBlocked check")
@@ -80,7 +79,7 @@ func (p *NewPVCBackupItemAction) Execute(item runtime.Unstructured, backup *vele
 		return nil, nil, errors.New(errMsg)
 	}
 
-	restConfig, err := rest.InClusterConfig()
+	restConfig, err := utils.GetKubeClientConfig()
 	if err != nil {
 		p.Log.Error("Failed to get the rest config in k8s cluster: %v", err)
 		return nil, nil, errors.WithStack(err)

--- a/pkg/plugin/delete_pvc_action_plugin.go
+++ b/pkg/plugin/delete_pvc_action_plugin.go
@@ -15,7 +15,6 @@ import (
 	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/rest"
 	"os"
 )
 
@@ -35,7 +34,7 @@ func (p *NewPVCDeleteItemAction) AppliesTo() (velero.ResourceSelector, error) {
 func (p *NewPVCDeleteItemAction) Execute(input *velero.DeleteItemActionExecuteInput) error {
 	item := input.Item
 
-	blocked, crdName, err := utils.IsObjectBlocked(item)
+	blocked, crdName, err := pluginItem.IsObjectBlocked(item)
 
 	if err != nil {
 		return errors.Wrap(err, "Failed during IsObjectBlocked check")
@@ -74,7 +73,7 @@ func (p *NewPVCDeleteItemAction) Execute(input *velero.DeleteItemActionExecuteIn
 		p.Log.Error(errMsg)
 		return errors.New(errMsg)
 	}
-	restConfig, err := rest.InClusterConfig()
+	restConfig, err := utils.GetKubeClientConfig()
 	if err != nil {
 		p.Log.Error("Failed to get the rest config in k8s cluster: %v", err)
 		return errors.WithStack(err)

--- a/pkg/plugin/util/util_unit_test.go
+++ b/pkg/plugin/util/util_unit_test.go
@@ -1,0 +1,42 @@
+package util
+
+import (
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"testing"
+)
+
+func Test_ItemToCRDName(t *testing.T) {
+	accessor := meta.NewAccessor()
+
+	backupUnstructuredMock := unstructured.Unstructured{}
+	accessor.SetKind(&backupUnstructuredMock, "Backup")
+	accessor.SetAPIVersion(&backupUnstructuredMock, "velero.io/v1")
+
+	backupCRDName, err := UnstructuredToCRDName(&backupUnstructuredMock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, backupCRDName, "backups.velero.io")
+
+	repositoryUnstructuredMock := unstructured.Unstructured{}
+	accessor.SetKind(&repositoryUnstructuredMock, "ResticRepository")
+	accessor.SetAPIVersion(&repositoryUnstructuredMock, "velero.io/v1")
+
+	repositoryCRDName, err := UnstructuredToCRDName(&repositoryUnstructuredMock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, repositoryCRDName, "resticrepositories.velero.io")
+
+	pvcUnstructuredMock := unstructured.Unstructured{}
+	accessor.SetKind(&pvcUnstructuredMock, "PersistentVolumeClaim")
+	accessor.SetAPIVersion(&pvcUnstructuredMock, "v1")
+
+	pvcCRDName, err := UnstructuredToCRDName(&pvcUnstructuredMock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, pvcCRDName, "persistentvolumeclaims")
+}

--- a/pkg/snapshotmgr/snapshot_manager.go
+++ b/pkg/snapshotmgr/snapshot_manager.go
@@ -296,14 +296,9 @@ Creates an Upload CR
 func (this *SnapshotManager) UploadSnapshot(uploadPE astrolabe.ProtectedEntity, ctx context.Context, backupRepositoryName string,
 	snapshotRef string) (*v1api.Upload, error) {
 	this.Info("Start creating Upload CR")
-	config, err := rest.InClusterConfig()
+	pluginClient, err := utils.CreatePluginClientSet()
 	if err != nil {
-		this.WithError(err).Errorf("Failed to get k8s inClusterConfig")
-		return nil, err
-	}
-	pluginClient, err := plugin_clientset.NewForConfig(config)
-	if err != nil {
-		this.WithError(err).Errorf("Failed to get k8s clientset from the given config: %v ", config)
+		this.WithError(err).Error("Failed to get k8s clientset")
 		return nil, err
 	}
 
@@ -380,7 +375,7 @@ func (this *SnapshotManager) deleteSnapshot(peID astrolabe.ProtectedEntityID, ba
 	log := this.WithField("peID", peID.String())
 	log.Info("SnapshotManager.deleteSnapshot was called.")
 	ctx := context.Background()
-	config, err := rest.InClusterConfig()
+	config, err := utils.GetKubeClientConfig()
 	if err != nil {
 		this.WithError(err).Errorf("Failed to get k8s inClusterConfig")
 		return err
@@ -612,14 +607,10 @@ const PollLogInterval = time.Minute
 
 func (this *SnapshotManager) CreateVolumeFromSnapshot(sourcePEID astrolabe.ProtectedEntityID, destinationPEID astrolabe.ProtectedEntityID, params map[string]map[string]interface{}) (updatedID astrolabe.ProtectedEntityID, err error) {
 	this.Infof("Start creating Download CR for %s", sourcePEID.String())
-	config, err := rest.InClusterConfig()
+
+	pluginClient, err := utils.CreatePluginClientSet()
 	if err != nil {
-		this.WithError(err).Errorf("Failed to get k8s inClusterConfig")
-		return
-	}
-	pluginClient, err := plugin_clientset.NewForConfig(config)
-	if err != nil {
-		this.WithError(err).Errorf("Failed to get k8s clientset with the given config: %v", config)
+		this.WithError(err).Error("Failed to get k8s clientset")
 		return
 	}
 

--- a/pkg/utils/utils_e2e_test.go
+++ b/pkg/utils/utils_e2e_test.go
@@ -24,13 +24,10 @@ import (
 	"testing"
 	"time"
 
-	k8sv1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/kubernetes"
-
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	backupdriverTypedV1 "github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/typed/backupdriver/v1alpha1"
 	"github.com/vmware-tanzu/velero/pkg/generated/clientset/versioned"
+	k8sv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -83,50 +80,11 @@ func TestRetrieveParamsFromBSL(t *testing.T) {
 	}
 }
 
-
-
-
-func createClientSet() (*kubernetes.Clientset, error) {
-	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
-	// if you want to change the loading rules (which files in which order), you can do so here
-
-	configOverrides := &clientcmd.ConfigOverrides{}
-	// if you want to change override values or bind them to flags, there are methods to help you
-
-	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
-	config, err := kubeConfig.ClientConfig()
-	if err != nil {
-		return nil, NewClientConfigNotFoundError("Could not create client config")
-	}
-
-	clientset, err := kubernetes.NewForConfig(config)
-
-	if err != nil {
-		return nil, errors.Wrap(err, "Could not create clientset")
-	}
-	return clientset, err
-}
-
-type ClientConfigNotFoundError struct {
-	errMsg string
-}
-
-func (this ClientConfigNotFoundError) Error() string {
-	return this.errMsg
-}
-
-func NewClientConfigNotFoundError(errMsg string) ClientConfigNotFoundError {
-	err := ClientConfigNotFoundError{
-		errMsg: errMsg,
-	}
-	return err
-}
-
 /*
  * For this test, set KUBECONFIG to point to a valid setup, with a BackupDriverNamespace created.
  */
 func Test_waitForPvSecret(t *testing.T) {
-	clientSet, err := createClientSet()
+	clientSet, err := CreateKubeClientSet()
 
 	if err != nil {
 		_, ok := err.(ClientConfigNotFoundError)

--- a/pkg/utils/utils_unit_test.go
+++ b/pkg/utils/utils_unit_test.go
@@ -17,13 +17,10 @@ limitations under the License.
 package utils
 
 import (
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/constants"
-	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/plugin/util"
-	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/constants"
 	"k8s.io/client-go/rest"
 	"strings"
 	"testing"
@@ -350,40 +347,6 @@ func TestGetComponentFromImage(t *testing.T) {
 			assert.Equal(t, actualVersion, test.expectedVersion)
 		})
 	}
-}
-
-func Test_ItemToCRDName(t *testing.T) {
-	accessor := meta.NewAccessor()
-
-	backupUnstructuredMock := unstructured.Unstructured{}
-	accessor.SetKind(&backupUnstructuredMock, "Backup")
-	accessor.SetAPIVersion(&backupUnstructuredMock,"velero.io/v1")
-
-	backupCRDName, err := util.UnstructuredToCRDName(&backupUnstructuredMock)
-	if err != nil {
-		t.Fatal(err)
-	}
-	assert.Equal(t, backupCRDName, "backups.velero.io")
-
-	repositoryUnstructuredMock := unstructured.Unstructured{}
-	accessor.SetKind(&repositoryUnstructuredMock, "ResticRepository")
-	accessor.SetAPIVersion(&repositoryUnstructuredMock,"velero.io/v1")
-
-	repositoryCRDName, err := util.UnstructuredToCRDName(&repositoryUnstructuredMock)
-	if err != nil {
-		t.Fatal(err)
-	}
-	assert.Equal(t, repositoryCRDName, "resticrepositories.velero.io")
-
-	pvcUnstructuredMock:= unstructured.Unstructured{}
-	accessor.SetKind(&pvcUnstructuredMock, "PersistentVolumeClaim")
-	accessor.SetAPIVersion(&pvcUnstructuredMock,"v1")
-
-	pvcCRDName, err := util.UnstructuredToCRDName(&pvcUnstructuredMock)
-	if err != nil {
-		t.Fatal(err)
-	}
-	assert.Equal(t, pvcCRDName, "persistentvolumeclaims")
 }
 
 func TestGetS3SessionOptionsFromParamsMap(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Get rid of the dependency on the retrieval of the in cluster k8s config and enable running backup-driver/data-manager server in a local linux environment for the convenience of debugging.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

1. Moved the util functions about the CRD name parsing from pkg/utils to pkg/plugin/util to avoid the cyclic dependencies.
2. Passed basic regression test in all flavors of clusters.
3. Command to run backup-driver/data-manager locally. `<binary>` below can be substituted by `backup-driver` or `data-manager-for-plugin`.

```
VELERO_NAMESPACE=<velero ns in your cluster> KUBECONFIG=<the path of kubeconfig file> /path/to/<binary> server
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
Get rid of the dependency on the retrieval of the in cluster k8s config and support running backup-driver and data-manager both in-cluster and out-of-cluster.
```
