### PR TITLE
Move Snapshot/DeleteSnapshot/CloneFromSnapshot into Failed state on error

### DIFF
--- a/pkg/plugin/restore_pvc_action_plugin.go
+++ b/pkg/plugin/restore_pvc_action_plugin.go
@@ -192,7 +192,7 @@ func (p *NewPVCRestoreItemAction) Execute(input *velero.RestoreItemActionExecute
 		p.Log.Error(errMsg)
 		return nil, errors.New(errMsg)
 	}
-	p.Log.Info("Restored, %v, from PVC %s/%s in the backup to PVC %s/%s", updatedCloneFromSnapshot.Status.ResourceHandle, pvc.Namespace, pvc.Name, targetNamespace, pvc.Name)
+	p.Log.Infof("Restored, %v, from PVC %s/%s in the backup to PVC %s/%s", updatedCloneFromSnapshot.Status.ResourceHandle, pvc.Namespace, pvc.Name, targetNamespace, pvc.Name)
 
 	return &velero.RestoreItemActionExecuteOutput{
 		SkipRestore: true,

--- a/pkg/snapshotUtils/local_snapshot.go
+++ b/pkg/snapshotUtils/local_snapshot.go
@@ -1,1 +1,0 @@
-package snapshotUtils

--- a/pkg/snapshotmgr/snapshot_manager.go
+++ b/pkg/snapshotmgr/snapshot_manager.go
@@ -281,6 +281,11 @@ func (this *SnapshotManager) createSnapshot(peID astrolabe.ProtectedEntityID, ta
 		return snapshotPEID, svcSnapshotName, nil
 	}
 	snapshotPE, err := this.Pem.GetProtectedEntity(ctx, snapshotPEID)
+	if err != nil {
+		this.Errorf("Failed to get the PE from the snapshotPEID %s", snapshotPEID)
+		return snapshotPEID, svcSnapshotName, err
+	}
+	// Create the Upload CR.
 	_, err = this.UploadSnapshot(snapshotPE, ctx, backupRepositoryName, snapshotRef)
 	if err != nil {
 		this.Errorf("Failed to create Upload CR for snapshot PEID %s, Supervisor Cluster snapshot name %s: %v", snapshotPEID.String(), svcSnapshotName, err)
@@ -502,7 +507,8 @@ func (this *SnapshotManager) deleteSnapshot(peID astrolabe.ProtectedEntityID, ba
 
 	log.Infof("Step 2: Deleting the durable snapshot from s3")
 	if backupRepositoryName != "" && backupRepositoryName != constants.WithoutBackupRepository {
-		backupRepositoryCR, err := pluginClient.BackupdriverV1alpha1().BackupRepositories().Get(context.TODO(), backupRepositoryName, metav1.GetOptions{})
+		var backupRepositoryCR *backupdriverv1.BackupRepository
+		backupRepositoryCR, err = pluginClient.BackupdriverV1alpha1().BackupRepositories().Get(context.TODO(), backupRepositoryName, metav1.GetOptions{})
 		if err != nil {
 			log.WithError(err).Errorf("Error while retrieving the backup repository CR %v", backupRepositoryName)
 			return err


### PR DESCRIPTION
**What this PR does / why we need it**:
In the current code, any failures that occur prior to the actual snapshot/clone/deletesnapshot operation do not move the associated CRDs into a Failed state. This leads to a situation where the plugin waits for either Completed or Failed state, but since the errors do not move the CRD into failed state, there is a possibility of the backup delete/create/restore operation becomes hung. The primary motive of this change is to move the CRDs into a terminal state.

**Testing Done:**
https://container-dp.svc.eng.vmware.com/job/Container_Precheck_Velero/1049/

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
NONE
```
Signed-off-by: Deepak Kinni <dkinni@vmware.com>