### PR TITLE
Updated the default image registry to the official registry for the fall-back mechanism

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -106,6 +106,10 @@ const (
 	VSphereCSIController          = "vsphere-csi-controller"
 	KubeSystemNamespace           = "kube-system"
 	VSphereCSIControllerNamespace = "vmware-system-csi"
+	// Default image registry for the fall-back mechanism in the image-parsing workflow
+	// when installing backup-driver and data-manager-for-plug while installing velero-plugin-for-vsphere.
+	// Make sure to update it accordingly if the official image registry gets migrated.
+	DefaultImageRegistry          = "vsphereveleroplugin"
 )
 
 const (

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -105,7 +105,7 @@ func imageVersion() string {
 
 func imageRegistry() string {
 	if buildinfo.Registry == "" {
-		return "dpcpinternal"
+		return constants.DefaultImageRegistry
 	}
 	return buildinfo.Registry
 }


### PR DESCRIPTION
Signed-off-by: Lintong Jiang <lintongj@vmware.com>

**What this PR does / why we need it**:

When install velero-plugin-for-vsphere, the matching backup-driver/data-manager images are parsed from the image specified in the initContainer section in velero deployment object. If there's any issue in parsing, there is a fall-back mechanism and it would fall back to use some default backup-driver/data-manager images. Currently, the default images are set to ones from dev registry (**dpcpinternal**), which is unexpected and confusing from users' point of view.

In this change, updating the fall back mechanism to images from the official regisry(**velerovsphereplugin**). 

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
Updated the default image registry to the official registry for the fall-back mechanism
```
