### PR TITLE
[Cherry-pick]Do not retrieve supervisor BackupRepository when it is unsepcified (#373)

### DIFF
--- a/pkg/backupdriver/backup_driver_controller.go
+++ b/pkg/backupdriver/backup_driver_controller.go
@@ -203,7 +203,10 @@ func (ctrl *backupDriverController) deleteSnapshot(deleteSnapshot *backupdrivera
 	}
 
 	brName := deleteSnapshot.Spec.BackupRepository
-	if ctrl.svcKubeConfig != nil {
+	// Backups created in Guest Cluster when local-mode is set do not exercise the Backup Repository claims workflow, as
+	// a result, the Backup Repository is unset. If the Backup Repository is observed unset when deleting the backup
+	// then there is no need to retrieve the corresponding supervisor Backup Repository as it is implied local-mode.
+	if ctrl.svcKubeConfig != nil && brName!= "" {
 		// For guest cluster, get the supervisor backup repository name
 		br, err := ctrl.backupdriverClient.BackupRepositories().Get(ctx, brName, metav1.GetOptions{})
 		if err != nil {


### PR DESCRIPTION
Backups created in Guest Cluster when local-mode is set do not exercise the Backup Repository claims workflow, as a result, the Backup Repository is unset. If the Backup Repository is observed unset when deleting the backup then there is no need to retrieve the corresponding supervisor Backup Repository as it is implied local-mode.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
The fix is a cherry-pick of PR 373. Do not retrieve supervisor BackupRepository when it is unspecified.
```
Signed-off-by: Deepak Kinni <dkinni@vmware.com>