### PR TITLE
CSI 2.3 Support for velero plugin

### DIFF
--- a/pkg/cmd/backupdriver/cli/install/install.go
+++ b/pkg/cmd/backupdriver/cli/install/install.go
@@ -131,8 +131,13 @@ func (o *InstallOptions) Run(c *cobra.Command, f client.Factory) error {
 		return err
 	}
 
+	fmt.Printf("Detected Cluster type %s during BackupDriver install\n", clusterFlavor)
+
 	// Check vSphere CSI driver version
-	_ = cmd.CheckVSphereCSIDriverVersion(kubeClient, clusterFlavor)
+	err = cmd.CheckVSphereCSIDriverVersion(kubeClient, clusterFlavor)
+	if err != nil {
+		return err
+	}
 
 	// Check feature flags for backup-driver
 	if err := o.CheckFeatureFlagsForBackupDriver(kubeClient); err != nil {

--- a/pkg/cmd/backupdriver/cli/server/server.go
+++ b/pkg/cmd/backupdriver/cli/server/server.go
@@ -238,7 +238,10 @@ func newServer(f client.Factory, config serverConfig, logger *logrus.Logger) (*s
 	snapshotMgrConfig[constants.VolumeSnapshotterLocalMode] = strconv.FormatBool(utils.IsFeatureEnabled(constants.VSphereLocalModeFlag, false, logger))
 
 	// If CLUSTER_FLAVOR is GUEST_CLUSTER, set up svcKubeConfig to communicate with the Supervisor Cluster
-	clusterFlavor, _ := utils.GetClusterFlavor(clientConfig)
+	clusterFlavor, err := utils.GetClusterFlavor(clientConfig)
+	if err != nil {
+		return nil, err
+	}
 	var svcConfig *rest.Config
 	var svcBackupdriverClient *backupdriver_clientset.BackupdriverV1alpha1Client
 	var svcKubeInformerFactory kubeinformers.SharedInformerFactory

--- a/pkg/cmd/datamgr/cli/install/install.go
+++ b/pkg/cmd/datamgr/cli/install/install.go
@@ -148,6 +148,8 @@ func (o *InstallOptions) Run(c *cobra.Command, f client.Factory) error {
 	// Check cluster flavor for data-manager
 	clusterFlavor := o.CheckClusterFlavorForDataManager()
 
+	fmt.Printf("Detected Cluster type %s during DataManager install\n", clusterFlavor)
+
 	// Check feature flags for data-manager
 	_ = o.CheckFeatureFlagsForDataManager(kubeClient)
 
@@ -158,7 +160,10 @@ func (o *InstallOptions) Run(c *cobra.Command, f client.Factory) error {
 	}
 
 	// Check vSphere CSI driver version
-	_ = cmd.CheckVSphereCSIDriverVersion(kubeClient, clusterFlavor)
+	err = cmd.CheckVSphereCSIDriverVersion(kubeClient, clusterFlavor)
+	if err != nil {
+		return err
+	}
 
 	// Check velero version
 	_ = cmd.CheckVeleroVersion(kubeClient, o.Namespace)

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -16,7 +16,9 @@ limitations under the License.
 
 package constants
 
-import "time"
+import (
+	"time"
+)
 
 const (
 	// supported volume type in plugin
@@ -81,9 +83,6 @@ const (
 const (
 	// Minimum velero version number to meet velero plugin requirement
 	VeleroMinVersion = "v1.5.1"
-
-	// Minimum csi driver version number to meet velero plugin requirement
-	CsiMinVersion = "v1.0.2"
 )
 
 const (
@@ -99,13 +98,14 @@ const (
 )
 
 const (
-	DataManagerForPlugin   string = "data-manager-for-plugin"
-	BackupDriverForPlugin  string = "backup-driver"
-	BackupDriverNamespace  string = "velero-vsphere-plugin-backupdriver"
-	VeleroPluginForVsphere string = "velero-plugin-for-vsphere"
-	VeleroDeployment       string = "velero"
+	DataManagerForPlugin          = "data-manager-for-plugin"
+	BackupDriverForPlugin         = "backup-driver"
+	BackupDriverNamespace         = "velero-vsphere-plugin-backupdriver"
+	VeleroPluginForVsphere        = "velero-plugin-for-vsphere"
+	VeleroDeployment              = "velero"
 	VSphereCSIController          = "vsphere-csi-controller"
 	KubeSystemNamespace           = "kube-system"
+	VSphereCSIControllerNamespace = "vmware-system-csi"
 )
 
 const (
@@ -114,6 +114,7 @@ const (
 
 const (
 	VCSecretNs           = "kube-system"
+	VCSystemCSINs        = "vmware-system-csi"
 	VCSecretNsSupervisor = "vmware-system-csi"
 	VCSecret             = "vsphere-config-secret"
 	VCSecretTKG          = "csi-vsphere-config"
@@ -131,6 +132,13 @@ const (
 	Supervisor               = "Supervisor Cluster"
 	TkgGuest                 = "TKG Guest Cluster"
 	VSphere                  = "vSphere Kubernetes Cluster"
+)
+
+const (
+	CsiDevVersion    = "v0.0.0"
+	CsiMinVersion    = "v1.0.2"
+	Csi2_3_0_Version = "v2.3.0"
+	Csi2_0_0_Version = "v2.0.0"
 )
 
 // feature flog constants
@@ -179,54 +187,54 @@ const (
 // words get an "s" attached.
 var ResourcesToBlock = map[string]bool{
 	// Kubernetes with vSphere Supervisor Cluster resources
-	"agentinstalls.installers.tmc.cloud.vmware.com":           true,
-	"aviloadbalancerconfigs.netoperator.vmware.com":           true,
-	"blockaffinities.crd.projectcalico.org":                   true,
-	"certificaterequests.cert-manager.io":                     true,
-	"certificates.cert-manager.io":                            true,
-	"challenges.acme.cert-manager.io":                         true,
-	"clusterissuers.cert-manager.io":                          true,
-	"clusterresourcesetbindings.addons.cluster.x-k8s.io":      true,
-	"clusterresourcesets.addons.cluster.x-k8s.io":             true,
-	"clusters.cluster.x-k8s.io":                               true,
-	"cnsnodevmattachments.cns.vmware.com":                     true,
-	"cnsregistervolumes.cns.vmware.com":                       true,
-	"cnsvolumemetadatas.cns.vmware.com":                       true,
-	"compatibilities.run.tanzu.vmware.com":                    true,
-	"contentlibraryproviders.vmoperator.vmware.com":           true,
-	"contentsourcebindings.vmoperator.vmware.com":             true,
-	"contentsources.vmoperator.vmware.com":                    true,
-	"gatewayclasses.networking.x-k8s.io":                      true,
-	"gateways.networking.x-k8s.io":                            true,
-	"haproxyloadbalancerconfigs.netoperator.vmware.com":       true,
-	"httproutes.networking.x-k8s.io":                          true,
-	"imagedisks.imagecontroller.vmware.com":                   true,
+	"agentinstalls.installers.tmc.cloud.vmware.com":      true,
+	"aviloadbalancerconfigs.netoperator.vmware.com":      true,
+	"blockaffinities.crd.projectcalico.org":              true,
+	"certificaterequests.cert-manager.io":                true,
+	"certificates.cert-manager.io":                       true,
+	"challenges.acme.cert-manager.io":                    true,
+	"clusterissuers.cert-manager.io":                     true,
+	"clusterresourcesetbindings.addons.cluster.x-k8s.io": true,
+	"clusterresourcesets.addons.cluster.x-k8s.io":        true,
+	"clusters.cluster.x-k8s.io":                          true,
+	"cnsnodevmattachments.cns.vmware.com":                true,
+	"cnsregistervolumes.cns.vmware.com":                  true,
+	"cnsvolumemetadatas.cns.vmware.com":                  true,
+	"compatibilities.run.tanzu.vmware.com":               true,
+	"contentlibraryproviders.vmoperator.vmware.com":      true,
+	"contentsourcebindings.vmoperator.vmware.com":        true,
+	"contentsources.vmoperator.vmware.com":               true,
+	"gatewayclasses.networking.x-k8s.io":                 true,
+	"gateways.networking.x-k8s.io":                       true,
+	"haproxyloadbalancerconfigs.netoperator.vmware.com":  true,
+	"httproutes.networking.x-k8s.io":                     true,
+	"imagedisks.imagecontroller.vmware.com":              true,
 	//"images.imagecontroller.vmware.com":                     true, // DO NOT ADD IT BACK
-	"installoptions.appplatform.wcp.vmware.com":               true,
-	"installrequirements.appplatform.wcp.vmware.com":          true,
-	"ipamblocks.crd.projectcalico.org":                        true,
-	"ipamconfigs.crd.projectcalico.org":                       true,
-	"ipamhandles.crd.projectcalico.org":                       true,
-	"ippools.crd.projectcalico.org":                           true,
-	"ippools.netoperator.vmware.com":                          true,
-	"issuers.cert-manager.io":                                 true,
-	"kubeadmconfigs.bootstrap.cluster.x-k8s.io":               true,
-	"kubeadmconfigtemplates.bootstrap.cluster.x-k8s.io":       true,
-	"kubeadmcontrolplanes.controlplane.cluster.x-k8s.io":      true,
-	"kuberneteslicenses.licenseoperator.vmware.com":           true,
-	"loadbalancerconfigs.netoperator.vmware.com":              true,
-	"loadbalancers.vmware.com":                                true,
-	"machinedeployments.cluster.x-k8s.io":                     true,
-	"machinehealthchecks.cluster.x-k8s.io":                    true,
-	"machinepools.exp.cluster.x-k8s.io":                       true,
-	"machines.cluster.x-k8s.io":                               true,
-	"machinesets.cluster.x-k8s.io":                            true,
-	"members.registryagent.vmware.com":                        true,
-	"ncpconfigs.nsx.vmware.com":                               true,
-	"network-attachment-definitions.k8s.cni.cncf.io":          true,
-	"networkinterfaces.netoperator.vmware.com":                true,
-	"networks.netoperator.vmware.com":                         true,
-	"nsxerrors.nsx.vmware.com":                                true,
+	"installoptions.appplatform.wcp.vmware.com":          true,
+	"installrequirements.appplatform.wcp.vmware.com":     true,
+	"ipamblocks.crd.projectcalico.org":                   true,
+	"ipamconfigs.crd.projectcalico.org":                  true,
+	"ipamhandles.crd.projectcalico.org":                  true,
+	"ippools.crd.projectcalico.org":                      true,
+	"ippools.netoperator.vmware.com":                     true,
+	"issuers.cert-manager.io":                            true,
+	"kubeadmconfigs.bootstrap.cluster.x-k8s.io":          true,
+	"kubeadmconfigtemplates.bootstrap.cluster.x-k8s.io":  true,
+	"kubeadmcontrolplanes.controlplane.cluster.x-k8s.io": true,
+	"kuberneteslicenses.licenseoperator.vmware.com":      true,
+	"loadbalancerconfigs.netoperator.vmware.com":         true,
+	"loadbalancers.vmware.com":                           true,
+	"machinedeployments.cluster.x-k8s.io":                true,
+	"machinehealthchecks.cluster.x-k8s.io":               true,
+	"machinepools.exp.cluster.x-k8s.io":                  true,
+	"machines.cluster.x-k8s.io":                          true,
+	"machinesets.cluster.x-k8s.io":                       true,
+	"members.registryagent.vmware.com":                   true,
+	"ncpconfigs.nsx.vmware.com":                          true,
+	"network-attachment-definitions.k8s.cni.cncf.io":     true,
+	"networkinterfaces.netoperator.vmware.com":           true,
+	"networks.netoperator.vmware.com":                    true,
+	"nsxerrors.nsx.vmware.com":                           true,
 	//"nsxlbmonitors.vmware.com":                              true, // DO NOT ADD IT BACK
 	//"nsxloadbalancermonitors.vmware.com":                    true, // DO NOT ADD IT BACK
 	"nsxlocks.nsx.vmware.com":                                 true,


### PR DESCRIPTION
**What this PR does / why we need it**:
Support for CSI 2.3 vSphere driver

There 2 major fixes:
1. **How cluster flavor is determined.**

In the current implementation, the cluster flavor needs to be determined first, if the cluster flavor is vanilla then we validate the csi driver version and also determine which Secret to watch for VC configuration.

In the older logic, the cluster flavor was determined based on the namespace and secret available, if the secret named `vsphere-config-secret` or `csi-vsphere-config` is found in `kube-system` then it's assumed to be a Vanilla setup. If a secret named `vsphere-config-secret` is found `vmware-system-csi` namespace then it's assumed to be a Supervisor flavor. And for Guest, we check if there is Service named `supervisor` in `default` namespace.

With CSI 2.3, since the relevant secrets are deployed in `vmware-system-csi` namespace for both Vanilla and Supervisor the same logic cannot be used to determine the cluster flavor. In the current fix, we see the environment variables of the csi deployment to determine the cluster flavor.

2. **Fix to determine which Secret to watch.**

Fix to watch for vc config secret in vmware-system-csi namespace for vanilla setups.
The secret location is the same for wcp setups, no change is necessary.

Additional Fixes made:
1. Refactored code to move methods into utils.go to prevent circular dependency.
2. Version check on driver only.
3. Previously errors were being ignored during startup when csi driver was not present or incompatible, fixed it.
4. Added Unit tests.
**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #DPCP-445

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
Fix to determine cluster type from vsphere-csi-controller deployment
Fix is to watch for vc config secret in vmware-system-csi namespace for vanilla setups.
The secret location is the same for wcp setups, no change is necessary. 
A restart of backup-driver and data-manager is necessary when csi driver is upgraded to 2.3.
```

**Testing Done**
1. No regression on vanilla setups.
2. Verified the plugin can be installed when 2.3 csi driver is installed.

Logs:
time="2021-05-18T19:48:13Z" level=info msg="CSI version : v2.3.0 for VC configuration Secret watch." logSource="/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/utils/utils.go:962"
time="2021-05-18T19:48:13Z" level=info msg="VC Configuration Secret: Namespace: vmware-system-csi Name: vsphere-config-secret" logSource="/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/utils/utils.go:969"


Signed-off-by: Deepak Kinni <dkinni@vmware.com>