### PR TITLE
Fix plugin image tag from 1.1.0 to v1.1.0

### DIFF
--- a/docs/guest.md
+++ b/docs/guest.md
@@ -36,11 +36,12 @@ Currently, only AWS plugin is supported and compatible with vSphere plugin. Plea
 velero plugin add <plugin-image>
 ```
 
-For Version 1.1.0 the command is
+For Version 1.1.1 the command is
 
 ```bash
-velero plugin add vsphereveleroplugin/velero-plugin-for-vsphere:1.1.0
+velero plugin add vsphereveleroplugin/velero-plugin-for-vsphere:v1.1.1
 ```
+Please refer to [velero-plugin-for-vsphere tags](https://github.com/vmware-tanzu/velero-plugin-for-vsphere/tags) for correct tags for versions 1.1.1 and higher.
 
 * The installation of Velero vSphere Plugin in Guest Cluster may take over ten minutes to complete, this is primarily because the plugin waits for the Velero app operator to write the Secret into a predefined namespace.
 * The installation may hang forever if Velero is not installed in the Supervisor Cluster.

--- a/docs/vanilla.md
+++ b/docs/vanilla.md
@@ -47,11 +47,12 @@ Currently, only AWS plugin is supported and compatible with vSphere plugin. Plea
 velero plugin add <plugin-image>
 ```
 
-For Version 1.1.0 the command is
+For Version 1.1.1 the command is
 
 ```bash
-velero plugin add vsphereveleroplugin/velero-plugin-for-vsphere:1.1.0
+velero plugin add vsphereveleroplugin/velero-plugin-for-vsphere:v1.1.1
 ```
+Please refer to [velero-plugin-for-vsphere tags](https://github.com/vmware-tanzu/velero-plugin-for-vsphere/tags) for correct tags for versions 1.1.1 and higher.
 
 ## Uninstall
 


### PR DESCRIPTION
Signed-off-by: xinyanw409 <wxinyan@vmware.com>

**What this PR does / why we need it**:
Fix plugin install command and change the image tag from "1.1.0" to "v1.1.0" in readme so it won't confuse users.
**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #355 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
NONE
```
