### PR TITLE
Do not retrieve supervisor BackupRepository when it is unsepcified

### DIFF
--- a/pkg/backupdriver/backup_driver_controller.go
+++ b/pkg/backupdriver/backup_driver_controller.go
@@ -203,7 +203,10 @@ func (ctrl *backupDriverController) deleteSnapshot(deleteSnapshot *backupdrivera
 	}
 
 	brName := deleteSnapshot.Spec.BackupRepository
-	if ctrl.svcKubeConfig != nil {
+	// Backups created in Guest Cluster when local-mode is set do not exercise the Backup Repository claims workflow, as
+	// a result, the Backup Repository is unset. If the Backup Repository is observed unset when deleting the backup
+	// then there is no need to retrieve the corresponding supervisor Backup Repository as it is implied local-mode.
+	if ctrl.svcKubeConfig != nil && brName!= "" {
 		// For guest cluster, get the supervisor backup repository name
 		br, err := ctrl.backupdriverClient.BackupRepositories().Get(ctx, brName, metav1.GetOptions{})
 		if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Backups created in Guest Cluster when local-mode is set do not exercise the Backup Repository claims workflow, as a result, the Backup Repository is unset. If the Backup Repository is observed unset when deleting the backup then there is no need to retrieve the corresponding supervisor Backup Repository as it is implied local-mode. 

**Testing**

Repro on v1.2.0
```
dkinni@dkinni-a02 ~ % velero backup create tkg-bk-1 --include-namespaces=demo-app --snapshot-volumes
Backup request "tkg-bk-1" submitted successfully.
Run `velero backup describe tkg-bk-1` or `velero backup logs tkg-bk-1` for more details.
dkinni@dkinni-a02 ~ % kubectl get snapshots -n demo-app snap-75cb9f53-a053-4ee0-a706-27df7ff198ce -o=custom-columns='Name:metadata.name,Status:status.phase'
Name                                        Status
snap-75cb9f53-a053-4ee0-a706-27df7ff198ce   Snapshotted

dkinni@dkinni-a02 ~ % velero delete backup tkg-bk-1
Are you sure you want to continue (Y/N)? Y
Request to delete backup "tkg-bk-1" submitted successfully.
The backup will be fully deleted after all associated data (disk snapshots, backup files, restores) are removed.

GC backup-driver logs:
time="2021-08-02T18:26:36Z" level=info msg="Calling Snapshot Manager to delete snapshot with snapshotID pvc:demo-app/nginx-logs:cGFyYXZpcnQtcHY6cHZjLThlNjIxMDc1LWNlOTItNDhlNy1hNzY1LWNiNTYxOWYyMzcwMzphWFprT2pReFpXSTVNemhtTFdFNFlXTXROR1JsTWkxaU1qYzRMVFV3TmpFNE1UTTNaR05oWkRwaFlXSTJNak13T0Mwd1pqVTFMVFF4WkRFdE9HSTFZeTFrWVdWalkyTTFaV1JrWkdF" controller=BackupDriverController logSource="/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/backupdriver/backup_driver_controller.go:173"
2021/08/02 18:26:36 pei = pvc:demo-app/nginx-logs:cGFyYXZpcnQtcHY6cHZjLThlNjIxMDc1LWNlOTItNDhlNy1hNzY1LWNiNTYxOWYyMzcwMzphWFprT2pReFpXSTVNemhtTFdFNFlXTXROR1JsTWkxaU1qYzRMVFV3TmpFNE1UTTNaR05oWkRwaFlXSTJNak13T0Mwd1pqVTFMVFF4WkRFdE9HSTFZeTFrWVdWalkyTTFaV1JrWkdF
time="2021-08-02T18:26:36Z" level=error msg="deleteSnapshot PreDeleteSnapshot: Failed to get delete snapshot Backup Repository " controller=BackupDriverController logSource="/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/backupdriver/backup_driver_controller.go:211"
time="2021-08-02T18:26:36Z" level=info msg="updateDeleteSnapshotStatusPhase: DeleteSnapshot velero/delete-344527c1-77df-4e02-9712-45c37383bf2c updated phase from New to Failed" controller=BackupDriverController logSource="/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/backupdriver/backup_driver_controller.go:411"

dkinni@dkinni-a02 ~ % kubectl get deletesnapshots delete-344527c1-77df-4e02-9712-45c37383bf2c -n velero -o=custom-columns='Name:metadata.name,Status:status.phase' 
Name                                          Status
delete-344527c1-77df-4e02-9712-45c37383bf2c   Failed
```

Fix Verification:
```
dkinni@dkinni-a02 ~ % velero backup create tkg-bk-2 --include-namespaces=demo-app --snapshot-volumes
Backup request "tkg-bk-2" submitted successfully.
Run `velero backup describe tkg-bk-2` or `velero backup logs tkg-bk-2` for more details.
dkinni@dkinni-a02 ~ % kubectl get snapshots -n demo-app snap-aabf2852-13cb-4216-b868-22a13c258cb4 -o=custom-columns='Name:metadata.name,Status:status.phase'
Name                                        Status
snap-aabf2852-13cb-4216-b868-22a13c258cb4   Snapshotted

dkinni@dkinni-a02 ~ % velero delete backup tkg-bk-2
Are you sure you want to continue (Y/N)? Y
Request to delete backup "tkg-bk-2" submitted successfully.
The backup will be fully deleted after all associated data (disk snapshots, backup files, restores) are removed.


GC backup-driver logs:
time="2021-08-02T18:41:56Z" level=info msg="deleteSnapshot changed: &{{ } {delete-1af0af82-18db-4490-9313-ba2ac8f3fe66  test-gc-e2e-demo-ns-yzizfrv /apis/backupdriver.cnsdp.vmware.com/v1alpha1/namespaces/test-gc-e2e-demo-ns-yzizfrv/deletesnapshots/delete-1af0af82-18db-4490-9313-ba2ac8f3fe66 0be113ca-a522-4a0b-9ec3-5ae6625aa66c 571693 1 2021-08-02 18:41:42 +0000 UTC <nil> <nil> map[velero.io/exclude-from-backup:true] map[] [] []  [{backup-driver Update backupdriver.cnsdp.vmware.com/v1alpha1 2021-08-02 18:41:42 +0000 UTC FieldsV1 &FieldsV1{Raw:*[123 34 102 58 109 101 116 97 100 97 116 97 34 58 123 34 102 58 108 97 98 101 108 115 34 58 123 34 46 34 58 123 125 44 34 102 58 118 101 108 101 114 111 46 105 111 47 101 120 99 108 117 100 101 45 102 114 111 109 45 98 97 99 107 117 112 34 58 123 125 125 125 44 34 102 58 115 112 101 99 34 58 123 34 46 34 58 123 125 44 34 102 58 98 97 99 107 117 112 82 101 112 111 115 105 116 111 114 121 34 58 123 125 44 34 102 58 115 110 97 112 115 104 111 116 73 68 34 58 123 125 125 44 34 102 58 115 116 97 116 117 115 34 58 123 125 125],}} {backup-driver-server Update backupdriver.cnsdp.vmware.com/v1alpha1 2021-08-02 18:41:58 +0000 UTC FieldsV1 &FieldsV1{Raw:*[123 34 102 58 115 116 97 116 117 115 34 58 123 34 102 58 99 111 109 112 108 101 116 105 111 110 84 105 109 101 115 116 97 109 112 34 58 123 125 44 34 102 58 109 101 115 115 97 103 101 34 58 123 125 44 34 102 58 112 104 97 115 101 34 58 123 125 125 125],}}]} {pvc:test-gc-e2e-demo-ns-yzizfrv/pvc-8e621075-ce92-48e7-a765-cb5619f23703:aXZkOjQxZWI5MzhmLWE4YWMtNGRlMi1iMjc4LTUwNjE4MTM3ZGNhZDozMWQ4NmQ1Yy1mYjcyLTQyMzMtODRiNC1hNjAzNzg3NDExMjY } {Completed DeleteSnapshot Successfully processed. 2021-08-02 18:41:58 +0000 UTC}}" logSource="/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/snapshotUtils/delete_snapshot.go:113"
time="2021-08-02T18:41:56Z" level=info msg="phase = Completed" logSource="/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/snapshotUtils/delete_snapshot.go:114"
time="2021-08-02T18:41:56Z" level=info msg="Created Supervisor DeleteSnapshot: delete-1af0af82-18db-4490-9313-ba2ac8f3fe66 for Guest DeleteSnapshot: delete-d794992f-e410-4590-871e-3bf2cf181ae4" logSource="/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/paravirt/paravirt_protected_entity.go:146"
time="2021-08-02T18:41:56Z" level=info msg="PVCProtectedEntity: Completed DeleteSnapshot with snapshotID: cGFyYXZpcnQtcHY6cHZjLThlNjIxMDc1LWNlOTItNDhlNy1hNzY1LWNiNTYxOWYyMzcwMzphWFprT2pReFpXSTVNemhtTFdFNFlXTXROR1JsTWkxaU1qYzRMVFV3TmpFNE1UTTNaR05oWkRvek1XUTRObVExWXkxbVlqY3lMVFF5TXpNdE9EUmlOQzFoTmpBek56ZzNOREV4TWpZ for the component: paravirt-pv:pvc-8e621075-ce92-48e7-a765-cb5619f23703:aXZkOjQxZWI5MzhmLWE4YWMtNGRlMi1iMjc4LTUwNjE4MTM3ZGNhZDozMWQ4NmQ1Yy1mYjcyLTQyMzMtODRiNC1hNjAzNzg3NDExMjY" logSource="/go/pkg/mod/github.com/vmware-tanzu/astrolabe@v0.4.0/pkg/pvc/pvc_protected_entity.go:214"
time="2021-08-02T18:41:56Z" level=info msg="Successfully deleted local snapshot for PE: pvc:demo-app/nginx-logs:cGFyYXZpcnQtcHY6cHZjLThlNjIxMDc1LWNlOTItNDhlNy1hNzY1LWNiNTYxOWYyMzcwMzphWFprT2pReFpXSTVNemhtTFdFNFlXTXROR1JsTWkxaU1qYzRMVFV3TmpFNE1UTTNaR05oWkRvek1XUTRObVExWXkxbVlqY3lMVFF5TXpNdE9EUmlOQzFoTmpBek56ZzNOREV4TWpZ" logSource="/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/snapshotmgr/snapshot_manager.go:487" peID="pvc:demo-app/nginx-logs:cGFyYXZpcnQtcHY6cHZjLThlNjIxMDc1LWNlOTItNDhlNy1hNzY1LWNiNTYxOWYyMzcwMzphWFprT2pReFpXSTVNemhtTFdFNFlXTXROR1JsTWkxaU1qYzRMVFV3TmpFNE1UTTNaR05oWkRvek1XUTRObVExWXkxbVlqY3lMVFF5TXpNdE9EUmlOQzFoTmpBek56ZzNOREV4TWpZ"
time="2021-08-02T18:41:56Z" level=info msg="Guest Cluster detected during delete snapshot, nothing more to do." logSource="/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/snapshotmgr/snapshot_manager.go:490" peID="pvc:demo-app/nginx-logs:cGFyYXZpcnQtcHY6cHZjLThlNjIxMDc1LWNlOTItNDhlNy1hNzY1LWNiNTYxOWYyMzcwMzphWFprT2pReFpXSTVNemhtTFdFNFlXTXROR1JsTWkxaU1qYzRMVFV3TmpFNE1UTTNaR05oWkRvek1XUTRObVExWXkxbVlqY3lMVFF5TXpNdE9EUmlOQzFoTmpBek56ZzNOREV4TWpZ"
time="2021-08-02T18:41:56Z" level=info msg="updateDeleteSnapshotStatusPhase: DeleteSnapshot velero/delete-d794992f-e410-4590-871e-3bf2cf181ae4 updated phase from New to Completed" controller=BackupDriverController logSource="/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/backupdriver/backup_driver_controller.go:414"
time="2021-08-02T18:41:56Z" level=info msg="deleteSnapshot: update status for SnapshotID: pvc:demo-app/nginx-logs:cGFyYXZpcnQtcHY6cHZjLThlNjIxMDc1LWNlOTItNDhlNy1hNzY1LWNiNTYxOWYyMzcwMzphWFprT2pReFpXSTVNemhtTFdFNFlXTXROR1JsTWkxaU1qYzRMVFV3TmpFNE1UTTNaR05oWkRvek1XUTRObVExWXkxbVlqY3lMVFF5TXpNdE9EUmlOQzFoTmpBek56ZzNOREV4TWpZ Namespace: velero Name: delete-d794992f-e410-4590-871e-3bf2cf181ae4, Completed" controller=BackupDriverController logSource="/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/backupdriver/backup_driver_controller.go:251"


dkinni@dkinni-a02 ~ % kubectl get deletesnapshots delete-d794992f-e410-4590-871e-3bf2cf181ae4 -n velero -o=custom-columns='Name:metadata.name,Status:status.phase'
Name                                          Status
delete-d794992f-e410-4590-871e-3bf2cf181ae4   Completed
```


**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note

```
Signed-off-by: Deepak Kinni <dkinni@vmware.com>