### PR TITLE
Move ivd Astrolabe plugin into Velero Plugin for vSphere

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ VDDK_LIBS:= $(LIB_DIR)/vmware-vix-disklib-distrib/lib64
 PLUGIN_BIN ?= velero-plugin-for-vsphere
 DATAMGR_BIN ?= data-manager-for-plugin
 BACKUPDRIVER_BIN ?= backup-driver
+VSPHERE_ASTROLABE ?= vsphere-astrolabe
 
 RELEASE_REGISTRY = vsphereveleroplugin
 REGISTRY ?= dpcpinternal
@@ -62,7 +63,7 @@ PLUGIN_DOCKERFILE ?= Dockerfile-plugin
 DATAMGR_DOCKERFILE ?= Dockerfile-datamgr
 BACKUPDRIVER_DOCKERFILE ?= Dockerfile-backup-driver
 
-all: dep plugin
+all: dep plugin vsphere-astrolabe
 
 dep:
 ifeq (,$(wildcard $(GOPATH)/src/$(VDDK_LIBS)))
@@ -80,6 +81,10 @@ datamgr:
 backup-driver:
 	@echo "making: $@"
 	$(MAKE) build BIN=$(BACKUPDRIVER_BIN) VERSION=$(VERSION)
+
+vsphere-astrolabe:
+	@echo "making: $@"
+	$(MAKE) build BIN=$(VSPHERE_ASTROLABE) VERSION=$(VERSION)
 
 local: build-dirs
 	GOOS=$(GOOS) \

--- a/cmd/vsphere-astrolabe/main.go
+++ b/cmd/vsphere-astrolabe/main.go
@@ -1,0 +1,29 @@
+/*
+ * Copyright the Astrolabe contributors
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package main
+
+import (
+	"github.com/vmware-tanzu/astrolabe/pkg/cmd"
+	"github.com/vmware-tanzu/astrolabe/pkg/server"
+	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/ivd"
+)
+
+func main() {
+	addonInits := map[string]server.InitFunc{
+		"ivd": ivd.NewIVDProtectedEntityTypeManager,
+	}
+	cmd.CliCore(addonInits)
+}

--- a/go.mod
+++ b/go.mod
@@ -14,8 +14,10 @@ require (
 	github.com/spf13/cobra v0.0.6
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.4.0
-	github.com/vmware-tanzu/astrolabe v0.4.0
+	github.com/vmware-tanzu/astrolabe v0.4.1-0.20210813185044-12eb18c3f6d5
 	github.com/vmware-tanzu/velero v1.5.1
+	github.com/vmware/govmomi v0.22.2-0.20200329013745-f2eef8fc745f
+	github.com/vmware/virtual-disks v0.0.4
 	k8s.io/api v0.18.4
 	k8s.io/apiextensions-apiserver v0.18.4
 	k8s.io/apimachinery v0.18.4

--- a/go.sum
+++ b/go.sum
@@ -138,8 +138,10 @@ github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180108230652-97fdf19511ea/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
+github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF22jk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/cpuguy83/go-md2man/v2 v2.0.0 h1:EoUDS0afbrsXAZ9YQ9jdu/mZ2sXgT1/2yyNng4PGlyM=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -159,6 +161,7 @@ github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4Kfc
 github.com/docker/docker v0.7.3-0.20190327010347-be7ac8be2ae0/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.3.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
+github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/libnetwork v0.8.0-dev.2.0.20190925143933-c8a5fca4a652/go.mod h1:93m0aTqz6z+g32wla4l4WxTrdtvBRmVzYRkYvasA5Z8=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
@@ -443,6 +446,7 @@ github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jellevandenhooff/dkim v0.0.0-20150330215556-f50fe3d243e1/go.mod h1:E0B/fFc00Y+Rasa88328GlI/XbtyysCtTHZS8h7IrBU=
+github.com/jessevdk/go-flags v1.4.0 h1:4IU2WS7AumrZ/40jfhf4QVDMsQwqA7VEHozFRrGARJA=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a/go.mod h1:wK6yTYYcgjHE1Z1QtXACPDjcFJyBskHEdagmnq3vsP8=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
@@ -643,7 +647,9 @@ github.com/rogpeppe/go-internal v1.2.2/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rubiojr/go-vhd v0.0.0-20160810183302-0bfd3b39853c/go.mod h1:DM5xW0nvfNNm2uytzsvhI3OnX8uzaRAg8UX/CnDqbto=
 github.com/russross/blackfriday v0.0.0-20170610170232-067529f716f4/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
+github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
+github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/go-glob v0.0.0-20170128012129-256dc444b735/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
@@ -654,6 +660,7 @@ github.com/shirou/gopsutil v0.0.0-20180427012116-c95755e4bcd7/go.mod h1:5b4v6he4
 github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4/go.mod h1:qsXQc7+bwAM3Q1u/4XEfrquwF8Lw7D7y5cD8CuHnfIc=
 github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=
 github.com/shurcooL/go-goon v0.0.0-20170922171312-37c2f522c041/go.mod h1:N5mDOmsrJOB+vfqUK+7DmDyjhSLIIBnXo9lvZJj3MWQ=
+github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.0.5/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.0.6/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
@@ -712,7 +719,9 @@ github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGr
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/ultraware/funlen v0.0.1/go.mod h1:Dp4UiAus7Wdb9KUZsYWZEWiRzGuM2kXM1lPbfaF6xhA=
 github.com/ultraware/funlen v0.0.2/go.mod h1:Dp4UiAus7Wdb9KUZsYWZEWiRzGuM2kXM1lPbfaF6xhA=
+github.com/urfave/cli v1.20.0 h1:fDqGv3UG/4jbVl/QkFwEdddtEDjh/5Ov6X+0B/3bPaw=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
+github.com/urfave/cli/v2 v2.2.0 h1:JTTnM6wKzdA0Jqodd966MVj4vWbbquZykeX1sKbe2C4=
 github.com/urfave/cli/v2 v2.2.0/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
 github.com/urfave/negroni v1.0.0/go.mod h1:Meg73S6kFm/4PpbYdq35yYWoCZ9mS/YSx+lKnmiohz4=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
@@ -725,8 +734,8 @@ github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
 github.com/vishvananda/netlink v1.0.0/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=
 github.com/vishvananda/netns v0.0.0-20171111001504-be1fbeda1936/go.mod h1:ZjcWmFBXmLKZu9Nxj3WKYEafiSqer2rnvPr0en9UNpI=
-github.com/vmware-tanzu/astrolabe v0.4.0 h1:2zAt8MthxLL19YSSUMleyDgW3AYkt6K+OWmbNivZj2s=
-github.com/vmware-tanzu/astrolabe v0.4.0/go.mod h1:XjIfIMV4r22huQ331wXkrJ4WDX55IViKAPH/sgvN0cU=
+github.com/vmware-tanzu/astrolabe v0.4.1-0.20210813185044-12eb18c3f6d5 h1:M7yqy5QdxRYib6H4jc+a7NU15WJu6OwSAr02H6NSTfY=
+github.com/vmware-tanzu/astrolabe v0.4.1-0.20210813185044-12eb18c3f6d5/go.mod h1:XjIfIMV4r22huQ331wXkrJ4WDX55IViKAPH/sgvN0cU=
 github.com/vmware-tanzu/velero v1.5.1 h1:PMcPfrhv91AfO/NPIWJDVUEql+DUixPnTjg+LTV95yI=
 github.com/vmware-tanzu/velero v1.5.1/go.mod h1:SIyHunlEyLVeKjWR34rv0mLeNVsH5wiR/EmQuUEo1/k=
 github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=

--- a/pkg/common/vsphere/cns_manager.go
+++ b/pkg/common/vsphere/cns_manager.go
@@ -1,0 +1,117 @@
+package vsphere
+
+import (
+	"context"
+	"github.com/sirupsen/logrus"
+	"github.com/vmware/govmomi/cns"
+	cnstypes "github.com/vmware/govmomi/cns/types"
+	"github.com/vmware/govmomi/object"
+)
+
+// CnsManager provides functionality to manage volumes.
+type CnsManager struct {
+	logger        logrus.FieldLogger
+	virtualCenter *VirtualCenter
+	cnsClient     *cns.Client
+}
+
+// GetCnsManager returns the Manager instance.
+func GetCnsManager(ctx context.Context, vc *VirtualCenter, cnsClient *cns.Client, logger logrus.FieldLogger) (*CnsManager, error) {
+	logger.Infof("Initializing new CnsManager...")
+	cnsManagerInstance := &CnsManager{
+		virtualCenter: vc,
+		cnsClient:     cnsClient,
+		logger:        logger,
+	}
+	return cnsManagerInstance, nil
+}
+
+func (this *CnsManager) CreateVolume(ctx context.Context, createSpecList []cnstypes.CnsVolumeCreateSpec) (*object.Task, error) {
+	invokeCount := 0
+	var createVolumeTask *object.Task
+	cachedCnsClient := this.cnsClient
+	var err error
+	for invokeCount <= DefaultAuthErrorRetryCount {
+		invokeCount++
+		createVolumeTask, err = cachedCnsClient.CreateVolume(ctx, createSpecList)
+		if err != nil {
+			cachedCnsClient, err = this.processError(invokeCount, err)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			break
+		}
+	}
+	return createVolumeTask, nil
+}
+
+func (this *CnsManager) DeleteVolume(ctx context.Context, volumeIDList []cnstypes.CnsVolumeId, deleteDisk bool) (*object.Task, error) {
+	invokeCount := 0
+	var deleteVolumeTask *object.Task
+	cachedCnsClient := this.cnsClient
+	var err error
+	for invokeCount <= DefaultAuthErrorRetryCount {
+		invokeCount++
+		deleteVolumeTask, err = cachedCnsClient.DeleteVolume(ctx, volumeIDList, deleteDisk)
+		if err != nil {
+			cachedCnsClient, err = this.processError(invokeCount, err)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			break
+		}
+	}
+	return deleteVolumeTask, nil
+}
+
+func (this *CnsManager) QueryVolume(ctx context.Context, queryFilter cnstypes.CnsQueryFilter) (*cnstypes.CnsQueryResult, error) {
+	invokeCount := 0
+	var queryResult *cnstypes.CnsQueryResult
+	cachedCnsClient := this.cnsClient
+	var err error
+	for invokeCount <= DefaultAuthErrorRetryCount {
+		invokeCount++
+		queryResult, err = cachedCnsClient.QueryVolume(ctx, queryFilter)
+		if err != nil {
+			cachedCnsClient, err = this.processError(invokeCount, err)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			break
+		}
+	}
+	return queryResult, nil
+}
+
+func (this *CnsManager) processError(invokeCount int, apiError error) (*cns.Client, error) {
+	log := this.logger
+	var refreshedCnsClient *cns.Client
+	var err error
+	if invokeCount > DefaultAuthErrorRetryCount {
+		log.Errorf("Exceeded retry count for auth errors, err: %v", apiError)
+		return nil, apiError
+	}
+	if CheckForVcAuthFaults(apiError, log) {
+		// On auth fault re-initiate a connect and try again.
+		_, refreshedCnsClient, err = this.virtualCenter.Connect(context.Background())
+		if err != nil {
+			log.Errorf("Failed to re-connect vcenter on auth errors..")
+			return nil, err
+		}
+		log.Infof("Successfully re-initiated vcenter connection")
+	} else {
+		// Return the error on actual api error conditions.
+		return nil, apiError
+	}
+	return refreshedCnsClient, nil
+}
+
+func (this *CnsManager) ResetManager(vcenter *VirtualCenter, cnsClient *cns.Client) {
+	log := this.logger
+	this.virtualCenter = vcenter
+	this.cnsClient = cnsClient
+	log.Infof("Done resetting CnsManager")
+}

--- a/pkg/common/vsphere/vcenter_utils.go
+++ b/pkg/common/vsphere/vcenter_utils.go
@@ -1,0 +1,128 @@
+package vsphere
+
+import (
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/vmware/govmomi/vim25/soap"
+	vim "github.com/vmware/govmomi/vim25/types"
+	"strconv"
+)
+
+func GetStringFromParamsMap(params map[string]interface{}, key string) (string, error) {
+	valueIF, ok := params[key]
+	if ok {
+		value, ok := valueIF.(string)
+		if !ok {
+			return "", errors.New("Value for params key " + key + " is not a string")
+		}
+		return value, nil
+	} else {
+		return "", errors.New("No such key " + key + " in params map")
+	}
+}
+
+func GetVirtualCenterFromParamsMap(params map[string]interface{}) (string, error) {
+	return GetStringFromParamsMap(params, HostVcParamKey)
+}
+
+func GetUserFromParamsMap(params map[string]interface{}) (string, error) {
+	return GetStringFromParamsMap(params, UserVcParamKey)
+}
+
+func GetPasswordFromParamsMap(params map[string]interface{}) (string, error) {
+	return GetStringFromParamsMap(params, PasswordVcParamKey)
+}
+
+func GetPortFromParamsMap(params map[string]interface{}) (string, error) {
+	return GetStringFromParamsMap(params, PortVcParamKey)
+}
+
+func GetDatacenterFromParamsMap(params map[string]interface{}) (string, error) {
+	return GetStringFromParamsMap(params, DatacenterVcParamKey)
+}
+
+func GetClusterFromParamsMap(params map[string]interface{}) (string, error) {
+	return GetStringFromParamsMap(params, ClusterVcParamKey)
+}
+
+func GetInsecureFlagFromParamsMap(params map[string]interface{}) (bool, error) {
+	insecureStr, err := GetStringFromParamsMap(params, InsecureFlagVcParamKey)
+	if err == nil {
+		return strconv.ParseBool(insecureStr)
+	}
+	return false, err
+}
+
+func GetVirtualCenterConfigFromParams(params map[string]interface{}, logger logrus.FieldLogger) (*VirtualCenterConfig, error) {
+	vcHost, err := GetVirtualCenterFromParamsMap(params)
+	if err != nil {
+		return nil, err
+	}
+	vcHostPortStr, err := GetPortFromParamsMap(params)
+	if err != nil {
+		return nil, err
+	}
+	vcHostPort, err := strconv.Atoi(vcHostPortStr)
+	if err != nil {
+		return nil, err
+	}
+	vcUser, err := GetUserFromParamsMap(params)
+	if err != nil {
+		return nil, err
+	}
+	vcPassword, err := GetPasswordFromParamsMap(params)
+	if err != nil {
+		return nil, err
+	}
+	insecure, err := GetInsecureFlagFromParamsMap(params)
+	if err != nil {
+		return nil, err
+	}
+	clusterId, err := GetClusterFromParamsMap(params)
+	if err != nil {
+		return nil, err
+	}
+	logger.Debug("Successfully retrieved VirtualCenterConfig from parameters.")
+	// Translate the params into VirtualCenterConfig.
+	vcConfig := &VirtualCenterConfig{
+		Scheme:          "https",
+		Host:            vcHost,
+		Port:            vcHostPort,
+		Username:        vcUser,
+		Password:        vcPassword,
+		ClusterId:       clusterId,
+		Insecure:        insecure,
+		VCClientTimeout: DefaultVCClientTimeoutInMinutes,
+	}
+	return vcConfig, nil
+}
+
+// Compare the vc configs, returns true if they are same else false
+func CheckIfVirtualCenterConfigChanged(oldVcConfig *VirtualCenterConfig, newVcConfig *VirtualCenterConfig) bool {
+	if oldVcConfig == nil {
+		return true
+	}
+	if oldVcConfig.Host != newVcConfig.Host || oldVcConfig.Username != newVcConfig.Username ||
+		oldVcConfig.Password != newVcConfig.Password {
+		return true
+	}
+	return false
+}
+
+func CheckForVcAuthFaults(err error, log logrus.FieldLogger) bool {
+	if soap.IsSoapFault(err) {
+		soapFault := soap.ToSoapFault(err)
+		receivedFault := soapFault.Detail.Fault
+		_, ok := receivedFault.(vim.NotAuthenticated)
+		if ok {
+			log.Infof("NotAuthenticated fault received during VC API invocation, err: %v", err)
+			return true
+		}
+		_, ok = receivedFault.(vim.InvalidLogin)
+		if ok {
+			log.Infof("InvalidLogin fault received during VC API invocation, err: %v", err)
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/common/vsphere/virtual_center.go
+++ b/pkg/common/vsphere/virtual_center.go
@@ -1,0 +1,279 @@
+package vsphere
+
+import (
+	"context"
+	"github.com/sirupsen/logrus"
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/cns"
+	"github.com/vmware/govmomi/session"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vslm"
+	"net"
+	neturl "net/url"
+	"strconv"
+	"sync"
+	"time"
+)
+
+const (
+	// DefaultScheme is the default connection scheme.
+	DefaultScheme = "https"
+	// DefaultRoundTripperCount is the default SOAP round tripper count.
+	DefaultRoundTripperCount = 3
+	// DefaultVCClientTimeoutInMinutes is the default timeout value.
+	DefaultVCClientTimeoutInMinutes = 30
+	// DefaultAuthErrorRetryCount is the number of retries
+	DefaultAuthErrorRetryCount = 1
+)
+
+// Keys for VCenter parameters
+const (
+	HostVcParamKey         = "VirtualCenter"
+	UserVcParamKey         = "user"
+	PasswordVcParamKey     = "password"
+	PortVcParamKey         = "port"
+	DatacenterVcParamKey   = "datacenters"
+	InsecureFlagVcParamKey = "insecure-flag"
+	ClusterVcParamKey      = "cluster-id"
+)
+
+// VirtualCenter holds details of a virtual center instance.
+type VirtualCenter struct {
+	// Config represents the virtual center configuration.
+	Config *VirtualCenterConfig
+	// Client represents the govmomi client instance for the connection.
+	Client *govmomi.Client
+	// CnsClient represents the CNS client instance.
+	CnsClient *cns.Client
+	// VslmClient  represents the VSLM client instance.
+	VslmClient *vslm.GlobalObjectManager
+	// Logger
+	logger logrus.FieldLogger
+	// Mutex to handle concurrent connect/disconnect
+	connectMutex sync.Mutex
+}
+
+// VirtualCenterConfig represents virtual center configuration.
+type VirtualCenterConfig struct {
+	// Scheme represents the connection scheme. (Ex: https)
+	Scheme string
+	// Host represents the virtual center host address.
+	Host string
+	// Port represents the virtual center host port.
+	Port int
+	// Username represents the virtual center username.
+	Username string
+	// Password represents the virtual center password in clear text.
+	Password string
+	// Cluster-id
+	ClusterId string
+	// Specifies whether to verify the server's certificate chain. Set to true to
+	// skip verification.
+	Insecure bool
+	// RoundTripperCount is the SOAP round tripper count. (retries = RoundTripperCount - 1)
+	RoundTripperCount int
+	// VCClientTimeout is the time limit in minutes for requests made by vCenter client
+	VCClientTimeout int
+}
+
+func GetVirtualCenter(ctx context.Context, config *VirtualCenterConfig, log logrus.FieldLogger) (*VirtualCenter, *vslm.GlobalObjectManager, *cns.Client, error) {
+	vc := &VirtualCenter{Config: config, logger: log}
+	vslmClient, cnsClient, err := vc.Connect(ctx)
+	if err != nil {
+		log.Errorf("Failed to connect to virtual center while retrieving a instance of it.")
+		return nil, nil, nil, err
+	}
+	return vc, vslmClient, cnsClient, nil
+}
+
+// newVslmClient creates a new VSLM client
+func newVslmClient(ctx context.Context, c *vim25.Client, logger logrus.FieldLogger) (*vslm.Client, error) {
+	vslmClient, err := vslm.NewClient(ctx, c)
+	if err != nil {
+		logger.Errorf("failed to create a new client for VSLM. err: %v", err)
+		return nil, err
+	}
+	return vslmClient, nil
+}
+
+// NewCnsClient creates a new CNS client
+func newCnsClient(ctx context.Context, c *vim25.Client, logger logrus.FieldLogger) (*cns.Client, error) {
+	cnsClient, err := cns.NewClient(ctx, c)
+	if err != nil {
+		logger.Errorf("failed to create a new client for CNS. err: %v", err)
+		return nil, err
+	}
+	return cnsClient, nil
+}
+
+// newClient creates a new govmomi Client instance.
+func (this *VirtualCenter) newClient(ctx context.Context) (*govmomi.Client, error) {
+	log := this.logger
+	if this.Config.Scheme == "" {
+		this.Config.Scheme = DefaultScheme
+	}
+
+	url, err := soap.ParseURL(net.JoinHostPort(this.Config.Host, strconv.Itoa(this.Config.Port)))
+	if err != nil {
+		log.Errorf("failed to parse URL %s with err: %v", url, err)
+		return nil, err
+	}
+	if this.Config.Insecure == false {
+		log.Warnf("The vCenter Configuration states secure connection, overriding to use insecure connection..")
+		this.Config.Insecure = true
+		// TODO: support vCenter connection using certs.
+	}
+	soapClient := soap.NewClient(url, this.Config.Insecure)
+	soapClient.Timeout = time.Duration(this.Config.VCClientTimeout) * time.Minute
+	log.Debugf("Setting vCenter soap client timeout to %v", soapClient.Timeout)
+	vimClient, err := vim25.NewClient(ctx, soapClient)
+	if err != nil {
+		log.Errorf("failed to create new client with err: %v", err)
+		return nil, err
+	}
+	vimClient.RoundTripper = session.KeepAlive(vimClient.RoundTripper, 10*time.Minute)
+	err = vimClient.UseServiceVersion("vsan")
+	if err != nil && this.Config.Host != "127.0.0.1" {
+		// skipping error for simulator connection for unit tests
+		log.Errorf("Failed to set vimClient service version to vsan. err: %v", err)
+		return nil, err
+	}
+	vimClient.UserAgent = "cns-dp-useragent"
+
+	client := &govmomi.Client{
+		Client:         vimClient,
+		SessionManager: session.NewManager(vimClient),
+	}
+
+	err = this.login(ctx, client)
+	if err != nil {
+		return nil, err
+	}
+
+	s, err := client.SessionManager.UserSession(ctx)
+	if err == nil {
+		log.Infof("New session ID for '%s' = %s", s.UserName, s.Key)
+	}
+
+	if this.Config.RoundTripperCount == 0 {
+		this.Config.RoundTripperCount = DefaultRoundTripperCount
+	}
+	client.RoundTripper = vim25.Retry(client.RoundTripper, vim25.TemporaryNetworkError(this.Config.RoundTripperCount))
+	return client, nil
+}
+
+// SessionManager.Login with user and password.
+func (this *VirtualCenter) login(ctx context.Context, client *govmomi.Client) error {
+	log := this.logger
+	log.Infof("Attempting login for user: %s", this.Config.Username)
+	err := client.SessionManager.Login(ctx, neturl.UserPassword(this.Config.Username, this.Config.Password))
+	if err != nil {
+		log.Errorf("Failed for login for username : %s error: %v", this.Config.Username, err)
+	}
+	return err
+}
+
+// Connect establishes a new connection with vSphere with updated credentials
+// If credentials are invalid then it fails the connection.
+func (this *VirtualCenter) Connect(ctx context.Context) (*vslm.GlobalObjectManager, *cns.Client, error) {
+	this.connectMutex.Lock()
+	defer this.connectMutex.Unlock()
+	log := this.logger
+	// If client was never initialized, initialize one.
+	var err error
+	if this.Client == nil {
+		this.Client, err = this.newClient(ctx)
+		if err != nil {
+			log.Errorf("failed to create govmomi client with err: %v", err)
+			return nil, nil, err
+		}
+	}
+	if this.VslmClient == nil {
+		vslmVcClient, err := newVslmClient(ctx, this.Client.Client, log)
+		if err != nil {
+			log.Errorf("failed to create VSLM client on vCenter host %q with err: %v", this.Config.Host, err)
+			return nil, nil, err
+		}
+		this.VslmClient = vslm.NewGlobalObjectManager(vslmVcClient)
+	}
+	if this.CnsClient == nil {
+		this.CnsClient, err = newCnsClient(ctx, this.Client.Client, log)
+		if err != nil {
+			log.Errorf("failed to create CNS client on vCenter host %q with err: %v", this.Config.Host, err)
+			return nil, nil, err
+		}
+	}
+
+	// If session hasn't expired, nothing to do.
+	sessionMgr := session.NewManager(this.Client.Client)
+	// SessionMgr.UserSession(ctx) retrieves and returns the SessionManager's CurrentSession field
+	// Nil is returned if the session is not authenticated or timed out.
+	userSession, err := sessionMgr.UserSession(ctx)
+	if err != nil {
+		log.Errorf("failed to obtain user session with err: %v", err)
+		return nil, nil, err
+	}
+	// Got a valid session if userSession is non-nil
+	if userSession != nil {
+		return this.VslmClient, this.CnsClient, nil
+	}
+	// Re-create all clients since the old session is no longer valid.
+	// If session has expired, create a new instance.
+	log.Warnf("Creating a new client session as the existing session isn't valid or not authenticated")
+	this.Client, err = this.newClient(ctx)
+	if err != nil {
+		log.Errorf("failed to create govmomi client with err: %v", err)
+		return nil, nil, err
+	}
+
+	// Recreate VslmClient If created using timed out VC Client
+	vslmVcClient, err := newVslmClient(ctx, this.Client.Client, this.logger)
+	if err != nil {
+		log.Errorf("failed to create VSLM client with err: %v", err)
+		return nil, nil, err
+	}
+	this.VslmClient = vslm.NewGlobalObjectManager(vslmVcClient)
+
+	// Recreate CNSClient If created using timed out VC Client
+	this.CnsClient, err = newCnsClient(ctx, this.Client.Client, this.logger)
+	if err != nil {
+		log.Errorf("failed to create CNS client on vCenter host %v with err: %v", this.Config.Host, err)
+		return nil, nil, err
+	}
+
+	return this.VslmClient, this.CnsClient, nil
+}
+
+// Disconnect disconnects the virtual center host connection if connected.
+func (this *VirtualCenter) Disconnect(ctx context.Context) error {
+	this.connectMutex.Lock()
+	defer this.connectMutex.Unlock()
+	log := this.logger
+	if this.VslmClient == nil {
+		log.Info("VslmClient wasn't connected, ignoring")
+	} else {
+		this.VslmClient = nil
+		log.Info("VslmClient was successfully disconnected.")
+	}
+	if this.CnsClient == nil {
+		log.Info("CnsClient wasn't connected, ignoring")
+	} else {
+		this.CnsClient = nil
+		log.Info("CnsClient was successfully disconnected.")
+	}
+	if this.Client == nil {
+		log.Info("Client wasn't connected, ignoring")
+		return nil
+	}
+	if err := this.Client.Logout(ctx); err != nil {
+		log.Errorf("failed to logout with err: %v", err)
+		return err
+	} else {
+		log.Info("VC Client was logged out.")
+	}
+	this.Client = nil
+	log.Infof("VC client disconnected.")
+	log.Infof("Disconnected all clients for the virtual center %s", this.Config.Host)
+	return nil
+}

--- a/pkg/common/vsphere/virtual_center_test.go
+++ b/pkg/common/vsphere/virtual_center_test.go
@@ -1,0 +1,225 @@
+package vsphere
+
+import (
+	"context"
+	"github.com/sirupsen/logrus"
+	"github.com/vmware-tanzu/astrolabe/pkg/util"
+	"github.com/vmware/govmomi/session"
+	"k8s.io/client-go/tools/clientcmd"
+	"os"
+	"testing"
+	"time"
+)
+
+/*
+	Steps
+	0. Set KUBECONFIG to the kubeconfig of vanilla or supervisor cluster.
+	1. Retrieve the vcenter connection parameters from the secret and create VcenterConfig.
+	2. Retrieve the vcenter center instance for the config.
+	3. Verify the clients are initialized.
+
+	Expected Output:
+	1. No errors during the workflow.
+
+*/
+func TestVirtualCenter_Connect(t *testing.T) {
+	log := GetLogger()
+	ctx := context.Background()
+	virtualCenterConfig := RetrieveVirtualCenterConfig(t, log)
+	log.Infof("Successfully retrieved VirtualCenterConfig : %+v", virtualCenterConfig)
+
+	virtualCenter, _, _, err := GetVirtualCenter(ctx, virtualCenterConfig, log)
+	if err != nil {
+		t.Fatalf("Failed to register virtual center err: %+v", err)
+	}
+	defer func() {
+		err = virtualCenter.Disconnect(ctx)
+		if err != nil {
+			log.Warnf("Was unable to disconnect vc clients as part of cleanup.")
+		}
+	}()
+	if virtualCenter.Client == nil || virtualCenter.CnsClient == nil || virtualCenter.VslmClient == nil {
+		t.Fatalf("Failed to initialize vc client")
+	}
+	log.Infof("PASS: Successfully initialized vcenter client.")
+}
+
+/*
+	Steps
+
+	0. Set KUBECONFIG to the kubeconfig of vanilla or supervisor cluster.
+	1. Retrieve the vcenter connection parameters from the secret and create VcenterConfig.
+	2. Retrieve the vcenter center instance for the config.
+	3. Verify the clients are initialized.
+	4. Invoke Disconnect and verify that clients are uninitialized.
+
+	Expected Output:
+	1. No errors during the workflow.
+
+*/
+func TestVirtualCenter_Disconnect(t *testing.T) {
+	log := GetLogger()
+	ctx := context.Background()
+	virtualCenterConfig := RetrieveVirtualCenterConfig(t, log)
+	log.Infof("Successfully retrieved VirtualCenterConfig : %+v", virtualCenterConfig)
+
+	virtualCenter, _, _, err := GetVirtualCenter(ctx, virtualCenterConfig, log)
+	if err != nil {
+		t.Fatalf("Failed to register virtual center err: %+v", err)
+	}
+	if virtualCenter.Client == nil || virtualCenter.CnsClient == nil || virtualCenter.VslmClient == nil {
+		t.Fatalf("Failed to initialize vc client")
+	}
+
+	err = virtualCenter.Disconnect(ctx)
+	if err != nil {
+		t.Fatalf("Failed to disconnect virtual center.")
+	}
+	if virtualCenter.VslmClient != nil || virtualCenter.CnsClient != nil || virtualCenter.Client != nil {
+		t.Fatalf("Clients are still initialized after disconnect.")
+	}
+	log.Infof("PASS: Successfully disconnected vcenter client.")
+}
+
+/*
+	Steps
+
+	0. Set KUBECONFIG to the kubeconfig of vanilla or supervisor cluster.
+	1. Retrieve the vcenter connection parameters from the secret and create VcenterConfig.
+	2. Retrieve the vcenter center instance for the config.
+	3. Verify the clients are initialized.
+	4. Invoke Connect and Disconnect concurrently.
+
+	Expected Output:
+	1. No errors during the workflow.
+
+*/
+func TestVirtualCenter_ConcurrentConnectDisconnect(t *testing.T) {
+	log := GetLogger()
+	ctx := context.Background()
+	virtualCenterConfig := RetrieveVirtualCenterConfig(t, log)
+	log.Infof("Successfully retrieved VirtualCenterConfig : %+v", virtualCenterConfig)
+
+	virtualCenter, _, _, err := GetVirtualCenter(ctx, virtualCenterConfig, log)
+	if err != nil {
+		t.Fatalf("Failed to register virtual center err: %+v", err)
+	}
+	out1 := make(chan error)
+	out2 := make(chan error)
+	go func() {
+		_, _, err1 := virtualCenter.Connect(ctx)
+		out1 <- err1
+	}()
+	go func() {
+		out2 <- virtualCenter.Disconnect(ctx)
+	}()
+	connectErr := <-out1
+	if connectErr != nil {
+		log.Errorf("Received exception on concurrent connect, err : %+v", connectErr)
+	}
+	disconnectErr := <-out2
+	if disconnectErr != nil {
+		log.Errorf("Received exception on concurrent disconnect, err : %+v", disconnectErr)
+	}
+	if connectErr != nil || disconnectErr != nil {
+		t.Fatalf("Received exception on concurrent connect disconnect.")
+	}
+	log.Infof("PASS: Concurrent connect disconnect did not throw any errors.")
+}
+
+/*
+	Steps
+
+	0. Set KUBECONFIG to the kubeconfig of vanilla or supervisor cluster.
+	1. Retrieve the vcenter connection parameters from the secret and create VcenterConfig.
+	2. Retrieve the vcenter center instance for the config.
+	3. Verify the clients are initialized.
+	4. Retrieve the session-id.
+	5. Invoke Connect on the vcenter again.
+	6. Verify that new session-id is returned.
+
+	Expected Output:
+	1. No errors during the workflow.
+
+*/
+func TestVirtualCenter_NewSessionCreationOnNewConnect(t *testing.T) {
+	log := GetLogger()
+	ctx := context.Background()
+	virtualCenterConfig := RetrieveVirtualCenterConfig(t, log)
+	log.Infof("Successfully retrieved VirtualCenterConfig : %+v", virtualCenterConfig)
+
+	virtualCenter, _, _, err := GetVirtualCenter(ctx, virtualCenterConfig, log)
+	if err != nil {
+		t.Fatalf("Failed to register virtual center err: %+v", err)
+	}
+
+	// Retrieve session id for initial connect.
+	sessionMgr := session.NewManager(virtualCenter.Client.Client)
+	userSession, err := sessionMgr.UserSession(ctx)
+	if err != nil {
+		t.Fatalf("Failed to retrieve the user session from current vc, err: %+v", err)
+	}
+	if userSession == nil {
+		t.Fatalf("Session was not initiated.")
+	}
+	initialSessionId := userSession.Key
+
+	//Disconnect vcenter.
+	err = virtualCenter.Disconnect(ctx)
+	if err != nil {
+		t.Fatalf("Failed to disconnect the initial vcenter session.")
+	}
+	_, _, err = virtualCenter.Connect(ctx)
+	if err != nil {
+		t.Fatalf("Failed to connect to vcenter, err: %+v", err)
+	}
+	if virtualCenter.Client == nil {
+		t.Fatalf("Failed to initialize vc client second time")
+	}
+
+	// Retrieve session id for initial connect.
+	sessionMgr = session.NewManager(virtualCenter.Client.Client)
+	userSession, err = sessionMgr.UserSession(ctx)
+	if err != nil {
+		t.Fatalf("Failed to retrieve the user session from current vc after disconnect and connect, err: %+v", err)
+	}
+	if userSession == nil {
+		t.Fatalf("Session after disconnect and connect was  not initiated.")
+	}
+	newSessionId := userSession.Key
+	if initialSessionId == newSessionId {
+		t.Fatalf("Failed to generate new session-id on connect-disconnect-connect")
+	}
+	log.Infof("PASS: new session-id was generated, old-session: %s, new-session: %s", initialSessionId, newSessionId)
+}
+
+func GetLogger() logrus.FieldLogger {
+	logger := logrus.New()
+	formatter := new(logrus.TextFormatter)
+	formatter.TimestampFormat = time.RFC3339Nano
+	formatter.FullTimestamp = true
+	logger.SetFormatter(formatter)
+	logger.SetLevel(logrus.DebugLevel)
+	return logger
+}
+
+func RetrieveVirtualCenterConfig(t *testing.T, log logrus.FieldLogger) *VirtualCenterConfig {
+	path := os.Getenv("KUBECONFIG")
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		t.Skipf("The KubeConfig file, %v, is not exist", path)
+	}
+	config, err := clientcmd.BuildConfigFromFlags("", path)
+	if err != nil {
+		t.Fatalf("Failed to build k8s config from kubeconfig file: %+v ", err)
+	}
+	params := make(map[string]interface{})
+	err = util.RetrievePlatformInfoFromConfig(config, params)
+	if err != nil {
+		t.Fatalf("Failed to get VC params from k8s: %+v", err)
+	}
+	virtualCenterConfig, err := GetVirtualCenterConfigFromParams(params, log)
+	if err != nil {
+		t.Fatalf("Failed to build VirtualCenterConfig from params: %+v", err)
+	}
+	return virtualCenterConfig
+}

--- a/pkg/common/vsphere/vslm_manager.go
+++ b/pkg/common/vsphere/vslm_manager.go
@@ -1,0 +1,302 @@
+package vsphere
+
+import (
+	"context"
+	"github.com/sirupsen/logrus"
+	vim "github.com/vmware/govmomi/vim25/types"
+	vslm_vsom "github.com/vmware/govmomi/vslm"
+	vslmtypes "github.com/vmware/govmomi/vslm/types"
+)
+
+// VslmManager provides functionality to manage fcds.
+type VslmManager struct {
+	logger        logrus.FieldLogger
+	virtualCenter *VirtualCenter
+	vsom          *vslm_vsom.GlobalObjectManager
+}
+
+// GetVslmManager returns the Manager instance.
+func GetVslmManager(
+	ctx context.Context,
+	vc *VirtualCenter,
+	vsom *vslm_vsom.GlobalObjectManager,
+	logger logrus.FieldLogger) (*VslmManager, error) {
+	logger.Infof("Initializing new VslmManager...")
+	vslmManagerInstance := &VslmManager{
+		virtualCenter: vc,
+		vsom:          vsom,
+		logger:        logger,
+	}
+	return vslmManagerInstance, nil
+}
+
+func (this *VslmManager) CreateSnapshot(ctx context.Context, id vim.ID, description string) (*vslm_vsom.Task, error) {
+	invokeCount := 0
+	var createSnapshotTask *vslm_vsom.Task
+	var err error
+	cachedVsom := this.vsom
+	for invokeCount <= DefaultAuthErrorRetryCount {
+		invokeCount++
+		createSnapshotTask, err = cachedVsom.CreateSnapshot(ctx, id, description)
+		if err != nil {
+			cachedVsom, err = this.processError(invokeCount, err)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			break
+		}
+	}
+	return createSnapshotTask, nil
+}
+
+func (this *VslmManager) DeleteSnapshot(ctx context.Context, id vim.ID, snapshotToDelete vim.ID) (*vslm_vsom.Task, error) {
+	invokeCount := 0
+	var deleteSnapshotTask *vslm_vsom.Task
+	cachedVsom := this.vsom
+	var err error
+	for invokeCount <= DefaultAuthErrorRetryCount {
+		invokeCount++
+		deleteSnapshotTask, err = cachedVsom.DeleteSnapshot(ctx, id, snapshotToDelete)
+		if err != nil {
+			cachedVsom, err = this.processError(invokeCount, err)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			break
+		}
+	}
+	return deleteSnapshotTask, nil
+}
+
+func (this *VslmManager) RetrieveSnapshotInfo(ctx context.Context, id vim.ID) ([]vim.VStorageObjectSnapshotInfoVStorageObjectSnapshot, error) {
+	invokeCount := 0
+	var retreiveSnapInfoResults []vim.VStorageObjectSnapshotInfoVStorageObjectSnapshot
+	cachedVsom := this.vsom
+	var err error
+	for invokeCount <= DefaultAuthErrorRetryCount {
+		invokeCount++
+		retreiveSnapInfoResults, err = cachedVsom.RetrieveSnapshotInfo(ctx, id)
+		if err != nil {
+			cachedVsom, err = this.processError(invokeCount, err)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			break
+		}
+	}
+	return retreiveSnapInfoResults, nil
+}
+
+func (this *VslmManager) Retrieve(ctx context.Context, id vim.ID) (*vim.VStorageObject, error) {
+	invokeCount := 0
+	var vStorageObject *vim.VStorageObject
+	cachedVsom := this.vsom
+	var err error
+	for invokeCount <= DefaultAuthErrorRetryCount {
+		invokeCount++
+		vStorageObject, err = cachedVsom.Retrieve(ctx, id)
+		if err != nil {
+			cachedVsom, err = this.processError(invokeCount, err)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			break
+		}
+	}
+	return vStorageObject, nil
+}
+
+func (this *VslmManager) RetrieveSnapshotDetails(ctx context.Context, id vim.ID, snapshotId vim.ID) (*vim.VStorageObjectSnapshotDetails, error) {
+	invokeCount := 0
+	var snapshotDetails *vim.VStorageObjectSnapshotDetails
+	cachedVsom := this.vsom
+	var err error
+	for invokeCount <= DefaultAuthErrorRetryCount {
+		invokeCount++
+		snapshotDetails, err = cachedVsom.RetrieveSnapshotDetails(ctx, id, snapshotId)
+		if err != nil {
+			cachedVsom, err = this.processError(invokeCount, err)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			break
+		}
+	}
+	return snapshotDetails, nil
+}
+
+func (this *VslmManager) UpdateMetadata(ctx context.Context, id vim.ID, metadata []vim.KeyValue, deleteKeys []string) (*vslm_vsom.Task, error) {
+	invokeCount := 0
+	var updateMetadatatTask *vslm_vsom.Task
+	cachedVsom := this.vsom
+	var err error
+	for invokeCount <= DefaultAuthErrorRetryCount {
+		invokeCount++
+		updateMetadatatTask, err = cachedVsom.UpdateMetadata(ctx, id, metadata, deleteKeys)
+		if err != nil {
+			cachedVsom, err = this.processError(invokeCount, err)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			break
+		}
+	}
+	return updateMetadatatTask, nil
+}
+
+func (this *VslmManager) RetrieveMetadata(ctx context.Context, id vim.ID, snapshotID *vim.ID, prefix string) ([]vim.KeyValue, error) {
+	invokeCount := 0
+	var retrieveMetadata []vim.KeyValue
+	cachedVsom := this.vsom
+	var err error
+	for invokeCount <= DefaultAuthErrorRetryCount {
+		invokeCount++
+		retrieveMetadata, err = cachedVsom.RetrieveMetadata(ctx, id, snapshotID, prefix)
+		if err != nil {
+			cachedVsom, err = this.processError(invokeCount, err)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			break
+		}
+	}
+	return retrieveMetadata, nil
+}
+
+func (this *VslmManager) CreateDiskFromSnapshot(ctx context.Context, id vim.ID, snapshotId vim.ID, name string, profile []vim.VirtualMachineProfileSpec, crypto *vim.CryptoSpec, path string) (*vslm_vsom.Task, error) {
+	invokeCount := 0
+	var createDiskFromSnapshotTask *vslm_vsom.Task
+	cachedVsom := this.vsom
+	var err error
+	for invokeCount <= DefaultAuthErrorRetryCount {
+		invokeCount++
+		createDiskFromSnapshotTask, err = cachedVsom.CreateDiskFromSnapshot(ctx, id, snapshotId, name, profile, crypto, path)
+		if err != nil {
+			cachedVsom, err = this.processError(invokeCount, err)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			break
+		}
+	}
+	return createDiskFromSnapshotTask, nil
+}
+
+func (this *VslmManager) ListObjectsForSpec(ctx context.Context, query []vslmtypes.VslmVsoVStorageObjectQuerySpec, maxResult int32) (*vslmtypes.VslmVsoVStorageObjectQueryResult, error) {
+	invokeCount := 0
+	var queryResult *vslmtypes.VslmVsoVStorageObjectQueryResult
+	cachedVsom := this.vsom
+	var err error
+	for invokeCount <= DefaultAuthErrorRetryCount {
+		invokeCount++
+		queryResult, err = cachedVsom.ListObjectsForSpec(ctx, query, maxResult)
+		if err != nil {
+			cachedVsom, err = this.processError(invokeCount, err)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			break
+		}
+	}
+	return queryResult, nil
+}
+
+func (this *VslmManager) CreateDisk(ctx context.Context, spec vim.VslmCreateSpec) (*vslm_vsom.Task, error) {
+	invokeCount := 0
+	var createDiskTask *vslm_vsom.Task
+	cachedVsom := this.vsom
+	var err error
+	for invokeCount <= DefaultAuthErrorRetryCount {
+		invokeCount++
+		createDiskTask, err = cachedVsom.CreateDisk(ctx, spec)
+		if err != nil {
+			cachedVsom, err = this.processError(invokeCount, err)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			break
+		}
+	}
+	return createDiskTask, nil
+}
+
+func (this *VslmManager) Clone(ctx context.Context, id vim.ID, spec vim.VslmCloneSpec) (*vslm_vsom.Task, error) {
+	invokeCount := 0
+	var cloneTask *vslm_vsom.Task
+	cachedVsom := this.vsom
+	var err error
+	for invokeCount <= DefaultAuthErrorRetryCount {
+		invokeCount++
+		cloneTask, err = cachedVsom.Clone(ctx, id, spec)
+		if err != nil {
+			cachedVsom, err = this.processError(invokeCount, err)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			break
+		}
+	}
+	return cloneTask, nil
+}
+
+func (this *VslmManager) Delete(ctx context.Context, id vim.ID) (*vslm_vsom.Task, error) {
+	invokeCount := 0
+	var deleteTask *vslm_vsom.Task
+	cachedVsom := this.vsom
+	var err error
+	for invokeCount <= DefaultAuthErrorRetryCount {
+		invokeCount++
+		deleteTask, err = cachedVsom.Delete(ctx, id)
+		if err != nil {
+			cachedVsom, err = this.processError(invokeCount, err)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			break
+		}
+	}
+	return deleteTask, nil
+}
+
+func (this *VslmManager) processError(invokeCount int, apiError error) (*vslm_vsom.GlobalObjectManager, error) {
+	log := this.logger
+	var refreshedVsom *vslm_vsom.GlobalObjectManager
+	var err error
+	if invokeCount > DefaultAuthErrorRetryCount {
+		log.Errorf("Exceeded retry count for auth errors, err: %v", apiError)
+		return nil, apiError
+	}
+	if CheckForVcAuthFaults(apiError, log) {
+		// On auth fault re-initiate a connect and try again.
+		refreshedVsom, _, err = this.virtualCenter.Connect(context.Background())
+		if err != nil {
+			log.Errorf("Failed to re-connect vcenter on auth errors..")
+			return nil, err
+		}
+		log.Infof("Successfully re-initiated vcenter connection")
+	} else {
+		// Return the error on actual api error conditions.
+		return nil, apiError
+	}
+	return refreshedVsom, nil
+}
+
+// ResetManager helps set new manager instance and VC configuration
+func (this *VslmManager) ResetManager(vcenter *VirtualCenter, vsom *vslm_vsom.GlobalObjectManager) {
+	log := this.logger
+	this.virtualCenter = vcenter
+	this.vsom = vsom
+	log.Infof("Done resetting VslmManager")
+}

--- a/pkg/common/vsphere/vslm_manager_test.go
+++ b/pkg/common/vsphere/vslm_manager_test.go
@@ -1,0 +1,191 @@
+package vsphere
+
+import (
+	"context"
+	vslmtypes "github.com/vmware/govmomi/vslm/types"
+	"testing"
+)
+
+/*
+	Steps
+
+	0. Set KUBECONFIG to the kubeconfig of vanilla or supervisor cluster.
+	1. Retrieve the vcenter connection parameters from the secret and create VcenterConfig.
+	2. Retrieve the vcenter center instance for the config.
+	3. Invoke GetVslmManager to associate the new vcenter instance.
+
+	Expected Output:
+	1. No errors during the workflow.
+
+*/
+func TestVslmManager_GetVslmManager(t *testing.T) {
+	log := GetLogger()
+	ctx := context.Background()
+	virtualCenterConfig := RetrieveVirtualCenterConfig(t, log)
+	log.Infof("Successfully retrieved VirtualCenterConfig : %+v", virtualCenterConfig)
+
+	virtualCenter, vslmClient, _, err := GetVirtualCenter(ctx, virtualCenterConfig, log)
+	if err != nil {
+		t.Fatalf("Failed to register virtual center err: %+v", err)
+	}
+	defer func() {
+		err = virtualCenter.Disconnect(ctx)
+		if err != nil {
+			log.Warnf("Was unable to disconnect vc clients as part of cleanup.")
+		}
+	}()
+	_, err = GetVslmManager(ctx, virtualCenter, vslmClient, log)
+	if err != nil {
+		t.Fatalf("Failed to retrieve vslm manager.")
+	}
+	log.Infof("PASS: Successfully retrieved vslm manager.")
+}
+
+/*
+	Steps
+
+	0. Set KUBECONFIG to the kubeconfig of vanilla or supervisor cluster.
+	1. Retrieve the vcenter connection parameters from the secret and create VcenterConfig.
+	2. Retrieve the vcenter center instance for the config.
+	3. Invoke GetVslmManager to associate the new vcenter instance.
+	4. Invoke VslmListObjectsForSpec to verify that APIs can be invoked.
+
+	Expected Output:
+	1. No errors during the workflow.
+
+*/
+func TestVslmManager_VslmApiInvocation(t *testing.T) {
+	log := GetLogger()
+	ctx := context.Background()
+	virtualCenterConfig := RetrieveVirtualCenterConfig(t, log)
+	log.Infof("Successfully retrieved VirtualCenterConfig : %+v", virtualCenterConfig)
+
+	virtualCenter, vslmClient, _, err := GetVirtualCenter(ctx, virtualCenterConfig, log)
+	if err != nil {
+		t.Fatalf("Failed to register virtual center err: %+v", err)
+	}
+	defer func() {
+		err = virtualCenter.Disconnect(ctx)
+		if err != nil {
+			log.Warnf("Was unable to disconnect vc clients as part of cleanup.")
+		}
+	}()
+	vslmManager, err := GetVslmManager(ctx, virtualCenter, vslmClient, log)
+	if err != nil {
+		t.Fatalf("Failed to retrieve vslm manager.")
+	}
+	// Invoke vslm APIs.
+	spec := vslmtypes.VslmVsoVStorageObjectQuerySpec{
+		QueryField:    "createTime",
+		QueryOperator: "greaterThan",
+		QueryValue:    []string{"0"},
+	}
+	res, err := vslmManager.ListObjectsForSpec(ctx, []vslmtypes.VslmVsoVStorageObjectQuerySpec{spec}, 1000)
+	if err != nil {
+		t.Fatalf("Failed to invoke VSLM APIs.")
+	}
+	log.Infof("PASS: Successfully invoked VSLM List API, retrieved %d FCDs", len(res.QueryResults))
+}
+
+/*
+	Steps
+
+	0. Set KUBECONFIG to the kubeconfig of vanilla or supervisor cluster.
+	1. Retrieve the vcenter connection parameters from the secret and create VcenterConfig.
+	2. Retrieve the vcenter center instance for the config.
+	3. Invoke Disconnect on the vcenter instance.
+	4. Use the vslm manager to invoke any of the vslm apis.
+
+	Expected Output:
+	1. No Error.
+
+*/
+func TestVslmManager_VslmApiInvocationAfterDisconnect(t *testing.T) {
+	log := GetLogger()
+	ctx := context.Background()
+	virtualCenterConfig := RetrieveVirtualCenterConfig(t, log)
+	log.Infof("Successfully retrieved VirtualCenterConfig : %+v", virtualCenterConfig)
+
+	virtualCenter, vslmClient, _, err := GetVirtualCenter(ctx, virtualCenterConfig, log)
+	if err != nil {
+		t.Fatalf("Failed to register virtual center err: %+v", err)
+	}
+	vslmManager, err := GetVslmManager(ctx, virtualCenter, vslmClient, log)
+	if vslmManager == nil {
+		t.Fatalf("Failed to retrieve vslm manager.")
+	}
+	err = virtualCenter.Disconnect(ctx)
+	if err != nil {
+		t.Fatalf("Failed to disconnect virtual center.")
+	}
+	// Invoke vslm APIs.
+	spec := vslmtypes.VslmVsoVStorageObjectQuerySpec{
+		QueryField:    "createTime",
+		QueryOperator: "greaterThan",
+		QueryValue:    []string{"0"},
+	}
+	res, err := vslmManager.ListObjectsForSpec(ctx, []vslmtypes.VslmVsoVStorageObjectQuerySpec{spec}, 1000)
+	if err != nil {
+		t.Fatalf("Failed to invoke VSLM APIs.")
+	}
+	log.Infof("PASS: Successfully invoked VSLM List API even after disconnect, retrieved %d FCDs", len(res.QueryResults))
+}
+
+/*
+	Steps
+
+	0. Set KUBECONFIG to the kubeconfig of vanilla or supervisor cluster.
+	1. Retrieve the vcenter connection parameters from the secret and create VcenterConfig.
+	2. Retrieve the vcenter center instance for the config.
+	3. Invoke GetVslmManager to associate the new vcenter instance.
+	4. Invoke any of the vslm APIs to trigger vcenter and vslm connect.
+	5. Create a VcenterConfig with alternate credentials.
+	6. Invoke Disconnect.
+	7. Retrieve the vcenter center instance with a new VcenterConfig.
+	8. Use the returned vcenter instance to Invoke ResetManager on the vslm manager.
+	9. Invoke any of the vslm apis to ensure no errors.
+
+	Expected Output:
+	1. No Error.
+
+*/
+func TestVslmManager_ResetManager(t *testing.T) {
+	log := GetLogger()
+	ctx := context.Background()
+	virtualCenterConfig := RetrieveVirtualCenterConfig(t, log)
+	log.Infof("Successfully retrieved VirtualCenterConfig : %+v", virtualCenterConfig)
+
+	virtualCenter, vslmClient, _, err := GetVirtualCenter(ctx, virtualCenterConfig, log)
+	if err != nil {
+		t.Fatalf("Failed to register virtual center err: %+v", err)
+	}
+	vslmManager, err := GetVslmManager(ctx, virtualCenter, vslmClient, log)
+	if err != nil {
+		t.Fatalf("Failed to retrieve vslm manager.")
+	}
+	err = virtualCenter.Disconnect(ctx)
+	if err != nil {
+		t.Fatalf("Was unable to disconnect vc clients, err: %+v", err)
+	}
+	// Using admin as alternate vcenter config
+	adminUser := "administrator@vsphere.local"
+	adminPass := "Admin!23"
+	virtualCenterConfig.Username = adminUser
+	virtualCenterConfig.Password = adminPass
+	newVirtualCenter, vslmClient, _, err := GetVirtualCenter(ctx, virtualCenterConfig, log)
+	if err != nil {
+		t.Fatalf("Failed to register virtual center err: %+v", err)
+	}
+	vslmManager.ResetManager(newVirtualCenter, vslmClient)
+	// Invoke vslm APIs.
+	spec := vslmtypes.VslmVsoVStorageObjectQuerySpec{
+		QueryField:    "createTime",
+		QueryOperator: "greaterThan",
+		QueryValue:    []string{"0"},
+	}
+	res, err := vslmManager.ListObjectsForSpec(ctx, []vslmtypes.VslmVsoVStorageObjectQuerySpec{spec}, 1000)
+	if err != nil {
+		t.Fatalf("Failed to invoke VSLM APIs.")
+	}
+	log.Infof("PASS: Successfully invoked VSLM List API after registering new vcenter, retrieved %d FCDs", len(res.QueryResults))
+}

--- a/pkg/ivd/ivd_protected_entity.go
+++ b/pkg/ivd/ivd_protected_entity.go
@@ -1,0 +1,544 @@
+/*
+ * Copyright 2019 the Astrolabe contributors
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ivd
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/vmware-tanzu/astrolabe/pkg/astrolabe"
+	"github.com/vmware-tanzu/astrolabe/pkg/util"
+	"github.com/vmware/govmomi/vim25/soap"
+	vim "github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/govmomi/vim25/xml"
+	"github.com/vmware/virtual-disks/pkg/disklib"
+	"github.com/vmware/virtual-disks/pkg/virtual_disks"
+	"io"
+	"io/ioutil"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"strings"
+
+	"context"
+	"github.com/vmware/govmomi/vslm"
+	vslmtypes "github.com/vmware/govmomi/vslm/types"
+	"time"
+)
+
+type IVDProtectedEntity struct {
+	ipetm    *IVDProtectedEntityTypeManager
+	id       astrolabe.ProtectedEntityID
+	data     []astrolabe.DataTransport
+	metadata []astrolabe.DataTransport
+	combined []astrolabe.DataTransport
+	logger   logrus.FieldLogger
+}
+
+type metadata struct {
+	VirtualStorageObject vim.VStorageObject         `xml:"virtualStorageObject"`
+	Datastore            vim.ManagedObjectReference `xml:"datastore"`
+	ExtendedMetadata     []vim.KeyValue             `xml:"extendedMetadata"`
+}
+
+func (this IVDProtectedEntity) GetDataReader(ctx context.Context) (io.ReadCloser, error) {
+	this.logger.Infof("GetDataReader called on IVD Protected Entity, %v", this.id.String())
+	err := this.ipetm.CheckVcenterConnections(ctx)
+	if err != nil {
+		return nil, err
+	}
+	diskConnectParam, err := this.getDiskConnectionParams(ctx, true)
+	if err != nil {
+		return nil, err
+	}
+
+	diskReader, vErr := virtual_disks.Open(diskConnectParam, this.logger)
+	if vErr != nil {
+		if vErr.VixErrorCode() == 20005 {
+			// Try the end access once
+			disklib.EndAccess(diskConnectParam)
+			diskReader, vErr = virtual_disks.Open(diskConnectParam, this.logger)
+		}
+		if vErr != nil {
+			return nil, errors.New(fmt.Sprintf(vErr.Error()+" with error code: %d", vErr.VixErrorCode()))
+		}
+	}
+
+	return diskReader, nil
+}
+
+func (this IVDProtectedEntity) copy(ctx context.Context, dataReader io.Reader,
+	metadata metadata) (int64, error) {
+	// TODO - restore metadata
+	dataWriter, err := this.getDataWriter(ctx)
+	if dataWriter != nil {
+		defer func() {
+			if err := dataWriter.Close(); err != nil {
+				this.logger.Errorf("The deferred data writer is closed with error, %v", err)
+			}
+		}()
+	}
+
+	if err != nil {
+		return 0, err
+	}
+
+	bufferedWriter := bufio.NewWriterSize(dataWriter, 1024*1024)
+	buf := make([]byte, 1024*1024)
+	bytesWritten, err := io.CopyBuffer(bufferedWriter, dataReader, buf) // TODO - add a copy routine that we can interrupt via context
+	if err != nil {
+		err = errors.Wrapf(err, "Failed in CopyBuffer, bytes written = %d", bytesWritten)
+	}
+	return bytesWritten, err
+}
+
+func (this IVDProtectedEntity) getDataWriter(ctx context.Context) (io.WriteCloser, error) {
+	diskConnectParam, err := this.getDiskConnectionParams(ctx, false)
+	if err != nil {
+		return nil, err
+	}
+
+	diskWriter, vErr := virtual_disks.Open(diskConnectParam, this.logger)
+	if vErr != nil {
+		return nil, errors.New(fmt.Sprintf(vErr.Error()+" with error code: %d", vErr.VixErrorCode()))
+	}
+
+	return diskWriter, nil
+}
+
+func (this IVDProtectedEntity) getDiskConnectionParams(ctx context.Context, readOnly bool) (disklib.ConnectParams, error) {
+	vc := this.ipetm.vcenter
+	_, _, err := vc.Connect(ctx)
+	if err != nil {
+		this.logger.Errorf("Failed to connect to VC")
+		return disklib.ConnectParams{}, err
+	}
+	url := vc.Client.Client.URL()
+	serverName := url.Hostname()
+	userName := vc.Config.Username
+	password := vc.Config.Password
+	fcdId := this.id.GetID()
+
+	vso, err := this.ipetm.vslmManager.Retrieve(ctx, NewVimIDFromPEID(this.id))
+	if err != nil {
+		return disklib.ConnectParams{}, err
+	}
+	datastore := vso.Config.Backing.GetBaseConfigInfoBackingInfo().Datastore.String()
+	datastore = strings.TrimPrefix(datastore, "Datastore:")
+
+	fcdssid := ""
+	if this.id.HasSnapshot() {
+		fcdssid = this.id.GetSnapshotID().String()
+	}
+	path := ""
+	var flags uint32
+	if readOnly {
+		flags = disklib.VIXDISKLIB_FLAG_OPEN_COMPRESSION_SKIPZ | disklib.VIXDISKLIB_FLAG_OPEN_READ_ONLY
+	} else {
+		flags = disklib.VIXDISKLIB_FLAG_OPEN_UNBUFFERED
+	}
+	transportMode := "nbd"
+	thumbPrint, err := disklib.GetThumbPrintForURL(*url)
+	if err != nil {
+		this.logger.Errorf("Failed to get the thumb print for the URL, %s", url.String())
+		return disklib.ConnectParams{}, err
+	}
+
+	params := disklib.NewConnectParams("",
+		serverName,
+		thumbPrint,
+		userName,
+		password,
+		fcdId,
+		datastore,
+		fcdssid,
+		"",
+		"vm-example",
+		path,
+		flags,
+		readOnly,
+		transportMode)
+
+	return params, nil
+}
+
+func (this IVDProtectedEntity) GetMetadataReader(ctx context.Context) (io.ReadCloser, error) {
+	this.logger.Infof("GetMetadataReader called on IVD Protected Entity, %v", this.id.String())
+	err := this.ipetm.CheckVcenterConnections(ctx)
+	if err != nil {
+		return nil, err
+	}
+	infoBuf, err := this.getMetadataBuf(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return ioutil.NopCloser(bytes.NewReader(infoBuf)), nil
+}
+
+func (this IVDProtectedEntity) getMetadataBuf(ctx context.Context) ([]byte, error) {
+	md, err := this.getMetadata(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "Retrieve failed")
+	}
+	retBuf, err := xml.MarshalIndent(md, "  ", "    ")
+	if err != nil {
+		return nil, err
+	}
+	return retBuf, nil
+}
+
+func (this IVDProtectedEntity) getMetadata(ctx context.Context) (metadata, error) {
+	vsoID := vim.ID{
+		Id: this.id.GetID(),
+	}
+	vso, err := this.ipetm.vslmManager.Retrieve(ctx, vsoID)
+	if err != nil {
+		return metadata{}, err
+	}
+	datastore := vso.Config.BaseConfigInfo.GetBaseConfigInfo().Backing.GetBaseConfigInfoBackingInfo().Datastore
+	var ssID *vim.ID = nil
+	if this.id.HasSnapshot() {
+
+		ssID = &vim.ID{
+			Id: this.id.GetSnapshotID().GetID(),
+		}
+	}
+	extendedMetadata, err := this.ipetm.vslmManager.RetrieveMetadata(ctx, vsoID, ssID, "")
+
+	retVal := metadata{
+		VirtualStorageObject: *vso,
+		Datastore:            datastore,
+		ExtendedMetadata:     extendedMetadata,
+	}
+	return retVal, nil
+}
+
+func readMetadataFromReader(ctx context.Context, metadataReader io.Reader) (metadata, error) {
+	mdBuf, err := ioutil.ReadAll(metadataReader) // TODO - limit this so it can't run us out of memory here
+	if err != nil && err != io.EOF {
+		return metadata{}, errors.Wrap(err, "ReadAll failed")
+	}
+	return readMetadataFromBuf(ctx, mdBuf)
+}
+
+func readMetadataFromBuf(ctx context.Context, buf []byte) (metadata, error) {
+	var retVal = metadata{}
+	err := xml.Unmarshal(buf, &retVal)
+	return retVal, err
+}
+
+func newProtectedEntityID(id vim.ID) astrolabe.ProtectedEntityID {
+	return astrolabe.NewProtectedEntityID("ivd", id.Id)
+}
+
+func newProtectedEntityIDWithSnapshotID(id vim.ID, snapshotID astrolabe.ProtectedEntitySnapshotID) astrolabe.ProtectedEntityID {
+	return astrolabe.NewProtectedEntityIDWithSnapshotID("ivd", id.Id, snapshotID)
+}
+
+func newIVDProtectedEntity(ipetm *IVDProtectedEntityTypeManager, id astrolabe.ProtectedEntityID) (IVDProtectedEntity, error) {
+	data, metadata, combined, err := ipetm.getDataTransports(id)
+	if err != nil {
+		return IVDProtectedEntity{}, err
+	}
+	newIPE := IVDProtectedEntity{
+		ipetm:    ipetm,
+		id:       id,
+		data:     data,
+		metadata: metadata,
+		combined: combined,
+		logger:   ipetm.logger,
+	}
+	return newIPE, nil
+}
+func (this IVDProtectedEntity) GetInfo(ctx context.Context) (astrolabe.ProtectedEntityInfo, error) {
+	this.logger.Infof("GetInfo called on IVD Protected Entity, %v", this.id.String())
+	err := this.ipetm.CheckVcenterConnections(ctx)
+	if err != nil {
+		return nil, err
+	}
+	vsoID := vim.ID{
+		Id: this.id.GetID(),
+	}
+	vso, err := this.ipetm.vslmManager.Retrieve(ctx, vsoID)
+	if err != nil {
+		return nil, errors.Wrap(err, "Retrieve failed")
+	}
+
+	retVal := astrolabe.NewProtectedEntityInfo(
+		this.id,
+		vso.Config.Name,
+		vso.Config.CapacityInMB * 1024 * 1024,
+		this.data,
+		this.metadata,
+		this.combined,
+		[]astrolabe.ProtectedEntityID{})
+	return retVal, nil
+}
+
+func (this IVDProtectedEntity) GetCombinedInfo(ctx context.Context) ([]astrolabe.ProtectedEntityInfo, error) {
+	ivdIPE, err := this.GetInfo(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return []astrolabe.ProtectedEntityInfo{ivdIPE}, nil
+}
+
+const waitTime = 3600 * time.Second
+
+/*
+ * Snapshot APIs
+ */
+func (this IVDProtectedEntity) Snapshot(ctx context.Context, params map[string]map[string]interface{}) (astrolabe.ProtectedEntitySnapshotID, error) {
+	this.logger.Infof("CreateSnapshot called on IVD Protected Entity, %v", this.id.String())
+	var retVal astrolabe.ProtectedEntitySnapshotID
+	retryInterval := time.Second
+	retryCount := 0
+	retrieveSnapDetailsErr := 0
+	err := wait.PollImmediate(retryInterval, time.Hour, func() (bool, error) {
+		err := this.ipetm.CheckVcenterConnections(ctx)
+		if err != nil {
+			this.logger.Errorf("The vCenter is disconnected during snapshot operation, error: %v, retrying..", err)
+			return false, nil
+		}
+		this.logger.Infof("Retrying CreateSnapshot on IVD Protected Entity, %v, for one hour at the maximum, Current retry count: %d", this.GetID().String(), retryCount)
+		var vslmTask *vslm.Task
+		vslmTask, err = this.ipetm.vslmManager.CreateSnapshot(ctx, NewVimIDFromPEID(this.GetID()), "AstrolabeSnapshot")
+		if err != nil {
+			return false, errors.Wrapf(err, "Failed to create a task for the CreateSnapshot invocation on IVD Protected Entity, %v", this.id.String())
+		}
+		this.logger.Infof("Retrieved VSLM task %s to track CreateSnapshot on IVD %s", vslmTask.Value, this.GetID().String())
+		retryCount++
+		start := time.Now()
+		ivdSnapshotIDAny, err := vslmTask.Wait(ctx, waitTime)
+		this.logger.Infof("Waited for %s to retrieve Task %s status.", time.Now().Sub(start), vslmTask.Value)
+		if err != nil {
+			if soap.IsVimFault(err) {
+				_, ok := soap.ToVimFault(err).(*vim.InvalidState)
+				if ok {
+					this.logger.WithError(err).Errorf("There is some operation, other than this CreateSnapshot invocation, on the VM attached still being protected by its VM state. Will retry in %v second(s)", retryInterval)
+					return false, nil
+				}
+				_, ok = soap.ToVimFault(err).(*vslmtypes.VslmSyncFault)
+				if ok {
+					this.logger.WithError(err).Errorf("CreateSnapshot failed with VslmSyncFault possibly due to race between concurrent DeleteSnapshot invocation. Will retry in %v second(s)", retryInterval)
+					return false, nil
+				}
+				_, ok = soap.ToVimFault(err).(*vim.NotFound)
+				if ok {
+					this.logger.WithError(err).Errorf("CreateSnapshot failed with NotFound. Will retry in %v second(s)", retryInterval)
+					return false, nil
+				}
+			}
+			if util.IsConnectionResetError(err) {
+				this.logger.WithError(err).Errorf("Network issue: connection reset by peer. Will retry in %v second(s)", retryInterval)
+				return false, nil
+			}
+			this.logger.Errorf("Error on CreateSnapshot: %+s", err.Error())
+			return false, errors.Wrapf(err, "Failed at waiting for the CreateSnapshot invocation on IVD Protected Entity, %v, Retry-Count: %d", this.id.String(), retryCount)
+		}
+		ivdSnapshotID := ivdSnapshotIDAny.(vim.ID)
+		this.logger.Infof("A new snapshot, %v, was created on IVD Protected Entity, %v, Retry-Count: %d, RetrieveSnapshotErr: %d", ivdSnapshotID.Id, this.GetID().String(), retryCount, retrieveSnapDetailsErr)
+
+		// Will try RetrieveSnapshotDetail right after the completion of CreateSnapshot to make sure there is no impact from race condition
+		_, err = this.ipetm.vslmManager.RetrieveSnapshotDetails(ctx, NewVimIDFromPEID(this.GetID()), ivdSnapshotID)
+		if err != nil {
+			retrieveSnapDetailsErr++
+			if soap.IsSoapFault(err) {
+				faultMsg := soap.ToSoapFault(err).String
+				if strings.Contains(faultMsg, "A specified parameter was not correct: snapshotId") {
+					this.logger.WithError(err).Error("Unexpected InvalidArgument SOAP fault due to the known race condition. Will retry")
+					return false, nil
+				}
+			}
+			this.logger.WithError(err).Warnf("Failed at retrieving the snapshot details post the" +
+				" completion of CreateSnapshot on %s, proceeding to use Snapshot %s anyways", this.id.String(), ivdSnapshotID.Id)
+		} else {
+			this.logger.Infof("The retrieval of the newly created snapshot, %s on IVD %s, " +
+				"is completed successfully, Retry-Count: %d, RetrieveSnapshotErr: %d",
+				ivdSnapshotID.Id, this.id.String(), retryCount, retrieveSnapDetailsErr)
+		}
+		retVal = astrolabe.NewProtectedEntitySnapshotID(ivdSnapshotID.Id)
+		return true, nil
+	})
+
+	if err != nil {
+		return astrolabe.ProtectedEntitySnapshotID{}, err
+	}
+	this.logger.Infof("CreateSnapshot completed on IVD Protected Entity, %v, with the new snapshot, %v, being created", this.id.String(), retVal.String())
+	return retVal, nil
+}
+
+func (this IVDProtectedEntity) ListSnapshots(ctx context.Context) ([]astrolabe.ProtectedEntitySnapshotID, error) {
+	peSnapshotIDs := []astrolabe.ProtectedEntitySnapshotID{}
+	this.logger.Infof("ListSnapshots called on IVD Protected Entity, %v", this.id.String())
+	err := this.ipetm.CheckVcenterConnections(ctx)
+	if err != nil {
+		return peSnapshotIDs, err
+	}
+	snapshotInfo, err := this.ipetm.vslmManager.RetrieveSnapshotInfo(ctx, NewVimIDFromPEID(this.GetID()))
+	if err != nil {
+		return nil, errors.Wrap(err, "RetrieveSnapshotInfo failed")
+	}
+	for _, curSnapshotInfo := range snapshotInfo {
+		peSnapshotIDs = append(peSnapshotIDs, astrolabe.NewProtectedEntitySnapshotID(curSnapshotInfo.Id.Id))
+	}
+	this.logger.Infof("Retrieved %d snapshots for pe-id: %s, snapshots= %v", len(peSnapshotIDs), this.GetID().String(), peSnapshotIDs)
+	return peSnapshotIDs, nil
+}
+func (this IVDProtectedEntity) DeleteSnapshot(ctx context.Context, snapshotToDelete astrolabe.ProtectedEntitySnapshotID, params map[string]map[string]interface{}) (bool, error) {
+	this.logger.Infof("DeleteSnapshot called on IVD Protected Entity, %v, with input arg, %v", this.GetID().String(), snapshotToDelete.String())
+	retryCount := 0
+	err := wait.PollImmediate(time.Second, time.Hour, func() (bool, error) {
+		err := this.ipetm.CheckVcenterConnections(ctx)
+		if err != nil {
+			this.logger.Errorf("The vCenter is disconnected during DeleteSnapshot operation, error: %v, retrying..", err)
+			return false, nil
+		}
+		this.logger.Debugf("Retrying DeleteSnapshot on IVD Protected Entity, %v, for one hour at the maximum", this.GetID().String())
+		vslmTask, err := this.ipetm.vslmManager.DeleteSnapshot(ctx, NewVimIDFromPEID(this.GetID()), NewVimSnapshotIDFromPESnapshotID(snapshotToDelete))
+		if err != nil {
+			// If the FCD is non-existent, Pandora immediately returns NotFound instead of creating a task.
+			if soap.IsSoapFault(err) {
+				soapFault := soap.ToSoapFault(err)
+				receivedFault := soapFault.Detail.Fault
+				_, ok := receivedFault.(vim.NotFound)
+				if ok {
+					this.logger.Warnf("The FCD id %s was not found in VC during deletion, assuming success, received error: %+v", this.GetID().GetID(), err)
+					return true, nil
+				}
+			}
+			return false, errors.Wrapf(err, "Failed to create a task for the DeleteSnapshot invocation on IVD Protected Entity, %v, with input arg, %v", this.GetID().String(), snapshotToDelete.String())
+		}
+		this.logger.Infof("Retrieved VSLM task %s to track DeleteSnapshot on IVD %s", vslmTask.Value, this.GetID().String())
+		retryCount++
+		start := time.Now()
+		_, err = vslmTask.Wait(ctx, waitTime)
+		this.logger.Infof("Waited for %s to retrieve Task %s status.", time.Now().Sub(start), vslmTask.Value)
+		if err != nil {
+			if soap.IsVimFault(err) {
+				switch soap.ToVimFault(err).(type) {
+				case *vim.InvalidArgument:
+					this.logger.WithError(err).Infof("Disk doesn't have given snapshot due to the snapshot stamp was removed in the previous DeleteSnapshot operation which failed with InvalidState fault. And it will be resolved by the next snapshot operation on the same VM. Will NOT retry")
+					return true, nil
+				case *vim.NotFound:
+					this.logger.WithError(err).Infof("There is a temporary catalog mismatch due to a race condition with one another concurrent DeleteSnapshot operation. And it will be resolved by the next consolidateDisks operation on the same VM. Will NOT retry")
+					return true, nil
+				case *vim.InvalidState:
+					this.logger.WithError(err).Error("There is some operation, other than this DeleteSnapshot invocation, on the same VM still being protected by its VM state. Will retry")
+					return false, nil
+				case *vim.TaskInProgress:
+					this.logger.WithError(err).Error("There is some other InProgress operation on the same VM. Will retry")
+					return false, nil
+				case *vim.FileLocked:
+					this.logger.WithError(err).Error("An error occurred while consolidating disks: Failed to lock the file. Will retry")
+					return false, nil
+				}
+			}
+			if util.IsConnectionResetError(err) {
+				this.logger.WithError(err).Error("Network issue: connection reset by peer. Will retry")
+				return false, nil
+			}
+			return false, errors.Wrapf(err, "Failed at waiting for the DeleteSnapshot invocation on IVD Protected Entity, %v, with input arg, %v", this.GetID().String(), snapshotToDelete.String())
+		}
+		return true, nil
+	})
+
+	if err != nil {
+		return false, err
+	}
+	this.logger.Infof("DeleteSnapshot completed on IVD Protected Entity, %s, with input arg, %s, Retry-Count: %d", this.GetID().String(), snapshotToDelete.String(), retryCount)
+	return true, nil
+}
+
+func (this IVDProtectedEntity) GetInfoForSnapshot(ctx context.Context, snapshotID astrolabe.ProtectedEntitySnapshotID) (*astrolabe.ProtectedEntityInfo, error) {
+	return nil, nil
+}
+
+func (this IVDProtectedEntity) GetComponents(ctx context.Context) ([]astrolabe.ProtectedEntity, error) {
+	return make([]astrolabe.ProtectedEntity, 0), nil
+}
+
+func (this IVDProtectedEntity) GetID() astrolabe.ProtectedEntityID {
+	return this.id
+}
+
+func (this IVDProtectedEntity) Overwrite(ctx context.Context, sourcePE astrolabe.ProtectedEntity, params map[string]map[string]interface{},
+	overwriteComponents bool) error {
+	this.logger.Infof("Overwriting current IVD PE %s with the source PE %s", this.GetID().String(), sourcePE.GetID().String())
+	// overwriteComponents is ignored because we have no components
+	if sourcePE.GetID().GetPeType() != "ivd" {
+		return errors.New("Overwrite source must be an ivd")
+	}
+	err := this.ipetm.CheckVcenterConnections(ctx)
+	if err != nil {
+		return err
+	}
+	// TODO - verify that our size is >= sourcePE size
+	metadataReader, err := sourcePE.GetMetadataReader(ctx)
+	if err != nil {
+		return errors.Wrap(err, "Could not retrieve metadata reader")
+	}
+
+	dataReader, err := sourcePE.GetDataReader(ctx)
+	if err != nil {
+		return errors.Wrap(err, "Could not retrieve data reader")
+	}
+
+	md, err := readMetadataFromReader(ctx, metadataReader)
+	// To enable cross-cluster restore, need to filter out the cns specific labels, i.e. prefix: cns, in md
+	md = FilterLabelsFromMetadataForCnsAPIs(md, "cns", this.logger)
+
+	_, err = this.copy(ctx, dataReader, md)
+	if err != nil {
+		return errors.Wrapf(err, "Data copy failed from PE %s, to PE %s", this.GetID().String(), sourcePE.GetID().String())
+	}
+	this.logger.Infof("Successfully Overwrote current IVD PE %s with the source PE %s", this.GetID().String(), sourcePE.GetID().String())
+	return nil
+}
+
+func NewIDFromString(idStr string) vim.ID {
+	return vim.ID{
+		Id: idStr,
+	}
+}
+
+func NewVimIDFromPEID(peid astrolabe.ProtectedEntityID) vim.ID {
+	if peid.GetPeType() == "ivd" {
+		return vim.ID{
+			Id: peid.GetID(),
+		}
+	} else {
+		return vim.ID{}
+	}
+}
+
+func NewVimSnapshotIDFromPEID(peid astrolabe.ProtectedEntityID) vim.ID {
+	if peid.HasSnapshot() {
+		return vim.ID{
+			Id: peid.GetSnapshotID().GetID(),
+		}
+	} else {
+		return vim.ID{}
+	}
+}
+
+func NewVimSnapshotIDFromPESnapshotID(peSnapshotID astrolabe.ProtectedEntitySnapshotID) vim.ID {
+	return vim.ID{
+		Id: peSnapshotID.GetID(),
+	}
+}

--- a/pkg/ivd/ivd_protected_entity_test.go
+++ b/pkg/ivd/ivd_protected_entity_test.go
@@ -1,0 +1,798 @@
+/*
+ * Copyright 2019 the Astrolabe contributors
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ivd
+
+import (
+	"context"
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/sirupsen/logrus"
+	"github.com/vmware-tanzu/astrolabe/pkg/astrolabe"
+	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/common/vsphere"
+	"github.com/vmware-tanzu/astrolabe/pkg/s3repository"
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/pbm"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/types"
+	"math"
+	"math/rand"
+	"os"
+	"reflect"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestProtectedEntityIDFromString(t *testing.T) {
+
+}
+
+const (
+	MaxNumOfIVDs = 15
+)
+
+func TestSnapshotOpsUnderRaceCondition(t *testing.T) {
+	// #0: Setup the environment
+	// Prerequisite: export ASTROLABE_VC_URL='https://<VC USER>:<VC USER PASSWORD>@<VC IP>/sdk'
+	u, exist := os.LookupEnv("ASTROLABE_VC_URL")
+	if !exist {
+		t.Skipf("ASTROLABE_VC_URL is not set")
+	}
+
+	nIVDs := 5
+	nIVDsStr, ok := os.LookupEnv("NUM_OF_IVD")
+	if ok {
+		nIVDsInt, err := strconv.Atoi(nIVDsStr)
+		if err == nil && nIVDsInt > 0 && nIVDsInt <= MaxNumOfIVDs {
+			nIVDs = nIVDsInt
+		}
+	}
+
+	vcUrl, err := soap.ParseURL(u)
+	if err != nil {
+		t.Skipf("Failed to parse the env variable, ASTROLABE_VC_URL, with err: %v", err)
+	}
+
+	ctx := context.Background()
+	logger := logrus.New()
+	formatter := new(logrus.TextFormatter)
+	formatter.TimestampFormat = time.RFC3339Nano
+	formatter.FullTimestamp = true
+	logger.SetFormatter(formatter)
+	logger.SetLevel(logrus.DebugLevel)
+	s3Config := astrolabe.S3Config{
+		URLBase: "VOID_URL",
+	}
+
+	params := make(map[string]interface{})
+	params[vsphere.HostVcParamKey] = vcUrl.Host
+	params[vsphere.PortVcParamKey] = vcUrl.Port()
+	params[vsphere.UserVcParamKey] = vcUrl.User.Username()
+	password, _ := vcUrl.User.Password()
+	params[vsphere.PasswordVcParamKey] = password
+	params[vsphere.InsecureFlagVcParamKey] = true
+	params[vsphere.ClusterVcParamKey] = ""
+
+	ivdPETM := getIVDProtectedEntityTypeManager(t, err, params, s3Config, logger)
+
+	virtualCenter := ivdPETM.vcenter
+
+	// #1: Create a few of IVDs
+	datastoreType := types.HostFileSystemVolumeFileSystemTypeVsan
+	datastores, err := findAllAccessibleDatastoreByType(ctx, virtualCenter.Client.Client, datastoreType)
+	if err != nil || len(datastores) <= 0 {
+		t.Skipf("Failed to find any all accessible datastore with type, %v", datastoreType)
+	}
+
+	logger.Infof("Step 1: Creating %v IVDs", nIVDs)
+	ivdDs := datastores[0]
+	var ivdIds []types.ID
+	for i := 0; i < nIVDs; i++ {
+		createSpec := getCreateSpec(getRandomName("ivd", 5), 10, ivdDs, nil)
+		vslmTask, err := ivdPETM.vslmManager.CreateDisk(ctx, createSpec)
+		if err != nil {
+			t.Skipf("Failed to create task for CreateDisk invocation")
+		}
+
+		taskResult, err := vslmTask.Wait(ctx, waitTime)
+		if err != nil {
+			t.Skipf("Failed at waiting for the CreateDisk invocation")
+		}
+		vStorageObject := taskResult.(types.VStorageObject)
+		ivdIds = append(ivdIds, vStorageObject.Config.Id)
+		logger.Debugf("IVD, %v, created", vStorageObject.Config.Id.Id)
+	}
+
+	if ivdIds == nil {
+		t.Skipf("Failed to create the list of ivds as expected")
+	}
+
+	defer func() {
+		for i := 0; i < nIVDs; i++ {
+			vslmTask, err := ivdPETM.vslmManager.Delete(ctx, ivdIds[i])
+			if err != nil {
+				t.Skipf("Failed to create task for DeleteDisk invocation with err: %v", err)
+			}
+
+			_, err = vslmTask.Wait(ctx, waitTime)
+			if err != nil {
+				t.Skipf("Failed at waiting for the DeleteDisk invocation with err: %v", err)
+			}
+			logger.Debugf("IVD, %v, deleted", ivdIds[i].Id)
+		}
+	}()
+
+	// #2: Create a VM
+	logger.Info("Step 2: Creating a VM")
+	hosts, err := findAllHosts(ctx, virtualCenter.Client.Client)
+	if err != nil || len(hosts) <= 0 {
+		t.Skipf("Failed to find all available hosts")
+	}
+	vmHost := hosts[0]
+
+	pc := property.DefaultCollector(virtualCenter.Client.Client)
+	var ivdDsMo mo.Datastore
+	err = pc.RetrieveOne(ctx, ivdDs.Reference(), []string{"name"}, &ivdDsMo)
+	if err != nil {
+		t.Skipf("Failed to get datastore managed object with err: %v", err)
+	}
+
+	logger.Debugf("Creating VM on host: %v, and datastore: %v", vmHost.Reference(), ivdDsMo.Name)
+	vmName := getRandomName("vm", 5)
+	vmMo, err := vmCreate(ctx, virtualCenter.Client.Client, vmHost.Reference(), vmName, ivdDsMo.Name, nil, logger)
+	if err != nil {
+		t.Skipf("Failed to create a VM with err: %v", err)
+	}
+	vmRef := vmMo.Reference()
+	logger.Debugf("VM, %v(%v), created on host: %v, and datastore: %v", vmRef, vmName, vmHost, ivdDsMo.Name)
+	defer func() {
+		vimTask, err := vmMo.Destroy(ctx)
+		if err != nil {
+			t.Skipf("Failed to destroy the VM %v with err: %v", vmName, err)
+		}
+		err = vimTask.Wait(ctx)
+		if err != nil {
+			t.Skipf("Failed at waiting for the destroy of VM %v with err: %v", vmName, err)
+		}
+		logger.Debugf("VM, %v(%v), destroyed", vmRef, vmName)
+	}()
+
+	// #3: Attach those IVDs to the VM
+	logger.Infof("Step 3: Attaching IVDs to VM %v", vmName)
+	for i := 0; i < nIVDs; i++ {
+		err = vmAttachDiskWithWait(ctx, virtualCenter.Client.Client, vmRef.Reference(), ivdIds[i], ivdDs.Reference())
+		if err != nil {
+			t.Skipf("Failed to attach ivd, %v, to, VM, %v with err: %v", ivdIds[i].Id, vmName, err)
+		}
+
+		logger.Debugf("IVD, %v, attached to VM, %v", ivdIds[i].Id, vmName)
+	}
+
+	defer func() {
+		for i := 0; i < nIVDs; i++ {
+			err = vmDetachDiskWithWait(ctx, virtualCenter.Client.Client, vmRef.Reference(), ivdIds[i])
+			if err != nil {
+				t.Skipf("Failed to detach ivd, %v, to, VM, %v with err: %v", ivdIds[i].Id, vmName, err)
+			}
+
+			logger.Debugf("IVD, %v, detached from VM, %v", ivdIds[i].Id, vmName)
+		}
+	}()
+
+	// #4: Mimic the race condition by running the concurrent CreateSnapshot and DeleteSnapshot operations
+	logger.Info("Step 4: Testing the API behavior under concurrent snapshot invocations")
+	errChannels := make([]chan error, nIVDs)
+	var wg sync.WaitGroup
+	var mutex sync.Mutex
+	for i := 0; i < nIVDs; i++ {
+		wg.Add(1)
+		go worker(&wg, &mutex, logger, params, i, ivdIds[i], ivdDs, errChannels)
+	}
+	wg.Wait()
+
+	defer func() {
+		logger.Debugf("Always clean up snapshots created in the test")
+		for i := 0; i < nIVDs; i++ {
+			logger.Debugf("Cleaning up snapshots for IVD %v", ivdIds[i].Id)
+			snapshotInfos, err := ivdPETM.vslmManager.RetrieveSnapshotInfo(ctx, ivdIds[i])
+			if err != nil {
+				t.Fatalf("Failed at retrieving snapshot info from IVD %v with err: %v", ivdIds[i].Id, err)
+			}
+
+			if len(snapshotInfos) == 0 {
+				logger.Debugf("No unexpected snasphot left behind for IVD %v", ivdIds[i].Id)
+				continue
+			}
+
+			for _, snapshotInfo := range snapshotInfos {
+				logger.Debugf("Cleaning up snapshot %v created for IVD %v but failed to be deleted", snapshotInfo.Id.Id, ivdIds[i].Id)
+				ivdPE, err := ivdPETM.GetProtectedEntity(ctx, newProtectedEntityID(ivdIds[i]))
+				if err != nil {
+					t.Fatalf("[Cleanup] Failed to get IVD protected entity at the cleanup phase with err: %v", err)
+				}
+				peSnapID := astrolabe.NewProtectedEntitySnapshotID(snapshotInfo.Id.Id)
+				_, err = ivdPE.DeleteSnapshot(ctx, peSnapID, make(map[string]map[string]interface{}))
+				if err != nil {
+					t.Fatalf("[Cleanup] Failed to DeleteSnapshot, %v, on IVD protected entity, %v with err: %v", peSnapID.GetID(), ivdPE.GetID().GetID(), err)
+				}
+			}
+		}
+	}()
+
+	// Error Handling
+	var result bool
+	result = true
+	for i := 0; i < nIVDs; i++ {
+		err := <-errChannels[i]
+		if err != nil {
+			result = false
+			t.Errorf("Worker %v on IVD %v failed with err: %v", i, ivdIds[i].Id, err)
+		}
+	}
+
+	if !result {
+		t.Fatal("Test Failed")
+	}
+
+}
+
+func worker(wg *sync.WaitGroup, mutex *sync.Mutex, logger logrus.FieldLogger, params map[string]interface{}, id int, diskId types.ID, datastore types.ManagedObjectReference, errChans []chan error) {
+	log := logger.WithFields(logrus.Fields{
+		"WorkerID": id,
+		"IvdID":    diskId.Id,
+	})
+	var err error
+	log.Debugf("Worker starting")
+	defer func() {
+		log.Debugf("Worker completed with err: %v", err)
+	}()
+
+	errChans[id] = make(chan error)
+	defer func() {
+		errChans[id] <- err
+		close(errChans[id])
+	}()
+
+	defer wg.Done()
+
+	ctx := context.Background()
+
+	s3Config := astrolabe.S3Config{
+		URLBase: "VOID_URL",
+	}
+	astrolabePETM, err := NewIVDProtectedEntityTypeManager(params, s3Config, logger)
+	if err != nil {
+		log.Error("Failed to get a new ivd PETM")
+		return
+	}
+	ivdPETM, ok := astrolabePETM.(*IVDProtectedEntityTypeManager)
+	if !ok {
+		log.Error("Did not get an IVDProtectedEntityTypeManager from NewIVDProtectedEntityTypeManager")
+		return
+	}
+	ivdPE, err := ivdPETM.GetProtectedEntity(ctx, newProtectedEntityID(diskId))
+	if err != nil {
+		log.Error("Failed to get IVD protected entity")
+		return
+	}
+
+	log.Debugf("Creating a snapshot on IVD protected entity")
+	peSnapID, err := createSnapshotLocked(mutex, ctx, ivdPE, log)
+	if err != nil {
+		log.Error("Failed to snapshot the IVD protected entity")
+		return
+	}
+
+	log.Debugf("Retrieving the newly created snapshot, %v, on IVD protected entity, %v", peSnapID.GetID(), ivdPE.GetID().GetID())
+	_, err = ivdPETM.vslmManager.RetrieveSnapshotDetails(ctx, diskId, NewIDFromString(peSnapID.String()))
+	if err != nil {
+		if soap.IsSoapFault(err) {
+			soapFault := soap.ToSoapFault(err)
+			soapType := reflect.TypeOf(soapFault)
+			log.WithError(err).Errorf("soap fault type: %v, err: %v", soapType, soapFault)
+			faultMsg := soap.ToSoapFault(err).String
+			if strings.Contains(faultMsg, "A specified parameter was not correct: snapshotId") {
+				log.WithError(err).Error("Unexpected InvalidArgument soap fault due to race condition")
+				return
+			}
+			log.WithError(err).Error("Unexpected soap fault")
+		} else {
+			log.WithError(err).Error("Unexpected other fault")
+		}
+
+		return
+	}
+
+	log.Debugf("Deleting the newly created snapshot, %v, on IVD protected entity, %v", peSnapID.GetID(), ivdPE.GetID().GetID())
+	_, err = ivdPE.DeleteSnapshot(ctx, peSnapID, make(map[string]map[string]interface{}))
+	if err != nil {
+		log.WithError(err).Errorf("Failed to DeleteSnapshot, %v, on IVD protected entity, %v", peSnapID.GetID(), ivdPE.GetID().GetID())
+	}
+}
+
+func createSnapshotLocked(mutex *sync.Mutex, ctx context.Context, ivdPE astrolabe.ProtectedEntity, log logrus.FieldLogger) (astrolabe.ProtectedEntitySnapshotID, error) {
+	log.Debugf("Acquiring the lock on CreateSnapshot")
+	mutex.Lock()
+	log.Debugf("Acquired the lock on CreateSnapshot")
+	defer func() {
+		mutex.Unlock()
+		log.Debugf("Released the lock on CreateSnapshot")
+	}()
+	peSnapID, err := ivdPE.Snapshot(ctx, nil)
+	if err != nil {
+		log.Error("Failed to snapshot the IVD protected entity")
+		return astrolabe.ProtectedEntitySnapshotID{}, err
+	}
+	return peSnapID, nil
+}
+
+func findAllHosts(ctx context.Context, client *vim25.Client) ([]types.ManagedObjectReference, error) {
+	finder := find.NewFinder(client)
+
+	hosts, err := finder.HostSystemList(ctx, "*")
+	if err != nil {
+		return nil, err
+	}
+
+	var hostList []types.ManagedObjectReference
+	for _, host := range hosts {
+		hostList = append(hostList, host.Reference())
+	}
+
+	return hostList, nil
+}
+
+func findAllAccessibleDatastoreByType(ctx context.Context, client *vim25.Client, datastoreType types.HostFileSystemVolumeFileSystemType) ([]types.ManagedObjectReference, error) {
+	finder := find.NewFinder(client)
+
+	hosts, err := findAllHosts(ctx, client)
+	if err != nil {
+		return nil, err
+	}
+	nHosts := len(hosts)
+
+	dss, err := finder.DatastoreList(ctx, "*")
+	if err != nil {
+		return nil, err
+	}
+
+	var dsList []types.ManagedObjectReference
+	for _, ds := range dss {
+		attachedHosts, err := ds.AttachedHosts(ctx)
+		if err != nil {
+			fmt.Printf("Failed to get all the attached hosts of datastore %v\n", ds.Name())
+			continue
+		}
+		if nHosts != len(attachedHosts) {
+			continue
+		}
+
+		dsType, err := ds.Type(ctx)
+		if err != nil {
+			fmt.Printf("Failed to get type of datastore %v\n", ds.Name())
+			continue
+		}
+		if dsType == datastoreType {
+			dsList = append(dsList, ds.Reference())
+			break
+		}
+	}
+
+	return dsList, nil
+}
+
+func getCreateSpec(name string, capacity int64, datastore types.ManagedObjectReference, profile []types.BaseVirtualMachineProfileSpec) types.VslmCreateSpec {
+	keepAfterDeleteVm := true
+	return types.VslmCreateSpec{
+		Name:              name,
+		KeepAfterDeleteVm: &keepAfterDeleteVm,
+		BackingSpec: &types.VslmCreateSpecDiskFileBackingSpec{
+			VslmCreateSpecBackingSpec: types.VslmCreateSpecBackingSpec{
+				Datastore: datastore,
+			},
+		},
+		CapacityInMB: capacity,
+		Profile:      profile,
+	}
+}
+
+func getRandomName(prefix string, nDigits int) string {
+	rand.Seed(time.Now().UnixNano())
+	num := rand.Int63n(int64(math.Pow10(nDigits)))
+	numstr := strconv.FormatInt(num, 10)
+	return fmt.Sprintf("%s-%s", prefix, numstr)
+}
+
+func vmAttachDisk(ctx context.Context, client *vim25.Client, vm types.ManagedObjectReference, diskId types.ID, datastore types.ManagedObjectReference) (*object.Task, error) {
+	req := types.AttachDisk_Task{
+		This:       vm.Reference(),
+		DiskId:     diskId,
+		Datastore:  datastore.Reference(),
+		UnitNumber: nil,
+	}
+
+	res, err := methods.AttachDisk_Task(ctx, client, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return object.NewTask(client, res.Returnval), nil
+}
+
+func vmAttachDiskWithWait(ctx context.Context, client *vim25.Client, vm types.ManagedObjectReference, diskId types.ID, datastore types.ManagedObjectReference) error {
+	vimTask, err := vmAttachDisk(ctx, client, vm, diskId, datastore)
+	if err != nil {
+		return err
+	}
+
+	err = vimTask.Wait(ctx)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func vmDetachDisk(ctx context.Context, client *vim25.Client, vm types.ManagedObjectReference, diskId types.ID) (*object.Task, error) {
+	req := types.DetachDisk_Task{
+		This:   vm.Reference(),
+		DiskId: diskId,
+	}
+
+	res, err := methods.DetachDisk_Task(ctx, client, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return object.NewTask(client, res.Returnval), nil
+}
+
+func vmDetachDiskWithWait(ctx context.Context, client *vim25.Client, vm types.ManagedObjectReference, diskId types.ID) error {
+	vimTask, err := vmDetachDisk(ctx, client, vm, diskId)
+	if err != nil {
+		return err
+	}
+
+	err = vimTask.Wait(ctx)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func vmCreate(ctx context.Context, client *vim25.Client, vmHost types.ManagedObjectReference, vmName string, dsName string, vmProfile []types.BaseVirtualMachineProfileSpec, logger logrus.FieldLogger) (*object.VirtualMachine, error) {
+	finder := find.NewFinder(client)
+	virtualMachineConfigSpec := types.VirtualMachineConfigSpec{
+		Name: vmName,
+		Files: &types.VirtualMachineFileInfo{
+			VmPathName: "[" + dsName + "]",
+		},
+		Annotation: "Quick Dummy",
+		GuestId:    "otherLinux64Guest",
+		NumCPUs:    1,
+		MemoryMB:   128,
+		DeviceChange: []types.BaseVirtualDeviceConfigSpec{
+			&types.VirtualDeviceConfigSpec{
+				Operation: types.VirtualDeviceConfigSpecOperationAdd,
+				Device: &types.ParaVirtualSCSIController{
+					VirtualSCSIController: types.VirtualSCSIController{
+						SharedBus: types.VirtualSCSISharingNoSharing,
+						VirtualController: types.VirtualController{
+							BusNumber: 0,
+							VirtualDevice: types.VirtualDevice{
+								Key: 1000,
+							},
+						},
+					},
+				},
+			},
+		},
+		VmProfile: vmProfile,
+	}
+	defaultFolder, err := finder.DefaultFolder(ctx)
+	defaultResourcePool, err := finder.DefaultResourcePool(ctx)
+	vmHostSystem := object.NewHostSystem(client, vmHost)
+	task, err := defaultFolder.CreateVM(ctx, virtualMachineConfigSpec, defaultResourcePool, vmHostSystem)
+	if err != nil {
+		logger.Errorf("Failed to create VM. Error: %v", err)
+		return nil, err
+	}
+
+	vmTaskInfo, err := task.WaitForResult(ctx, nil)
+	if err != nil {
+		logger.Errorf("Error occurred while waiting for create VM task result. Error: %v", err)
+		return nil, err
+	}
+
+	vmRef := vmTaskInfo.Result.(object.Reference)
+	nodeVM := object.NewVirtualMachine(client, vmRef.Reference())
+	return nodeVM, nil
+}
+
+func TestBackupEncryptedIVD(t *testing.T) {
+	// #0: Setup the environment
+	// Prerequisite: export ASTROLABE_VC_URL='https://<VC USER>:<VC USER PASSWORD>@<VC IP>/sdk'
+	u, exist := os.LookupEnv("ASTROLABE_VC_URL")
+	if !exist {
+		t.Skipf("ASTROLABE_VC_URL is not set")
+	}
+
+	vcUrl, err := soap.ParseURL(u)
+	if err != nil {
+		t.Skipf("Failed to parse the env variable, ASTROLABE_VC_URL, with err: %v", err)
+	}
+
+	ctx := context.Background()
+	logger := logrus.New()
+	formatter := new(logrus.TextFormatter)
+	formatter.TimestampFormat = time.RFC3339Nano
+	formatter.FullTimestamp = true
+	logger.SetFormatter(formatter)
+	logger.SetLevel(logrus.DebugLevel)
+	s3Config := astrolabe.S3Config{
+		URLBase: "VOID_URL",
+	}
+	params := make(map[string]interface{})
+	params[vsphere.HostVcParamKey] = vcUrl.Host
+	params[vsphere.PortVcParamKey] = vcUrl.Port()
+	params[vsphere.UserVcParamKey] = vcUrl.User.Username()
+	password, _ := vcUrl.User.Password()
+	params[vsphere.PasswordVcParamKey] = password
+	params[vsphere.InsecureFlagVcParamKey] = true
+	params[vsphere.ClusterVcParamKey] = ""
+
+	ivdPETM := getIVDProtectedEntityTypeManager(t, err, params, s3Config, logger)
+
+	virtualCenter := ivdPETM.vcenter
+	datastoreType := types.HostFileSystemVolumeFileSystemTypeVsan
+	datastores, err := findAllAccessibleDatastoreByType(ctx, virtualCenter.Client.Client, datastoreType)
+	if err != nil || len(datastores) <= 0 {
+		t.Skipf("Failed to find any all accessible datastore with type, %v", datastoreType)
+	}
+	vmDs := datastores[0]
+	ivdDs := datastores[len(datastores)-1]
+	encryptionProfileId, err := getEncryptionProfileId(ctx, virtualCenter.Client.Client)
+	if err != nil {
+		t.Skipf("Failed to get encryption profile ID: %v", err)
+	}
+
+	// #1: Create an encrypted VM
+	logger.Info("Step 1: Creating a VM")
+	hosts, err := findAllHosts(ctx, virtualCenter.Client.Client)
+	if err != nil || len(hosts) <= 0 {
+		t.Skipf("Failed to find all available hosts")
+	}
+	vmHost := hosts[0]
+
+	pc := property.DefaultCollector(virtualCenter.Client.Client)
+	var vmDsMo mo.Datastore
+	err = pc.RetrieveOne(ctx, vmDs.Reference(), []string{"name"}, &vmDsMo)
+	if err != nil {
+		t.Skipf("Failed to get datastore managed object with err: %v", err)
+	}
+
+	logger.Debugf("Creating VM on host: %v, and datastore: %v", vmHost.Reference(), vmDsMo.Name)
+	vmName := getRandomName("vm", 5)
+	vmProfile := getProfileSpecs(encryptionProfileId)
+	vmMo, err := vmCreate(ctx, virtualCenter.Client.Client, vmHost.Reference(), vmName, vmDsMo.Name, vmProfile, logger)
+	if err != nil {
+		t.Skipf("Failed to create a VM with err: %v", err)
+	}
+	vmRef := vmMo.Reference()
+	logger.Debugf("VM, %v(%v), created on host: %v, and datastore: %v", vmRef, vmName, vmHost, vmDsMo.Name)
+	defer func() {
+		vimTask, err := vmMo.Destroy(ctx)
+		if err != nil {
+			t.Skipf("Failed to destroy the VM %v with err: %v", vmName, err)
+		}
+		err = vimTask.Wait(ctx)
+		if err != nil {
+			t.Skipf("Failed at waiting for the destroy of VM %v with err: %v", vmName, err)
+		}
+		logger.Debugf("VM, %v(%v), destroyed", vmRef, vmName)
+	}()
+
+	// #2: Poweron the VM
+	logger.Info("Step 2: Powering on a VM")
+	vimTask, err := vmMo.PowerOn(ctx)
+	if err != nil {
+		t.Skipf("Failed to create a VM PowerOn task: %v", err)
+	}
+	err = vimTask.Wait(ctx)
+	if err != nil {
+		t.Skipf("Failed at waiting for the PowerOn of VM %v with err: %v", vmName, err)
+	}
+	logger.Debugf("VM, %v(%v), powered on", vmRef, vmName)
+	defer func() {
+		vimTask, err := vmMo.PowerOff(ctx)
+		if err != nil {
+			t.Skipf("Failed to create a VM PowerOff task: %v", err)
+		}
+		err = vimTask.Wait(ctx)
+		if err != nil {
+			t.Skipf("Failed at waiting for the PowerOff of VM %v with err: %v", vmName, err)
+		}
+		logger.Debugf("VM, %v(%v), powered off", vmRef, vmName)
+	}()
+
+	// #3: Create encrypted IVDs
+	nIVDs := 2
+	logger.Infof("Creating %v encrypted IVDs", nIVDs)
+	ivdProfile := vmProfile
+
+	var ivdIds []types.ID
+	for i := 0; i < nIVDs; i++ {
+		createSpec := getCreateSpec(getRandomName("ivd", 5), 50, ivdDs, ivdProfile)
+		vslmTask, err := ivdPETM.vslmManager.CreateDisk(ctx, createSpec)
+		if err != nil {
+			t.Skipf("Failed to create task for CreateDisk invocation")
+		}
+
+		taskResult, err := vslmTask.Wait(ctx, waitTime)
+		if err != nil {
+			t.Skipf("Failed at waiting for the CreateDisk invocation")
+		}
+		vStorageObject := taskResult.(types.VStorageObject)
+		ivdIds = append(ivdIds, vStorageObject.Config.Id)
+		logger.Debugf("IVD, %v, created", vStorageObject.Config.Id.Id)
+	}
+
+	if ivdIds == nil {
+		t.Skipf("Failed to create the list of ivds as expected")
+	}
+
+	defer func() {
+		for i := 0; i < nIVDs; i++ {
+			vslmTask, err := ivdPETM.vslmManager.Delete(ctx, ivdIds[i])
+			if err != nil {
+				t.Skipf("Failed to create task for DeleteDisk invocation with err: %v", err)
+			}
+
+			_, err = vslmTask.Wait(ctx, waitTime)
+			if err != nil {
+				t.Skipf("Failed at waiting for the DeleteDisk invocation with err: %v", err)
+			}
+			logger.Debugf("IVD, %v, deleted", ivdIds[i].Id)
+		}
+	}()
+
+	// #4: Attach it to VM
+	logger.Infof("Step 4: Attaching IVDs to VM %v", vmName)
+	for i := 0; i < nIVDs; i++ {
+		err = vmAttachDiskWithWait(ctx, virtualCenter.Client.Client, vmRef.Reference(), ivdIds[i], ivdDs.Reference())
+		if err != nil {
+			t.Skipf("Failed to attach ivd, %v, to, VM, %v with err: %v", ivdIds[i].Id, vmName, err)
+		}
+
+		logger.Debugf("IVD, %v, attached to VM, %v", ivdIds[i].Id, vmName)
+	}
+
+	defer func() {
+		for i := 0; i < nIVDs; i++ {
+			err = vmDetachDiskWithWait(ctx, virtualCenter.Client.Client, vmRef.Reference(), ivdIds[i])
+			if err != nil {
+				t.Skipf("Failed to detach ivd, %v, to, VM, %v with err: %v", ivdIds[i].Id, vmName, err)
+			}
+
+			logger.Debugf("IVD, %v, detached from VM, %v", ivdIds[i].Id, vmName)
+		}
+	}()
+	// #5: Backup the IVD
+	logger.Infof("Step 5: Backing up encrypted IVDs")
+	// #5.1: Create an IVD snapshot
+	logger.Debugf("Creating a snapshot on each IVD")
+	//var snapPEIDs []astrolabe.ProtectedEntityID
+	snapPEIDtoIvdPEMap := make(map[astrolabe.ProtectedEntityID]astrolabe.ProtectedEntity)
+	for _, ivdId := range ivdIds {
+		ivdPE, err := ivdPETM.GetProtectedEntity(ctx, newProtectedEntityID(ivdId))
+		if err != nil {
+			t.Skipf("Failed to get IVD protected entity for the IVD, %v", ivdId)
+		}
+
+		snapID, err := ivdPE.Snapshot(ctx, nil)
+		if err != nil {
+			t.Errorf("Failed to snapshot the IVD protected entity, %v", ivdId)
+		}
+		snapPEID := astrolabe.NewProtectedEntityIDWithSnapshotID("ivd", ivdId.Id, snapID)
+		snapPEIDtoIvdPEMap[snapPEID] = ivdPE
+	}
+
+	// #5.2: Copy the IVD snapshot to specified object store
+	logger.Debugf("Copying the IVD snapshots to object store")
+	s3PETM, err := setupPETM("ivd", logger)
+	if err != nil {
+		t.Skipf("Failed to setup s3 PETM for the object store")
+	}
+
+	snapPEIDtos3PEMap := make(map[astrolabe.ProtectedEntityID]astrolabe.ProtectedEntity)
+	for snapPEID, _ := range snapPEIDtoIvdPEMap {
+		snapPE, err := ivdPETM.GetProtectedEntity(ctx, snapPEID)
+		if err != nil {
+			t.Fatalf("Failed to get snapshot protected entity for the IVD snapshot, %v", snapPEID.String())
+		}
+		s3PE, err := s3PETM.Copy(ctx, snapPE, make(map[string]map[string]interface{}), astrolabe.AllocateNewObject)
+		if err != nil {
+			t.Fatalf("Failed to copy snapshot PE, %v, to S3 object store: %v", snapPEID.String(), err)
+		}
+		snapPEIDtos3PEMap[snapPEID] = s3PE
+	}
+
+	defer func() {
+		for snapPEID, _ := range snapPEIDtoIvdPEMap {
+			s3PE := snapPEIDtos3PEMap[snapPEID]
+			_, err := s3PE.DeleteSnapshot(ctx, snapPEID.GetSnapshotID(), make(map[string]map[string]interface{}))
+			if err != nil {
+				logger.Errorf("Failed to delete snapshot, %v, on object store: %v", snapPEID.GetSnapshotID().String(), err)
+			}
+		}
+	}()
+
+	// #5.3: Delete the local IVD snapshot
+	for snapPEID, ivdPE := range snapPEIDtoIvdPEMap {
+		_, err := ivdPE.DeleteSnapshot(ctx, snapPEID.GetSnapshotID(), make(map[string]map[string]interface{}))
+		if err != nil {
+			t.Fatalf("Failed to delete local IVD snapshot, %v: %v", snapPEID.GetSnapshotID(), err)
+		}
+	}
+}
+
+func getProfileSpecs(profileId string) []types.BaseVirtualMachineProfileSpec {
+	var profileSpecs []types.BaseVirtualMachineProfileSpec
+	if profileId == "" {
+		profileSpecs = append(profileSpecs, &types.VirtualMachineDefaultProfileSpec{})
+	} else {
+		profileSpecs = append(profileSpecs, &types.VirtualMachineDefinedProfileSpec{
+			VirtualMachineProfileSpec: types.VirtualMachineProfileSpec{},
+			ProfileId:                 profileId,
+		})
+	}
+	return profileSpecs
+}
+
+func getEncryptionProfileId(ctx context.Context, client *vim25.Client) (string, error) {
+	pbmClient, err := pbm.NewClient(ctx, client)
+	if err != nil {
+		return "", err
+	}
+
+	encryptionProfileName := "VM Encryption Policy"
+	return pbmClient.ProfileIDByName(ctx, encryptionProfileName)
+}
+
+func setupPETM(typeName string, logger logrus.FieldLogger) (*s3repository.ProtectedEntityTypeManager, error) {
+	sess, err := session.NewSession(&aws.Config{
+		Region: aws.String("us-west-1")},
+	)
+	if err != nil {
+		return nil, err
+	}
+	s3petm, err := s3repository.NewS3RepositoryProtectedEntityTypeManager(typeName, *sess, "velero-plugin-s3-repo",
+		"plugins/vsphere-volumes-repo/", logger)
+	if err != nil {
+		return nil, err
+	}
+	return s3petm, err
+}

--- a/pkg/ivd/ivd_protected_entity_type_manager.go
+++ b/pkg/ivd/ivd_protected_entity_type_manager.go
@@ -1,0 +1,410 @@
+/*
+ * Copyright 2019 the Astrolabe contributors
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ivd
+
+import (
+	"context"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/vmware-tanzu/astrolabe/pkg/astrolabe"
+	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/common/vsphere"
+	"github.com/vmware-tanzu/astrolabe/pkg/util"
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/govmomi/vslm"
+	vslmtypes "github.com/vmware/govmomi/vslm/types"
+	"github.com/vmware/virtual-disks/pkg/disklib"
+	"io"
+	"sync"
+	"time"
+)
+
+const vsphereMajor = 6
+const vSphereMinor = 7
+const disklibLib64 = "/usr/lib/vmware-vix-disklib/lib64"
+const vddkconfig = "vddk-config"
+
+var configLoadLock sync.Mutex
+
+type IVDProtectedEntityTypeManager struct {
+	vcenterConfig *vsphere.VirtualCenterConfig
+	vcenter       *vsphere.VirtualCenter
+	vslmManager   *vsphere.VslmManager
+	cnsManager    *vsphere.CnsManager
+	s3Config      astrolabe.S3Config
+	logger        logrus.FieldLogger
+}
+
+func NewIVDProtectedEntityTypeManager(params map[string]interface{},
+	s3Config astrolabe.S3Config,
+	logger logrus.FieldLogger) (astrolabe.ProtectedEntityTypeManager, error) {
+	logger.Infof("Initializing IVD Protected Entity Manager")
+	retVal := IVDProtectedEntityTypeManager{
+		s3Config:      s3Config,
+		logger:        logger,
+	}
+	logger.Infof("Loading new IVD Protected Entity Manager")
+	err := retVal.ReloadConfig(context.Background(), params)
+	if err != nil {
+		logger.Errorf("Could not initialize ivd service, error: %v", err)
+		logger.Warn("Saving uninitialized ivd service, will retry on service access..")
+	}
+	return &retVal, nil
+}
+
+func (this *IVDProtectedEntityTypeManager) GetTypeName() string {
+	return "ivd"
+}
+
+func (this *IVDProtectedEntityTypeManager) GetProtectedEntity(ctx context.Context, id astrolabe.ProtectedEntityID) (astrolabe.ProtectedEntity, error) {
+	err := this.CheckVcenterConnections(ctx)
+	if err != nil {
+		return nil, err
+	}
+	retIPE, err := newIVDProtectedEntity(this, id)
+	if err != nil {
+		return nil, err
+	}
+	return retIPE, nil
+}
+
+func (this *IVDProtectedEntityTypeManager) GetProtectedEntities(ctx context.Context) ([]astrolabe.ProtectedEntityID, error) {
+	err := this.CheckVcenterConnections(ctx)
+	if err != nil {
+		return []astrolabe.ProtectedEntityID{}, err
+	}
+	// Kludge because of PR
+	spec := vslmtypes.VslmVsoVStorageObjectQuerySpec{
+		QueryField:    "createTime",
+		QueryOperator: "greaterThan",
+		QueryValue:    []string{"0"},
+	}
+	res, err := this.vslmManager.ListObjectsForSpec(ctx, []vslmtypes.VslmVsoVStorageObjectQuerySpec{spec}, 1000)
+	if err != nil {
+		return nil, err
+	}
+	retIDs := make([]astrolabe.ProtectedEntityID, len(res.Id))
+	for idNum, curVSOID := range res.Id {
+		retIDs[idNum] = newProtectedEntityID(curVSOID)
+	}
+	return retIDs, nil
+}
+
+func (this *IVDProtectedEntityTypeManager) Copy(ctx context.Context, sourcePE astrolabe.ProtectedEntity,
+	params map[string]map[string]interface{}, options astrolabe.CopyCreateOptions) (astrolabe.ProtectedEntity, error) {
+	sourcePEInfo, err := sourcePE.GetInfo(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "GetInfo failed")
+	}
+	dataReader, err := sourcePE.GetDataReader(ctx)
+
+	if err != nil {
+		return nil, errors.Wrap(err, "GetDataReader failed")
+	}
+
+	if dataReader != nil { // If there's no data we will not get a reader and no error
+		defer func() {
+			if err := dataReader.Close(); err != nil {
+				this.logger.Errorf("The deferred data reader is closed with error, %v", err)
+			}
+		}()
+	}
+
+	metadataReader, err := sourcePE.GetMetadataReader(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "GetMetadataReader failed")
+	}
+	returnPE, err := this.copyInt(ctx, sourcePEInfo, options, dataReader, metadataReader)
+	if err != nil {
+		return nil, errors.Wrap(err, "copyInt failed")
+	}
+	return returnPE, nil
+}
+
+func (this *IVDProtectedEntityTypeManager) CopyFromInfo(ctx context.Context, peInfo astrolabe.ProtectedEntityInfo,
+	params map[string]map[string]interface{}, options astrolabe.CopyCreateOptions) (astrolabe.ProtectedEntity, error) {
+	return nil, nil
+}
+
+func (this *IVDProtectedEntityTypeManager) copyInt(ctx context.Context, sourcePEInfo astrolabe.ProtectedEntityInfo,
+	options astrolabe.CopyCreateOptions, dataReader io.Reader, metadataReader io.Reader) (astrolabe.ProtectedEntity, error) {
+	this.logger.Infof("ivd PETM copyInt called")
+	if sourcePEInfo.GetID().GetPeType() != "ivd" {
+		return nil, errors.New("Copy source must be an ivd")
+	}
+	var err error
+	ourVC := false
+	existsInOurVC := false
+	for _, checkData := range sourcePEInfo.GetDataTransports() {
+		vcenterURL, ok := checkData.GetParam("vcenter")
+
+		if checkData.GetTransportType() == "vadp" && ok && vcenterURL == this.vcenter.Client.URL().Host {
+			ourVC = true
+			existsInOurVC = true
+			break
+		}
+	}
+
+	if ourVC {
+		_, err := this.vslmManager.Retrieve(ctx, NewVimIDFromPEID(sourcePEInfo.GetID()))
+		if err != nil {
+			if soap.IsSoapFault(err) {
+				fault := soap.ToSoapFault(err).Detail.Fault
+				if _, ok := fault.(types.NotFound); ok {
+					// Doesn't exist in our local system, we can't just clone it
+					existsInOurVC = false
+				} else {
+					return nil, errors.Wrap(err, "Retrieve failed")
+				}
+			}
+		}
+	}
+
+	this.logger.WithField("ourVC", ourVC).WithField("existsInOurVC", existsInOurVC).Debug("Ready to restore from snapshot")
+
+	var retPE IVDProtectedEntity
+	var createTask *vslm.Task
+
+	md, err := readMetadataFromReader(ctx, metadataReader)
+	if err != nil {
+		return nil, err
+	}
+
+	if ourVC && existsInOurVC {
+		md, err := FilterLabelsFromMetadataForVslmAPIs(md, this.vcenterConfig, this.logger)
+		if err != nil {
+			return nil, err
+		}
+		hasSnapshot := sourcePEInfo.GetID().HasSnapshot()
+		if hasSnapshot {
+			createTask, err = this.vslmManager.CreateDiskFromSnapshot(ctx, NewVimIDFromPEID(sourcePEInfo.GetID()), NewVimSnapshotIDFromPEID(sourcePEInfo.GetID()),
+				sourcePEInfo.GetName(), nil, nil, "")
+			if err != nil {
+				return nil, errors.Wrap(err, "CreateDiskFromSnapshot failed")
+			}
+		} else {
+			keepAfterDeleteVm := true
+			cloneSpec := types.VslmCloneSpec{
+				Name:              sourcePEInfo.GetName(),
+				KeepAfterDeleteVm: &keepAfterDeleteVm,
+				Metadata:          md.ExtendedMetadata,
+			}
+			createTask, err = this.vslmManager.Clone(ctx, NewVimIDFromPEID(sourcePEInfo.GetID()), cloneSpec)
+		}
+
+		if err != nil {
+			this.logger.WithError(err).WithField("HasSnapshot", hasSnapshot).Error("Failed at creating volume from local snapshot/volume")
+			return nil, err
+		}
+
+		retVal, err := createTask.WaitNonDefault(ctx, time.Hour*24, time.Second*10, true, time.Second*30)
+		if err != nil {
+			this.logger.WithError(err).Error("Failed at waiting for the task of creating volume")
+			return nil, err
+		}
+		newVSO := retVal.(types.VStorageObject)
+		retPE, err = newIVDProtectedEntity(this, newProtectedEntityID(newVSO.Config.Id))
+
+		// if there is any local snasphot, we need to call updateMetadata explicitly
+		// since CreateDiskFromSnapshot doesn't accept metadata as a param. The API need to be changed accordingly.
+		if hasSnapshot {
+			updateTask, err := this.vslmManager.UpdateMetadata(ctx, newVSO.Config.Id, md.ExtendedMetadata, []string{})
+			if err != nil {
+				this.logger.WithError(err).Error("Failed at calling UpdateMetadata")
+				return nil, err
+			}
+			_, err = updateTask.WaitNonDefault(ctx, time.Hour*24, time.Second*10, true, time.Second*30)
+			if err != nil {
+				this.logger.WithError(err).Error("Failed at waiting for the UpdateMetadata task")
+				return nil, err
+			}
+		}
+	} else {
+		// To enable cross-cluster restore, need to filter out the cns specific labels, i.e. prefix: cns, in md
+		md = FilterLabelsFromMetadataForCnsAPIs(md, "cns", this.logger)
+
+		this.logger.Infof("Ready to provision a new volume with the source metadata: %v", md)
+		volumeVimID, err := CreateCnsVolumeInCluster(ctx, this.vcenterConfig, this.vcenter.Client, this.cnsManager, md, this.logger)
+		if err != nil {
+			return nil, errors.Wrap(err, "CreateDisk failed")
+		}
+		retPE, err = newIVDProtectedEntity(this, newProtectedEntityID(volumeVimID))
+		if err != nil {
+			return nil, errors.Wrap(err, "CreateDisk failed")
+		}
+		_, err = retPE.copy(ctx, dataReader, md)
+		if err != nil {
+			this.logger.Errorf("Failed to copy data from data source to newly-provisioned IVD protected entity")
+			return nil, errors.Wrapf(err, "Failed to copy data from data source to newly-provisioned IVD protected entity")
+		}
+		this.logger.WithField("volumeId", volumeVimID.Id).WithField("volumeName", md.VirtualStorageObject.Config.Name).Info("Copied snapshot data to newly-provisioned IVD protected entity")
+	}
+	return retPE, nil
+}
+
+func (this *IVDProtectedEntityTypeManager) getDataTransports(id astrolabe.ProtectedEntityID) ([]astrolabe.DataTransport,
+	[]astrolabe.DataTransport,
+	[]astrolabe.DataTransport, error) {
+	vadpParams := make(map[string]string)
+	vadpParams["id"] = id.GetID()
+	if id.GetSnapshotID().String() != "" {
+		vadpParams["snapshotID"] = id.GetSnapshotID().String()
+	}
+	vadpParams["vcenter"] = this.vcenterConfig.Host
+
+	dataS3Transport, err := astrolabe.NewS3DataTransportForPEID(id, this.s3Config)
+	if err != nil {
+		return nil, nil, nil, errors.Wrap(err, "Could not create S3 data transport")
+	}
+
+	data := []astrolabe.DataTransport{
+		astrolabe.NewDataTransport("vadp", vadpParams),
+		dataS3Transport,
+	}
+
+	mdS3Transport, err := astrolabe.NewS3MDTransportForPEID(id, this.s3Config)
+	if err != nil {
+		return nil, nil, nil, errors.Wrap(err, "Could not create S3 md transport")
+	}
+
+	md := []astrolabe.DataTransport{
+		mdS3Transport,
+	}
+
+	combinedS3Transport, err := astrolabe.NewS3CombinedTransportForPEID(id, this.s3Config)
+	if err != nil {
+		return nil, nil, nil, errors.Wrap(err, "Could not create S3 combined transport")
+	}
+
+	combined := []astrolabe.DataTransport{
+		combinedS3Transport,
+	}
+
+	return data, md, combined, nil
+}
+
+func (this *IVDProtectedEntityTypeManager) CheckVcenterConnections(ctx context.Context) error {
+	this.logger.Infof("Checking vCenter connections...")
+	if this.vcenter == nil || this.vslmManager == nil || this.cnsManager == nil {
+		err := this.ReloadConfig(ctx, make(map[string]interface{}))
+		if err != nil {
+			this.logger.Errorf("The vCenter is disconnected, error: %v", err)
+			return err
+		}
+	}
+	this.logger.Infof("vCenter connected, proceeding with operation")
+	return nil
+}
+
+func (this *IVDProtectedEntityTypeManager) ReloadConfig(ctx context.Context, params map[string]interface{}) error {
+	configLoadLock.Lock()
+	defer configLoadLock.Unlock()
+	this.logger.Debug("Started Load Config of IVD Protected Entity Manager")
+	var newVcConfig *vsphere.VirtualCenterConfig
+	var err error
+	if len(params) == 0  {
+		// vc operation path, for example createSnapshot.
+		// Used to verify if the connections are still up.
+		// Will be using the last known vcenter config for the checks.
+		newVcConfig = this.vcenterConfig
+	} else {
+		// The params are possibly updated, this is the password rotation path.
+		newVcConfig, err = vsphere.GetVirtualCenterConfigFromParams(params, this.logger)
+		if err != nil {
+			this.logger.Errorf("Failed to populate VirtualCenterConfig during reload %v", err)
+			return err
+		}
+	}
+	configChanged := vsphere.CheckIfVirtualCenterConfigChanged(this.vcenterConfig, newVcConfig)
+	if !configChanged {
+		this.logger.Debug("No VirtualCenterConfig change detected during periodic reload.")
+		// Check if the connections are initialized.
+		if this.vcenter != nil {
+			this.logger.Debug("The vcenter connections are alive, no reload necessary.")
+			// the vcenter connection is initialized, nothing to do
+			return nil
+		}
+	} else {
+		this.logger.Infof("Detected VirtualCenterConfig change during periodic reload.")
+		// Detected config change.
+		this.vcenterConfig = newVcConfig
+		if this.vcenter != nil {
+			// Disconnecting older vc instance.
+			err = this.vcenter.Disconnect(ctx)
+			if err != nil {
+				this.logger.Errorf("Failed to disconnect older vcenter instance.")
+				return err
+			}
+		}
+	}
+	// continue to establish the connection.
+	reloadedVc, vslmClient, cnsClient, err := vsphere.GetVirtualCenter(ctx, newVcConfig, this.logger)
+	if err != nil {
+		return err
+	}
+	this.vcenter = reloadedVc
+	if this.vslmManager == nil {
+		this.logger.Infof("Initializing VSLM Manager")
+		this.vslmManager, err = vsphere.GetVslmManager(ctx, this.vcenter, vslmClient, this.logger)
+		if err != nil {
+			this.logger.Errorf("failed to initialize vslm manager. err=%v", err)
+			return errors.Wrapf(err, "Failed to initialize vslm manager")
+		}
+	} else {
+		this.logger.Infof("Resetting VSLM Manager")
+		this.vslmManager.ResetManager(reloadedVc, vslmClient)
+	}
+	if this.cnsManager == nil {
+		this.logger.Infof("Initializing CNS Manager")
+		this.cnsManager, err = vsphere.GetCnsManager(ctx, this.vcenter, cnsClient, this.logger)
+		if err != nil {
+			this.logger.Errorf("failed to initialize cns manager. err=%v", err)
+			return errors.Wrapf(err, "Failed to initialize cns manager")
+		}
+	} else {
+		this.logger.Infof("Resetting CNS Manager")
+		this.cnsManager.ResetManager(reloadedVc, cnsClient)
+	}
+
+	// check whether customized vddk config is provided.
+	// currently only support user to modify vixdisklib nfc log level and transport log level
+	path := ""
+	if _, ok := params[vddkconfig]; !ok {
+		this.logger.Info("No customized vddk log level provided, set vddk log level as default")
+	} else {
+		this.logger.Infof("Customized vddk config provided: %v", params[vddkconfig])
+		vddkConfig := params[vddkconfig].(map[string]string)
+		path, err = util.CreateConfigFile(vddkConfig, this.logger)
+		if err != nil {
+			this.logger.Error("Failed to create config file for vddk. Cannot proceed to init vddk lib")
+			return errors.Wrap(err, "Failed to create config file")
+		}
+	}
+	err = disklib.InitEx(vsphereMajor, vSphereMinor, disklibLib64, path)
+	if err != nil {
+		return errors.Wrap(err, "Could not initialize VDDK during config reload")
+	}
+	if path != "" {
+		err = util.DeleteConfigFile(path, this.logger)
+		if err != nil {
+			return errors.Wrap(err, "Failed to delete config file")
+		}
+	}
+	this.logger.Infof("Initialized VDDK")
+	this.logger.Infof("Load Config of IVD Protected Entity Manager completed successfully")
+	return nil
+}

--- a/pkg/ivd/ivd_protected_entity_type_manager_test.go
+++ b/pkg/ivd/ivd_protected_entity_type_manager_test.go
@@ -1,0 +1,800 @@
+/*
+ * Copyright 2019 the Astrolabe contributors
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ivd
+
+import (
+	"context"
+	"fmt"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/vmware-tanzu/astrolabe/pkg/astrolabe"
+	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/common/vsphere"
+	"github.com/vmware-tanzu/astrolabe/pkg/util"
+	"github.com/vmware/govmomi/cns"
+	cnstypes "github.com/vmware/govmomi/cns/types"
+	vim25types "github.com/vmware/govmomi/vim25/types"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestProtectedEntityTypeManager(t *testing.T) {
+	vcUrlStr := os.Getenv("VC_URL")
+	if vcUrlStr == "" {
+		t.Skip("VC_URL not provided, skipping test")
+	}
+	// Example VC_URL "https://administrator%40vsphere.local:Admin%2123@csm-wdc-vc-0.eng.vmware.com:443/sdk"
+	vcUrl, err := url.Parse(vcUrlStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("%s\n", vcUrl.String())
+
+	params := make(map[string]interface{})
+	params[vsphere.HostVcParamKey] = vcUrl.Hostname()
+	params[vsphere.PortVcParamKey] = vcUrl.Port()
+	params[vsphere.UserVcParamKey] = vcUrl.User.Username()
+	password, _ := vcUrl.User.Password()
+	params[vsphere.PasswordVcParamKey] = password
+	params[vsphere.InsecureFlagVcParamKey] = "true"
+	params[vsphere.ClusterVcParamKey] = ""
+
+	ivdPETM, err := NewIVDProtectedEntityTypeManager(params, astrolabe.S3Config{URLBase: "/ivd"}, logrus.New())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+
+	pes, err := ivdPETM.GetProtectedEntities(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("# of PEs returned = %d\n", len(pes))
+}
+
+func getVcConfigFromParams(params map[string]interface{}) (*url.URL, bool, error) {
+	var vcUrl url.URL
+	vcUrl.Scheme = "https"
+	vcHostStr, err := vsphere.GetVirtualCenterFromParamsMap(params)
+	if err != nil {
+		return nil, false, err
+	}
+	vcHostPortStr, err := vsphere.GetPortFromParamsMap(params)
+	if err != nil {
+		return nil, false, err
+	}
+
+	vcUrl.Host = fmt.Sprintf("%s:%s", vcHostStr, vcHostPortStr)
+
+	vcUser, err := vsphere.GetUserFromParamsMap(params)
+	if err != nil {
+		return nil, false, err
+	}
+	vcPassword, err := vsphere.GetPasswordFromParamsMap(params)
+	if err != nil {
+		return nil, false, err
+	}
+	vcUrl.User = url.UserPassword(vcUser, vcPassword)
+	vcUrl.Path = "/sdk"
+
+	insecure, err := vsphere.GetInsecureFlagFromParamsMap(params)
+
+	return &vcUrl, insecure, nil
+}
+
+func GetVcUrlFromConfig(config *rest.Config) (*url.URL, bool, error) {
+	params := make(map[string]interface{})
+
+	err := util.RetrievePlatformInfoFromConfig(config, params)
+	if err != nil {
+		return nil, false, errors.Errorf("Failed to retrieve VC config secret: %+v", err)
+	}
+
+	vcUrl, insecure, err := getVcConfigFromParams(params)
+	if err != nil {
+		return nil, false, errors.Errorf("Failed to get VC config from params: %+v", err)
+	}
+
+	return vcUrl, insecure, nil
+}
+
+func GetParamsFromConfig(config *rest.Config) (map[string]interface{}, error) {
+	params := make(map[string]interface{})
+
+	err := util.RetrievePlatformInfoFromConfig(config, params)
+	if err != nil {
+		return nil, errors.Errorf("Failed to retrieve VC config secret: %+v", err)
+	}
+
+	return params, nil
+}
+
+func verifyMdIsRestoredAsExpected(md metadata, version string, logger logrus.FieldLogger) bool {
+	var reservedLabels []string
+	if strings.Contains(version, "6.7U3") {
+		reservedLabels = []string{
+			"cns.clusterID",
+			"cns.clusterType",
+			"cns.vSphereUser",
+			"cns.k8s.pvName",
+			"cns.tag",
+		}
+	} else if strings.HasPrefix(version, "7.0") {
+		reservedLabels = []string{
+			"cns.containerCluster.clusterFlavor",
+			"cns.containerCluster.clusterId",
+			"cns.containerCluster.clusterType",
+			"cns.containerCluster.vSphereUser",
+			"cns.k8s.pv.name",
+			"cns.tag",
+			"cns.version",
+		}
+	} else {
+		logger.Debug("Newer VC version than what we expect. Skip the verification.")
+		return true
+	}
+
+	extendedMdMap := make(map[string]string)
+
+	for _, label := range md.ExtendedMetadata {
+		extendedMdMap[label.Key] = label.Value
+	}
+
+	for _, key := range reservedLabels {
+		_, ok := extendedMdMap[key]
+		if !ok {
+			return false
+		}
+	}
+
+	return true
+}
+
+func TestCreateCnsVolume(t *testing.T) {
+	path := os.Getenv("KUBECONFIG")
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		// path/to/whatever does not exist
+		t.Skipf("The KubeConfig file, %v, is not exist", path)
+	}
+
+	config, err := clientcmd.BuildConfigFromFlags("", path)
+	if err != nil {
+		t.Fatalf("Failed to build k8s config from kubeconfig file: %+v ", err)
+	}
+
+	ctx := context.Background()
+
+	// Step 1: To create the IVD PETM, get all PEs and select one as the reference.
+	params := make(map[string]interface{})
+
+	err = util.RetrievePlatformInfoFromConfig(config, params)
+	if err != nil {
+		t.Fatalf("Failed to retrieve VC config secret: %+v", err)
+	}
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.DebugLevel)
+
+	ivdPETM := getIVDProtectedEntityTypeManager(t, err, params, astrolabe.S3Config{URLBase: "/ivd"}, logger)
+
+	virtualCenter := ivdPETM.vcenter
+	version := virtualCenter.Client.Version
+	logger.Debugf("vcUrl = %v, version = %v", ivdPETM.vcenterConfig.Host, version)
+
+	var queryFilter cnstypes.CnsQueryFilter
+	var volumeIDList []cnstypes.CnsVolumeId
+
+	// construct a dummy metadata object
+	md := metadata{
+		vim25types.VStorageObject{
+			DynamicData: vim25types.DynamicData{},
+			Config: vim25types.VStorageObjectConfigInfo{
+				BaseConfigInfo: vim25types.BaseConfigInfo{
+					DynamicData:                 vim25types.DynamicData{},
+					Id:                          vim25types.ID{},
+					Name:                        "xyz",
+					CreateTime:                  time.Time{},
+					KeepAfterDeleteVm:           nil,
+					RelocationDisabled:          nil,
+					NativeSnapshotSupported:     nil,
+					ChangedBlockTrackingEnabled: nil,
+					Backing:                     nil,
+					Iofilter:                    nil,
+				},
+				CapacityInMB:    10,
+				ConsumptionType: nil,
+				ConsumerId:      nil,
+			},
+		},
+		vim25types.ManagedObjectReference{},
+		nil,
+	}
+
+	logger.Debugf("IVD md: %v", md.ExtendedMetadata)
+
+	t.Logf("PE name, %v", md.VirtualStorageObject.Config.Name)
+	md = FilterLabelsFromMetadataForCnsAPIs(md, "cns", logger)
+
+	ivdParams := make(map[string]interface{})
+	err = util.RetrievePlatformInfoFromConfig(config, ivdParams)
+	if err != nil {
+		t.Fatalf("Failed to retrieve VC config secret: %+v", err)
+	}
+
+	volumeId, err := createCnsVolumeWithClusterConfig(ctx, ivdPETM.vcenterConfig, config, virtualCenter.Client, ivdPETM.cnsManager, md, logger)
+	if err != nil {
+		t.Fatal("Fail to provision a new volume")
+	}
+
+	t.Logf("CNS volume, %v, created", volumeId)
+	var volumeIDListToDelete []cnstypes.CnsVolumeId
+	volumeIDList = append(volumeIDListToDelete, cnstypes.CnsVolumeId{Id: volumeId})
+
+	defer func() {
+		// Always delete the newly created volume at the end of test
+		t.Logf("Deleting volume: %+v", volumeIDList)
+		deleteTask, err := ivdPETM.cnsManager.DeleteVolume(ctx, volumeIDList, true)
+		if err != nil {
+			t.Errorf("Failed to delete volume. Error: %+v \n", err)
+			t.Fatal(err)
+		}
+		deleteTaskInfo, err := cns.GetTaskInfo(ctx, deleteTask)
+		if err != nil {
+			t.Errorf("Failed to delete volume. Error: %+v \n", err)
+			t.Fatal(err)
+		}
+		deleteTaskResult, err := cns.GetTaskResult(ctx, deleteTaskInfo)
+		if err != nil {
+			t.Errorf("Failed to detach volume. Error: %+v \n", err)
+			t.Fatal(err)
+		}
+		if deleteTaskResult == nil {
+			t.Fatalf("Empty delete task results")
+		}
+		deleteVolumeOperationRes := deleteTaskResult.GetCnsVolumeOperationResult()
+		if deleteVolumeOperationRes.Fault != nil {
+			t.Fatalf("Failed to delete volume: fault=%+v", deleteVolumeOperationRes.Fault)
+		}
+		t.Logf("Volume deleted sucessfully")
+	}()
+
+	// Step 4: Query the volume result for the newly created protected entity/volume
+	queryFilter.VolumeIds = volumeIDList
+	queryResult, err := ivdPETM.cnsManager.QueryVolume(ctx, queryFilter)
+	if err != nil {
+		t.Errorf("Failed to query volume. Error: %+v \n", err)
+		t.Fatal(err)
+	}
+	logger.Debugf("Sucessfully Queried Volumes. queryResult: %+v", queryResult)
+
+	newPE, err := newIVDProtectedEntity(ivdPETM, newProtectedEntityID(NewIDFromString(volumeId)))
+	if err != nil {
+		t.Fatalf("Failed to get a new PE: %v", err)
+	}
+
+	newMD, err := newPE.getMetadata(ctx)
+	if err != nil {
+		t.Fatalf("Failed to get the metadata: %v", err)
+	}
+
+	logger.Debugf("IVD md: %v", newMD.ExtendedMetadata)
+
+	// Verify the test result between the actual and expected
+	if md.VirtualStorageObject.Config.Name != queryResult.Volumes[0].Name {
+		t.Errorf("Volume names mismatch, src: %v, dst: %v", md.VirtualStorageObject.Config.Name, queryResult.Volumes[0].Name)
+	} else {
+		t.Logf("Volume names match, name: %v", md.VirtualStorageObject.Config.Name)
+	}
+}
+
+func TestRestoreCnsVolumeFromSnapshot(t *testing.T) {
+	path := os.Getenv("KUBECONFIG")
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		// path/to/whatever does not exist
+		t.Skipf("The KubeConfig file, %v, is not exist", path)
+	}
+
+	config, err := clientcmd.BuildConfigFromFlags("", path)
+	if err != nil {
+		t.Fatalf("Failed to build k8s config from kubeconfig file: %+v ", err)
+	}
+
+	ctx := context.Background()
+
+	// Step 1: To create the IVD PETM, get all PEs and select one as the reference.
+	vcUrl, insecure, err := GetVcUrlFromConfig(config)
+	if err != nil {
+		t.Fatalf("Failed to get VC config from params: %+v", err)
+	}
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.DebugLevel)
+	params := make(map[string]interface{})
+	params[vsphere.HostVcParamKey] = vcUrl.Host
+	params[vsphere.PortVcParamKey] = vcUrl.Port()
+	params[vsphere.UserVcParamKey] = vcUrl.User.Username()
+	password, _ := vcUrl.User.Password()
+	params[vsphere.PasswordVcParamKey] = password
+	params[vsphere.InsecureFlagVcParamKey] = insecure
+	params[vsphere.ClusterVcParamKey] = ""
+
+	ivdPETM := getIVDProtectedEntityTypeManager(t, err, params, astrolabe.S3Config{URLBase: "/ivd"}, logger)
+
+	virtualCenter := ivdPETM.vcenter
+	version := virtualCenter.Client.Version
+	logger.Debugf("vcUrl = %v, version = %v", vcUrl, version)
+
+	peIDs, err := ivdPETM.GetProtectedEntities(ctx)
+	if err != nil {
+		t.Fatalf("Failed to get all PEs: %+v", err)
+	}
+	t.Logf("# of PEs returned = %d\n", len(peIDs))
+
+	var md metadata
+	var queryFilter cnstypes.CnsQueryFilter
+	var volumeIDList []cnstypes.CnsVolumeId
+
+	peID := peIDs[0]
+	t.Logf("Selected PE ID: %v", peID.String())
+
+	// Get general govmomi client and cns client
+	// Step 2: Query the volume result for the selected protected entity/volume
+	volumeIDList = append(volumeIDList, cnstypes.CnsVolumeId{Id: peID.GetID()})
+
+	queryFilter.VolumeIds = volumeIDList
+	queryResult, err := ivdPETM.cnsManager.QueryVolume(ctx, queryFilter)
+	if err != nil {
+		t.Errorf("Failed to query volume. Error: %+v \n", err)
+		t.Fatal(err)
+	}
+	logger.Debugf("Sucessfully Queried Volumes. queryResult: %+v", queryResult)
+
+	// Step 3: Create a new volume with the same metadata as the selected one
+	pe, err := newIVDProtectedEntity(ivdPETM, peID)
+	if err != nil {
+		t.Fatalf("Failed to get a new PE from the peID, %v: %v", peID.String(), err)
+	}
+
+	md, err = pe.getMetadata(ctx)
+	if err != nil {
+		t.Fatalf("Failed to get the metadata of the PE, %v: %v", pe.id.String(), err)
+	}
+	logger.Debugf("IVD md: %v", md.ExtendedMetadata)
+
+	ivdParams := make(map[string]interface{})
+	err = util.RetrievePlatformInfoFromConfig(config, ivdParams)
+	if err != nil {
+		t.Fatalf("Failed to retrieve VC config secret: %+v", err)
+	}
+
+	t.Logf("PE name, %v", md.VirtualStorageObject.Config.Name)
+	md = FilterLabelsFromMetadataForCnsAPIs(md, "cns", logger)
+	volumeId, err := createCnsVolumeWithClusterConfig(ctx, ivdPETM.vcenterConfig, config, virtualCenter.Client, ivdPETM.cnsManager, md, logger)
+	if err != nil {
+		t.Fatal("Fail to provision a new volume")
+	}
+
+	t.Logf("CNS volume, %v, created", volumeId)
+	var volumeIDListToDelete []cnstypes.CnsVolumeId
+	volumeIDList = append(volumeIDListToDelete, cnstypes.CnsVolumeId{Id: volumeId})
+
+	defer func() {
+		// Always delete the newly created volume at the end of test
+		t.Logf("Deleting volume: %+v", volumeIDList)
+		deleteTask, err := ivdPETM.cnsManager.DeleteVolume(ctx, volumeIDList, true)
+		if err != nil {
+			t.Errorf("Failed to delete volume. Error: %+v \n", err)
+			t.Fatal(err)
+		}
+		deleteTaskInfo, err := cns.GetTaskInfo(ctx, deleteTask)
+		if err != nil {
+			t.Errorf("Failed to delete volume. Error: %+v \n", err)
+			t.Fatal(err)
+		}
+		deleteTaskResult, err := cns.GetTaskResult(ctx, deleteTaskInfo)
+		if err != nil {
+			t.Errorf("Failed to detach volume. Error: %+v \n", err)
+			t.Fatal(err)
+		}
+		if deleteTaskResult == nil {
+			t.Fatalf("Empty delete task results")
+		}
+		deleteVolumeOperationRes := deleteTaskResult.GetCnsVolumeOperationResult()
+		if deleteVolumeOperationRes.Fault != nil {
+			t.Fatalf("Failed to delete volume: fault=%+v", deleteVolumeOperationRes.Fault)
+		}
+		t.Logf("Volume deleted sucessfully")
+	}()
+
+	// Step 4: Query the volume result for the newly created protected entity/volume
+	queryFilter.VolumeIds = volumeIDList
+	queryResult, err = ivdPETM.cnsManager.QueryVolume(ctx, queryFilter)
+	if err != nil {
+		t.Errorf("Failed to query volume. Error: %+v \n", err)
+		t.Fatal(err)
+	}
+	logger.Debugf("Sucessfully Queried Volumes. queryResult: %+v", queryResult)
+
+	newPE, err := newIVDProtectedEntity(ivdPETM, newProtectedEntityID(NewIDFromString(volumeId)))
+	if err != nil {
+		t.Fatalf("Failed to get a new PE from the peID, %v: %v", peID.String(), err)
+	}
+
+	newMD, err := newPE.getMetadata(ctx)
+	if err != nil {
+		t.Fatalf("Failed to get the metadata of the PE, %v: %v", pe.id.String(), err)
+	}
+
+	logger.Debugf("IVD md: %v", newMD.ExtendedMetadata)
+
+	// Verify the test result between the actual and expected
+	if md.VirtualStorageObject.Config.Name != queryResult.Volumes[0].Name {
+		t.Errorf("Volume names mismatch, src: %v, dst: %v", md.VirtualStorageObject.Config.Name, queryResult.Volumes[0].Name)
+	} else {
+		t.Logf("Volume names match, name: %v", md.VirtualStorageObject.Config.Name)
+	}
+
+	if verifyMdIsRestoredAsExpected(newMD, version, logger) {
+		t.Logf("Volume metadata is restored as expected")
+	} else {
+		t.Errorf("Volume metadata is NOT restored as expected")
+	}
+}
+
+func TestOverwriteCnsVolumeFromSnapshot(t *testing.T) {
+	path := os.Getenv("KUBECONFIG")
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		// path/to/whatever does not exist
+		t.Skipf("The KubeConfig file, %v, is not exist", path)
+	}
+
+	config, err := clientcmd.BuildConfigFromFlags("", path)
+	if err != nil {
+		t.Fatalf("Failed to build k8s config from kubeconfig file: %+v ", err)
+	}
+
+	ctx := context.Background()
+
+	// Step 1: To create the IVD PETM, get all PEs and select one as the reference.
+	params, err := GetParamsFromConfig(config)
+	if err != nil {
+		t.Fatalf("Failed to get VC config from params: %+v", err)
+	}
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.DebugLevel)
+
+	ivdPETM := getIVDProtectedEntityTypeManager(t, err, params, astrolabe.S3Config{URLBase: "/ivd"}, logger)
+
+	virtualCenter := ivdPETM.vcenter
+
+	peIDs, err := ivdPETM.GetProtectedEntities(ctx)
+	if err != nil {
+		t.Fatalf("Failed to get all PEs: %+v", err)
+	}
+	t.Logf("# of PEs returned = %d\n", len(peIDs))
+
+	var md metadata
+	var queryFilter cnstypes.CnsQueryFilter
+	var volumeIDList []cnstypes.CnsVolumeId
+
+	peID := peIDs[0]
+	t.Logf("Selected PE ID: %v", peID.String())
+
+	// Get general govmomi client and cns client
+	// Step 2: Query the volume result for the selected protected entity/volume
+	volumeIDList = append(volumeIDList, cnstypes.CnsVolumeId{Id: peID.GetID()})
+
+	queryFilter.VolumeIds = volumeIDList
+	queryResult, err := ivdPETM.cnsManager.QueryVolume(ctx, queryFilter)
+	if err != nil {
+		t.Errorf("Failed to query volume. Error: %+v \n", err)
+		t.Fatal(err)
+	}
+	logger.Debugf("Sucessfully Queried Volumes. queryResult: %+v", queryResult)
+
+	// Step 3: Create a new volume with the same metadata as the selected one
+	pe, err := newIVDProtectedEntity(ivdPETM, peID)
+	if err != nil {
+		t.Fatalf("Failed to get a new PE from the peID, %v: %v", peID.String(), err)
+	}
+
+	md, err = pe.getMetadata(ctx)
+	if err != nil {
+		t.Fatalf("Failed to get the metadata of the PE, %v: %v", pe.id.String(), err)
+	}
+	logger.Debugf("IVD md: %v", md.ExtendedMetadata)
+
+	snapshotID, err := pe.Snapshot(ctx, nil)
+	if err != nil {
+		t.Fatalf("Failed to snapshot PE, %v: %v", pe.id.String(), err)
+	}
+	snapshotPEID := pe.GetID().IDWithSnapshot(snapshotID)
+
+	ivdParams := make(map[string]interface{})
+	err = util.RetrievePlatformInfoFromConfig(config, ivdParams)
+	if err != nil {
+		t.Fatalf("Failed to retrieve VC config secret: %+v", err)
+	}
+
+	t.Logf("PE name, %v", md.VirtualStorageObject.Config.Name)
+	md = FilterLabelsFromMetadataForCnsAPIs(md, "cns", logger)
+	volumeId, err := createCnsVolumeWithClusterConfig(ctx, ivdPETM.vcenterConfig, config, virtualCenter.Client, ivdPETM.cnsManager, md, logger)
+	if err != nil {
+		t.Fatal("Fail to provision a new volume")
+	}
+
+	t.Logf("CNS volume, %v, created", volumeId)
+	var volumeIDListToDelete []cnstypes.CnsVolumeId
+	volumeIDList = append(volumeIDListToDelete, cnstypes.CnsVolumeId{Id: volumeId})
+
+	defer func() {
+		// Always delete the newly created volume at the end of test
+		t.Logf("Deleting volume: %+v", volumeIDList)
+		deleteTask, err := ivdPETM.cnsManager.DeleteVolume(ctx, volumeIDList, true)
+		if err != nil {
+			t.Errorf("Failed to delete volume. Error: %+v \n", err)
+			t.Fatal(err)
+		}
+		deleteTaskInfo, err := cns.GetTaskInfo(ctx, deleteTask)
+		if err != nil {
+			t.Errorf("Failed to delete volume. Error: %+v \n", err)
+			t.Fatal(err)
+		}
+		deleteTaskResult, err := cns.GetTaskResult(ctx, deleteTaskInfo)
+		if err != nil {
+			t.Errorf("Failed to detach volume. Error: %+v \n", err)
+			t.Fatal(err)
+		}
+		if deleteTaskResult == nil {
+			t.Fatalf("Empty delete task results")
+		}
+		deleteVolumeOperationRes := deleteTaskResult.GetCnsVolumeOperationResult()
+		if deleteVolumeOperationRes.Fault != nil {
+			t.Fatalf("Failed to delete volume: fault=%+v", deleteVolumeOperationRes.Fault)
+		}
+		t.Logf("Volume deleted sucessfully")
+	}()
+
+	// Step 4: Query the volume result for the newly created protected entity/volume
+	queryFilter.VolumeIds = volumeIDList
+	queryResult, err = ivdPETM.cnsManager.QueryVolume(ctx, queryFilter)
+	if err != nil {
+		t.Errorf("Failed to query volume. Error: %+v \n", err)
+		t.Fatal(err)
+	}
+	logger.Debugf("Sucessfully Queried Volumes. queryResult: %+v", queryResult)
+
+	snapshotPE, err := ivdPETM.GetProtectedEntity(ctx, snapshotPEID)
+	if err != nil {
+		t.Fatalf("Failed to get a PE for the snapshot peID, %v: %v", snapshotID.String(), err)
+	}
+
+	newPE, err := newIVDProtectedEntity(ivdPETM, newProtectedEntityID(NewIDFromString(volumeId)))
+	if err != nil {
+		t.Fatalf("Failed to get a new PE from the peID, %v: %v", peID.String(), err)
+	}
+
+	err = newPE.Overwrite(ctx, snapshotPE, nil, false)
+	if err != nil {
+		t.Fatalf("Failed to overwrite PE with snapshotPE, %v, %v: %v", pe.id.String(), snapshotPE.GetID().String(), err)
+	}
+}
+
+/*
+	Steps
+
+	0. Set KUBECONFIG to the kubeconfig of vanilla or supervisor cluster.
+	1. Invoke GetParamsFromConfig to retrieve the IVD params from secret.
+	2. Invoke NewIVDProtectedEntityTypeManager to create a new IVDProtectedEntityTypeManager
+	3. Use the vcenterManager instance to verify clients are initialized.
+	4. Invoke GetProtectedEntities to verify vslm api invocations.
+
+	Expected Output:
+	1. No errors.
+
+*/
+func TestIVDProtectedEntityTypeManager_NewIVDProtectedEntityTypeManager(t *testing.T) {
+	path := os.Getenv("KUBECONFIG")
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		t.Skipf("The KubeConfig file, %v, is not exist", path)
+	}
+	config, err := clientcmd.BuildConfigFromFlags("", path)
+	if err != nil {
+		t.Fatalf("Failed to build k8s config from kubeconfig file: %+v ", err)
+	}
+	log := GetLogger()
+	ctx := context.Background()
+	params := make(map[string]interface{})
+	err = util.RetrievePlatformInfoFromConfig(config, params)
+	if err != nil {
+		t.Fatalf("Failed to get VC params from k8s: %+v", err)
+	}
+	s3Config := astrolabe.S3Config{
+		URLBase: "VOID_URL",
+	}
+	ivdPETM := getIVDProtectedEntityTypeManager(t, err, params, s3Config, log)
+
+	if ivdPETM.vcenterConfig == nil || ivdPETM.vslmManager == nil || ivdPETM.vcenter == nil ||
+		ivdPETM.cnsManager == nil {
+		t.Fatalf("Failed to correctly initialize IVD PE type manager.")
+	}
+	defer func() {
+		err = ivdPETM.vcenter.Disconnect(ctx)
+		if err != nil {
+			log.Warnf("Was unable to disconnect vc as part of cleanup.")
+		}
+	}()
+
+	// Validate by invoking ivd petm APIs.
+	entities, err := ivdPETM.GetProtectedEntities(ctx)
+	if err != nil {
+		t.Fatalf("Received error when retrieving IVD PEs, err: %+v", err)
+	}
+	log.Infof("PASS: Successfully retrieved %d IVD PEs", len(entities))
+}
+
+/*
+	Steps
+
+	0. Set KUBECONFIG to the kubeconfig of vanilla or supervisor cluster.
+	1. Invoke GetParamsFromConfig to retrieve the IVD params from secret.
+	2. Invoke NewIVDProtectedEntityTypeManager to create a new IVDProtectedEntityTypeManager
+	3. Invoke GetProtectedEntities to verify vslm api invocations.
+	4. Create the params copy and update the credentials.
+	5. Invoke ReloadConfig with the new params.
+	6. Invoke GetProtectedEntities to verify that the new credentials are used for vsl api invocation.
+
+	Expected Output:
+	1. No errors.
+
+*/
+func TestIVDProtectedEntityTypeManager_ReloadConfig(t *testing.T) {
+	path := os.Getenv("KUBECONFIG")
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		t.Skipf("The KubeConfig file, %v, is not exist", path)
+	}
+	config, err := clientcmd.BuildConfigFromFlags("", path)
+	if err != nil {
+		t.Fatalf("Failed to build k8s config from kubeconfig file: %+v ", err)
+	}
+	log := GetLogger()
+	ctx := context.Background()
+	params := make(map[string]interface{})
+	err = util.RetrievePlatformInfoFromConfig(config, params)
+	if err != nil {
+		t.Fatalf("Failed to get VC params from k8s: %+v", err)
+	}
+
+	s3Config := astrolabe.S3Config{
+		URLBase: "VOID_URL",
+	}
+	ivdPETM := getIVDProtectedEntityTypeManager(t, err, params, s3Config, log)
+
+	defer func() {
+		err = ivdPETM.vcenter.Disconnect(ctx)
+		if err != nil {
+			log.Warnf("Was unable to disconnect vc as part of cleanup.")
+		}
+	}()
+	// Using admin as alternate vcenter config
+	adminUser := "administrator@vsphere.local"
+	adminPass := "Admin!23"
+	params[vsphere.UserVcParamKey] = adminUser
+	params[vsphere.PasswordVcParamKey] = adminPass
+	err = ivdPETM.ReloadConfig(ctx, params)
+	if err != nil {
+		t.Fatalf("Failed to Reload Config for IVD PE Type Manager")
+	}
+	if ivdPETM.vcenterConfig.Username != adminUser || ivdPETM.vcenterConfig.Password != adminPass {
+		t.Fatalf("The IVD PE Type Manager parameters weren't reloaded succcessfully.")
+	}
+	virtualCenter := ivdPETM.vcenter
+	if virtualCenter.Config.Username != adminUser || virtualCenter.Config.Password != adminPass {
+		t.Fatalf("The vcenter instance credentials were not updated.")
+	}
+	// Validate by invoking ivd petm APIs.
+	entities, err := ivdPETM.GetProtectedEntities(ctx)
+	if err != nil {
+		t.Fatalf("Received error when retrieving IVD PEs, err: %+v", err)
+	}
+	log.Infof("PASS: Successfully retrieved %d IVD PEs after credential rotation", len(entities))
+}
+
+/*
+	Steps
+
+	0. Set KUBECONFIG to the kubeconfig of vanilla or supervisor cluster.
+	1. Invoke GetParamsFromConfig to retrieve the IVD params from secret.
+	2. Invoke NewIVDProtectedEntityTypeManager to create a new IVDProtectedEntityTypeManager
+	3. Invoke GetProtectedEntities to verify vslm api invocations.
+	4. Invoke ReloadConfig with the same params again.
+	6. Verify vcenterManager instance to see no config change since there is no change in params.
+
+	Expected Output:
+	1. No errors.
+
+*/
+func TestIVDProtectedEntityTypeManager_ReloadConfigNoConfigChanges(t *testing.T) {
+	path := os.Getenv("KUBECONFIG")
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		t.Skipf("The KubeConfig file, %v, is not exist", path)
+	}
+	config, err := clientcmd.BuildConfigFromFlags("", path)
+	if err != nil {
+		t.Fatalf("Failed to build k8s config from kubeconfig file: %+v ", err)
+	}
+	log := GetLogger()
+	ctx := context.Background()
+	params := make(map[string]interface{})
+	err = util.RetrievePlatformInfoFromConfig(config, params)
+	if err != nil {
+		t.Fatalf("Failed to get VC params from k8s: %+v", err)
+	}
+
+	s3Config := astrolabe.S3Config{
+		URLBase: "VOID_URL",
+	}
+	ivdPETM := getIVDProtectedEntityTypeManager(t, err, params, s3Config, log)
+	defer func() {
+		err = ivdPETM.vcenter.Disconnect(ctx)
+		if err != nil {
+			log.Warnf("Was unable to disconnect vc as part of cleanup.")
+		}
+	}()
+	err = ivdPETM.ReloadConfig(ctx, params)
+	if err != nil {
+		t.Fatalf("Failure duing ReloadConfig with same params.")
+	}
+	virtualCenter := ivdPETM.vcenter
+	if virtualCenter.Config.Username != params[vsphere.UserVcParamKey] ||
+		virtualCenter.Config.Password != params[vsphere.PasswordVcParamKey] {
+		t.Fatalf("The vcenter instance credentials were unexpectedly updated.")
+	}
+	// Validate by invoking ivd petm APIs.
+	entities, err := ivdPETM.GetProtectedEntities(ctx)
+	if err != nil {
+		t.Fatalf("Received error when retrieving IVD PEs, err: %+v", err)
+	}
+	log.Infof("PASS: Reload with no param change did not update vc, IVD PE: %d", len(entities))
+}
+
+func getIVDProtectedEntityTypeManager(t *testing.T, err error, params map[string]interface{}, s3Config astrolabe.S3Config, log logrus.FieldLogger) *IVDProtectedEntityTypeManager {
+	astrolabePETM, err := NewIVDProtectedEntityTypeManager(params, s3Config, log)
+	if err != nil {
+		t.Fatalf("Failed to initialize IVD PE Type manager, err: %+v", err)
+	}
+	ivdPETM, ok := astrolabePETM.(*IVDProtectedEntityTypeManager)
+	if !ok {
+		t.Fatalf("Did not get an IVDProtectedEntityTypeManager from NewIVDProtectedEntityTypeManager")
+	}
+	return ivdPETM
+}
+
+func GetLogger() logrus.FieldLogger {
+	logger := logrus.New()
+	formatter := new(logrus.TextFormatter)
+	formatter.TimestampFormat = time.RFC3339Nano
+	formatter.FullTimestamp = true
+	logger.SetFormatter(formatter)
+	logger.SetLevel(logrus.DebugLevel)
+	return logger
+}

--- a/pkg/ivd/ivd_protected_entity_type_manager_util.go
+++ b/pkg/ivd/ivd_protected_entity_type_manager_util.go
@@ -1,0 +1,409 @@
+package ivd
+
+import (
+	"context"
+	"fmt"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/common/vsphere"
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/cns"
+	cnstypes "github.com/vmware/govmomi/cns/types"
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/mo"
+	vim25types "github.com/vmware/govmomi/vim25/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"strings"
+)
+
+func findDatacenterPath(ctx context.Context, client *vim25.Client, objectRef vim25types.ManagedObjectReference, logger logrus.FieldLogger) (string, error) {
+	pc := property.DefaultCollector(client)
+	pathElements, err := mo.Ancestors(ctx, client, pc.Reference(), objectRef)
+	if err != nil {
+		return "", err
+	}
+
+	var dcPath string
+	for i, pathElement := range pathElements {
+		if pathElement.Parent == nil {
+			continue
+		}
+		dcPath = dcPath + "/" + pathElement.Name
+		if pathElements[i].Self.Type == "Datacenter" {
+			break
+		}
+	}
+
+	logger.Debugf("objectRef = %v, dcPath = %v", objectRef, dcPath)
+	return dcPath, nil
+}
+
+func findHostsOfNodeVMs(ctx context.Context, client *vim25.Client, config *rest.Config, logger logrus.FieldLogger) ([]vim25types.ManagedObjectReference, error) {
+	// #1: get hostNames of all node VMs
+	clientSet, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	nodeList, err := clientSet.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	vmHostNameMap := make(map[string]bool)
+	for _, node := range nodeList.Items {
+		if node.Name == "" {
+			return nil, errors.Errorf("One of the node VM with uid, %v, in the cluster has empty node name", node.UID)
+		}
+		vmHostNameMap[node.Name] = true
+	}
+
+	// #2: go through the VM list in this VC and get their host from vm.runtime
+	finder := find.NewFinder(client)
+
+	dcs, err := finder.DatacenterList(ctx, "*")
+	if err != nil {
+		logger.WithError(err).Error("Failed to find the list of data centers in VC")
+		return nil, err
+	}
+
+	var vmRefList []vim25types.ManagedObjectReference
+	for _, dc := range dcs {
+		path := fmt.Sprintf("%v/vm/...", dc.InventoryPath)
+		vms, err := finder.VirtualMachineList(ctx, path)
+		if err != nil {
+			_, ok := err.(*find.NotFoundError)
+			if ok {
+				logger.Warnf("No VMs can be found in data center, %v. Skip it.", dc.InventoryPath)
+				continue
+			}
+			logger.WithError(err).Errorf("Failed to find the list of VMs in a data center, %v", dc.InventoryPath)
+			return nil, err
+		}
+
+		for _, vm := range vms {
+			vmRefList = append(vmRefList, vm.Reference())
+		}
+	}
+
+	logger.Debugf("vmRefList = %v", vmRefList)
+
+	pc := property.DefaultCollector(client)
+	var vmMoList []mo.VirtualMachine
+	err = pc.Retrieve(ctx, vmRefList, []string{"runtime", "guest"}, &vmMoList)
+	if err != nil {
+		logger.WithError(err).Error("Failed to retrieve VM runtime and guest properties")
+		return nil, err
+	}
+
+	var hostList []vim25types.ManagedObjectReference
+	hostRefMap := make(map[vim25types.ManagedObjectReference]bool)
+	for _, vmMo := range vmMoList {
+		_, ok := vmHostNameMap[vmMo.Guest.HostName]
+		if !ok {
+			continue
+		}
+
+		_, ok = hostRefMap[*vmMo.Runtime.Host]
+		if !ok {
+			hostRefMap[*vmMo.Runtime.Host] = true
+			hostList = append(hostList, *vmMo.Runtime.Host)
+		}
+	}
+
+	logger.Debugf("hostList = %v", hostList)
+	return hostList, nil
+}
+
+func findSharedDatastoresFromAllNodeVMs(ctx context.Context, client *vim25.Client, config *rest.Config, logger logrus.FieldLogger) ([]vim25types.ManagedObjectReference, error) {
+	finder := find.NewFinder(client)
+
+	hosts, err := findHostsOfNodeVMs(ctx, client, config, logger)
+	if err != nil {
+		logger.WithError(err).Error("Failed to find hosts of all node VMs")
+		return nil, err
+	}
+	nHosts := len(hosts)
+	if nHosts <= 0 {
+		logger.WithError(err).Error("No hosts can be found for node VMs")
+		return nil, errors.New("No hosts can be found for node VMs")
+	}
+
+	dcPathMap := make(map[string]bool)
+	for _, host := range hosts {
+		dcPath, err := findDatacenterPath(ctx, client, host.Reference(), logger)
+		if err != nil {
+			logger.Debugf("Failed to find a datacenter from ancestors of VM, %v", host.Reference())
+			continue
+		}
+		dcPathMap[dcPath] = true
+	}
+
+	var dss []*object.Datastore
+	for dcPath, _ := range dcPathMap {
+		path := fmt.Sprintf("%v/datastore/...", dcPath)
+		dssPerDC, err := finder.DatastoreList(ctx, path)
+		if err != nil {
+			_, ok := err.(*find.NotFoundError)
+			if ok {
+				logger.Warnf("No datastores can be found in data center, %v. Skip it.", dcPath)
+				continue
+			}
+			logger.WithError(err).Errorf("Failed to find the list of datastores in data center, %v", dcPath)
+			return nil, err
+		}
+		dss = append(dss, dssPerDC...)
+	}
+
+	var dsList []vim25types.ManagedObjectReference
+	for _, ds := range dss {
+		dsType, err := ds.Type(ctx)
+		if err != nil {
+			logger.WithError(err).Warnf("Failed to get type of datastore %v", ds.Reference())
+			continue
+		}
+
+		if dsType == vim25types.HostFileSystemVolumeFileSystemTypeNFS41 {
+			// Currently, provisioning PV on NFS 4.1 datastore is not officially supported.
+			// It will be turned on once it is supported.
+			continue
+		}
+
+		if dsType == vim25types.HostFileSystemVolumeFileSystemTypeNFS {
+			var dsMo mo.Datastore
+			err = ds.Properties(ctx, ds.Reference(), []string{"info"}, &dsMo)
+			if err != nil {
+				logger.WithError(err).Warnf("Failed to get info of datastore %v", ds.Reference())
+				continue
+			}
+			logger.Debugf("NFS name = %v", dsMo.Info.GetDatastoreInfo().Name)
+			nasDsInfo, ok := dsMo.Info.(*vim25types.NasDatastoreInfo)
+			if !ok {
+				logger.Debugf("Failed to get info of NFS datastore %v", ds.Reference())
+				continue
+			}
+			logger.Debugf("NAS RemoteHost = %v", nasDsInfo.Nas.RemoteHost)
+			if strings.Contains(nasDsInfo.Nas.RemoteHost, "eng.vmware.com") {
+				logger.Debugf("Detected a VMware specific NFS volume, %v. Skipping it", nasDsInfo.Name)
+				continue
+			}
+		}
+
+		attachedHosts, err := ds.AttachedHosts(ctx)
+		if err != nil {
+			logger.WithError(err).Warnf("Failed to get all the attached hosts of datastore %v", ds.Reference())
+			continue
+		}
+
+		if len(attachedHosts) < nHosts {
+			continue
+		}
+
+		// make the array of attached hosts a map of attached hosts for the convenience of look-up
+		attachedHostsMap := make(map[vim25types.ManagedObjectReference]vim25types.ManagedObjectReference)
+		for _, host := range attachedHosts {
+			attachedHostsMap[host.Reference()] = ds.Reference()
+		}
+
+		// traverse the hosts of node VMs and filter out datastores that are not accessible from any host of node VMs
+		eligible := true
+		for _, host := range hosts {
+			_, ok := attachedHostsMap[host.Reference()]
+			if !ok {
+				eligible = false
+				break
+			}
+		}
+
+		if eligible {
+			dsList = append(dsList, ds.Reference())
+		}
+	}
+
+	logger.Debugf("Shared datastores from all node VMs: %v", dsList)
+	return dsList, nil
+}
+
+func createCnsVolumeWithClusterConfig(ctx context.Context, vcConfig *vsphere.VirtualCenterConfig, config *rest.Config, client *govmomi.Client, cnsManager *vsphere.CnsManager, md metadata, logger logrus.FieldLogger) (string, error) {
+	logger.Infof("createCnsVolumeWithClusterConfig called with args, config params and metadata: %v", md)
+
+	reservedLabelsMap, err := fillInClusterSpecificParams(vcConfig, logger)
+	if err != nil {
+		logger.WithError(err).Error("Failed at calling fillInClusterSpecificParams")
+		return "", err
+	}
+
+	// Preparing for the VolumeCreateSpec for the volume provisioning
+	logger.Info("Preparing for the VolumeCreateSpec for the volume provisioning")
+	dsList, err := findSharedDatastoresFromAllNodeVMs(ctx, client.Client, config, logger)
+	if err != nil {
+		logger.WithError(err).Error("Failed to find any datastore in the underlying vSphere")
+		return "", err
+	}
+
+	var metadataList []cnstypes.BaseCnsEntityMetadata
+	metadata := &cnstypes.CnsKubernetesEntityMetadata{
+		CnsEntityMetadata: cnstypes.CnsEntityMetadata{
+			EntityName: md.VirtualStorageObject.Config.Name,
+			Labels:     md.ExtendedMetadata,
+		},
+		EntityType: string(cnstypes.CnsKubernetesEntityTypePV),
+	}
+	metadataList = append(metadataList, cnstypes.BaseCnsEntityMetadata(metadata))
+
+	var cnsVolumeCreateSpecList []cnstypes.CnsVolumeCreateSpec
+	cnsVolumeCreateSpec := cnstypes.CnsVolumeCreateSpec{
+		Name:       md.VirtualStorageObject.Config.Name,
+		VolumeType: string(cnstypes.CnsVolumeTypeBlock),
+		Datastores: dsList,
+		Metadata: cnstypes.CnsVolumeMetadata{
+			ContainerCluster: cnstypes.CnsContainerCluster{
+				ClusterType: string(cnstypes.CnsClusterTypeKubernetes), // hard coded for the moment
+				ClusterId:   reservedLabelsMap["cns.containerCluster.clusterId"],
+				VSphereUser: reservedLabelsMap["cns.containerCluster.vSphereUser"],
+			},
+			EntityMetadata: metadataList,
+		},
+		BackingObjectDetails: &cnstypes.CnsBlockBackingDetails{
+			CnsBackingObjectDetails: cnstypes.CnsBackingObjectDetails{
+				CapacityInMb: md.VirtualStorageObject.Config.CapacityInMB,
+			},
+		},
+	}
+
+	cnsVolumeCreateSpecList = append(cnsVolumeCreateSpecList, cnsVolumeCreateSpec)
+	logger.Infof("Provisioning volume using the spec: %v", cnsVolumeCreateSpec)
+
+	// provision volume using CNS API
+	createTask, err := cnsManager.CreateVolume(ctx, cnsVolumeCreateSpecList)
+	if err != nil {
+		logger.WithError(err).Errorf("Failed to create volume. Error: %+v", err)
+		return "", err
+	}
+	createTaskInfo, err := cns.GetTaskInfo(ctx, createTask)
+	if err != nil {
+		logger.WithError(err).Errorf("Failed to create volume. Error: %+v", err)
+		return "", err
+	}
+	createTaskResult, err := cns.GetTaskResult(ctx, createTaskInfo)
+	if err != nil {
+		logger.WithError(err).Errorf("Failed to create volume. Error: %+v", err)
+		return "", err
+	}
+	if createTaskResult == nil {
+		err := errors.New("Empty create task results")
+		logger.Error(err.Error())
+		return "", err
+	}
+	createVolumeOperationRes := createTaskResult.GetCnsVolumeOperationResult()
+	if createVolumeOperationRes.Fault != nil {
+		logger.Errorf("Failed to create volume: fault=%+v", createVolumeOperationRes.Fault)
+		return "", errors.New(createVolumeOperationRes.Fault.LocalizedMessage)
+	}
+
+	volumeId := createVolumeOperationRes.VolumeId.Id
+	logger.Infof("CNS volume, %v, created", volumeId)
+	return volumeId, nil
+}
+
+func fillInClusterSpecificParams(vcConfig *vsphere.VirtualCenterConfig, logger logrus.FieldLogger) (map[string]string, error) {
+	logger.Infof("Retrieved cluster id, %v, and vSphere user, %v", vcConfig.ClusterId, vcConfig.ClusterId)
+
+	// currently, we only pick up two cluster specific labels, cluster-id and vsphere-user.
+	// For the following labels,
+	//    cns.containerCluster.clusterType -- always "KUBERNETES", and no other type available for the moment
+	//    cns.containerCluster.clusterFlavor -- the most recent govmomi version doesn't provide field to set the cluster flavor
+	//    others are not cluster specfic, but cns specific
+	reservedLabelsMap := map[string]string{
+		//"cns.containerCluster.clusterFlavor",
+		//"cns.containerCluster.clusterType",
+		//"cns.k8s.pv.name",
+		//"cns.tag",
+		//"cns.version",
+		"cns.containerCluster.clusterId":   vcConfig.ClusterId,
+		"cns.containerCluster.vSphereUser": vcConfig.Username,
+	}
+
+	return reservedLabelsMap, nil
+}
+
+func FilterLabelsFromMetadataForVslmAPIs(md metadata, vcConfig *vsphere.VirtualCenterConfig, logger logrus.FieldLogger) (metadata, error) {
+	var kvsList []vim25types.KeyValue
+
+	logger.Debugf("labels of CNS volume before filtering: %v", md.ExtendedMetadata)
+
+	reservedLabelsMap, err := fillInClusterSpecificParams(vcConfig, logger)
+	if err != nil {
+		logger.WithError(err).Error("Failed at calling fillInClusterSpecificParams")
+		return metadata{}, err
+	}
+
+	for key, value := range reservedLabelsMap {
+		kvsList = append(kvsList, vim25types.KeyValue{
+			Key:   key,
+			Value: value,
+		})
+	}
+
+	for _, label := range md.ExtendedMetadata {
+		value, ok := reservedLabelsMap[label.Key]
+		if !ok {
+			value = label.Value
+		}
+		kvsList = append(kvsList, vim25types.KeyValue{
+			Key:   label.Key,
+			Value: value,
+		})
+	}
+	md.ExtendedMetadata = kvsList
+
+	logger.Debugf("labels of CNS volume after filtering: %v", md.ExtendedMetadata)
+
+	return md, nil
+}
+
+func FilterLabelsFromMetadataForCnsAPIs(md metadata, prefix string, logger logrus.FieldLogger) metadata {
+	// prefix: cns.containerCluster
+	var kvsList []vim25types.KeyValue
+
+	logger.Debugf("labels of CNS volume before filtering ones with certain prefix, %v: %v", prefix, md.ExtendedMetadata)
+
+	for _, label := range md.ExtendedMetadata {
+		if !strings.HasPrefix(label.Key, prefix) {
+			kvsList = append(kvsList, vim25types.KeyValue{
+				Key:   label.Key,
+				Value: label.Value,
+			})
+		}
+	}
+	md.ExtendedMetadata = kvsList
+
+	logger.Infof("labels of CNS volume after filtering ones with certain prefix, %v: %v", prefix, md.ExtendedMetadata)
+
+	return md
+}
+
+func CreateCnsVolumeInCluster(ctx context.Context, vcConfig *vsphere.VirtualCenterConfig, client *govmomi.Client, cnsManager *vsphere.CnsManager, md metadata, logger logrus.FieldLogger) (vim25types.ID, error) {
+	logger.Infof("CreateCnsVolumeInCluster called with args, metadata: %v", md)
+
+	// Get the cluster configuration for node, datastore information.
+	logger.Debug("Retrieving cluster configuration")
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		logger.WithError(err).Error("Failed to get k8s inClusterConfig")
+		return vim25types.ID{}, err
+	}
+
+	volumeId, err := createCnsVolumeWithClusterConfig(ctx, vcConfig, config, client, cnsManager, md, logger)
+	if err != nil {
+		logger.WithError(err).Error("Failed to call createCnsVolumeWithClusterConfig")
+		return vim25types.ID{}, err
+	}
+
+	return NewIDFromString(volumeId), nil
+}

--- a/pkg/paravirt/paravirt_protected_entity_type_manager_test.go
+++ b/pkg/paravirt/paravirt_protected_entity_type_manager_test.go
@@ -306,7 +306,7 @@ func TestPVCSnapshotOps(t *testing.T) {
 		URLBase: "VOID_URL",
 	})
 
-	pem := server.NewDirectProtectedEntityManagerFromParamMap(configInfo, logger)
+	pem := server.NewDirectProtectedEntityManagerFromParamMap(configInfo, nil, logger)
 
 	// Initialize the External Astrolabe ProtectedEntity Type Manager for paravirtualized entities
 	paravirtParams := make(map[string]interface{})

--- a/pkg/snapshotmgr/data_manager_protected_entity_type_manager.go
+++ b/pkg/snapshotmgr/data_manager_protected_entity_type_manager.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"github.com/vmware-tanzu/astrolabe/pkg/ivd"
+	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/ivd"
 )
 
 import "github.com/vmware-tanzu/astrolabe/pkg/astrolabe"

--- a/pkg/snapshotmgr/snapshot_manager.go
+++ b/pkg/snapshotmgr/snapshot_manager.go
@@ -23,6 +23,7 @@ import (
 	"github.com/vmware-tanzu/astrolabe/pkg/common/vsphere"
 	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/backuprepository"
 	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/constants"
+	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/ivd"
 	v1 "k8s.io/api/core/v1"
 	"os"
 	"strings"
@@ -127,8 +128,11 @@ func NewSnapshotManagerFromConfig(configInfo server.ConfigInfo, s3RepoParams map
 	isLocalMode := utils.GetBool(config[constants.VolumeSnapshotterLocalMode], false)
 	initRemoteStorage := clusterFlavor == constants.VSphere
 
+	addOnInits := map[string]server.InitFunc {
+		"ivd": ivd.NewIVDProtectedEntityTypeManager,
+	}
 	// Initialize the DirectProtectedEntityManager
-	dpem := server.NewDirectProtectedEntityManagerFromParamMap(configInfo, logger)
+	dpem := server.NewDirectProtectedEntityManagerFromParamMap(configInfo, addOnInits, logger)
 
 	snapMgr := SnapshotManager{
 		FieldLogger:   logger,

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hashicorp/go-version"
 	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/constants"
 	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/typed/backupdriver/v1alpha1"
+	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/ivd"
 	"io/ioutil"
 	"k8s.io/client-go/tools/clientcmd"
 	"net"
@@ -41,7 +42,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/vmware-tanzu/astrolabe/pkg/astrolabe"
-	"github.com/vmware-tanzu/astrolabe/pkg/ivd"
 	"github.com/vmware-tanzu/astrolabe/pkg/s3repository"
 	datamover_api "github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/apis/datamover/v1alpha1"
 	plugin_clientset "github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned"
@@ -333,7 +333,7 @@ func RetrieveVSLFromVeleroBSLs(params map[string]interface{}, bslName string, co
 	return nil
 }
 
-func GetIVDPETMFromParamsMap(params map[string]interface{}, logger logrus.FieldLogger) (*ivd.IVDProtectedEntityTypeManager, error) {
+func GetIVDPETMFromParamsMap(params map[string]interface{}, logger logrus.FieldLogger) (astrolabe.ProtectedEntityTypeManager, error) {
 	// Largely a dummy s3Config - s3Config is to enable access to astrolabe objects via S3 which we don't support from
 	// here
 	s3Config := astrolabe.S3Config{


### PR DESCRIPTION
**What this PR does / why we need it**:
Moves IVD (Improved Virtual Disk/First Class Disk) from astrolabe core into Velero Plug-in for vSphere

**Does this PR introduce a user-facing change?**:

```release-note
Moved the vSphere specific ivd Protected Entity from Astrolabe into Velero Plugin for vSphere, no functionality
changes in the IVD PE otherwise. Added vsphere-astrolabe CLI tool that can interact with IVDs
```
