### PR TITLE
Update to use distroless image

### DIFF
--- a/Dockerfile-backup-driver
+++ b/Dockerfile-backup-driver
@@ -12,13 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:focal
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends ca-certificates wget bzip2 && \
-    apt-get remove -y wget bzip2 && \
-    rm -rf /var/lib/apt/lists/*
-RUN mkdir /vddkLibs
+FROM gcr.io/distroless/base-debian10:nonroot
 COPY /bin/linux/amd64/lib/vmware-vix-disklib/lib64/* /vddkLibs/
 ADD /bin/linux/amd64/backup-driver* /backup-driver
-USER nobody:nogroup
+USER nonroot:nonroot
 ENTRYPOINT ["/backup-driver"]

--- a/Dockerfile-datamgr
+++ b/Dockerfile-datamgr
@@ -12,13 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:focal
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends ca-certificates wget bzip2 && \
-    apt-get remove -y wget bzip2 && \
-    rm -rf /var/lib/apt/lists/*
+FROM gcr.io/distroless/base-debian10:nonroot
 ADD /bin/linux/amd64/data-* /datamgr
-RUN mkdir /vddkLibs
 COPY /bin/linux/amd64/lib/vmware-vix-disklib/lib64/* /vddkLibs/
-USER nobody:nogroup
+USER nonroot:nonroot
 ENTRYPOINT ["/datamgr"]

--- a/Dockerfile-plugin
+++ b/Dockerfile-plugin
@@ -12,15 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:focal
-RUN mkdir /plugins
-RUN mkdir /scripts
+FROM busybox:1.33.1 AS busybox
+
+FROM gcr.io/distroless/base-debian10:nonroot
 ADD /bin/linux/amd64/velero-* /plugins/
 ADD /bin/linux/amd64/data-* /
 ADD /bin/linux/amd64/backup-driver* /
 COPY /bin/linux/amd64/install.sh /scripts/
 COPY /bin/linux/amd64/lib/vmware-vix-disklib/lib64/* /plugins/
 ENV LD_LIBRARY_PATH=/plugins
+COPY --from=busybox /bin/sh /bin/sh
+COPY --from=busybox /bin/chmod /bin/chmod
+COPY --from=busybox /bin/cp /bin/cp
+USER root
 RUN ["chmod", "+x", "/scripts/install.sh"]
-USER nobody:nogroup
-ENTRYPOINT ["/scripts/install.sh"]
+USER nonroot:nonroot
+ENTRYPOINT ["/bin/sh","/scripts/install.sh"]


### PR DESCRIPTION
Signed-off-by: xinyanw409 <wxinyan@vmware.com>

**What this PR does / why we need it**:
Update to use  ubuntu:distroless base image from ubunu:focal base image. 
**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #382 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
Update to use distroless base image.
```
