### PR TITLE
Decouple from vSphere CSI driver for Vanilla 

### DIFF
--- a/hack/test.sh
+++ b/hack/test.sh
@@ -53,5 +53,5 @@ if [[ -n "${GOFLAGS:-}" ]]; then
 fi
 
 echo go test "${TARGETS}" ${TIMEOUT} ${RUN_SINGLE_CASE} ${VERBOSE} ${DISABLE_CACHE}
-go test "${TARGETS}" ${TIMEOUT} ${RUN_SINGLE_CASE} ${VERBOSE} ${DISABLE_CACHE}
+go test -gcflags="-l" "${TARGETS}" ${TIMEOUT} ${RUN_SINGLE_CASE} ${VERBOSE} ${DISABLE_CACHE}
 echo "Success!"

--- a/pkg/cmd/backupdriver/cli/install/install.go
+++ b/pkg/cmd/backupdriver/cli/install/install.go
@@ -133,12 +133,6 @@ func (o *InstallOptions) Run(c *cobra.Command, f client.Factory) error {
 
 	fmt.Printf("Detected Cluster type %s during BackupDriver install\n", clusterFlavor)
 
-	// Check vSphere CSI driver version
-	err = cmd.CheckVSphereCSIDriverVersion(kubeClient, clusterFlavor)
-	if err != nil {
-		return err
-	}
-
 	// Check feature flags for backup-driver
 	if err := o.CheckFeatureFlagsForBackupDriver(kubeClient); err != nil {
 		return err
@@ -231,7 +225,7 @@ func (o *InstallOptions) Complete(args []string, f client.Factory) error {
 }
 
 func (o *InstallOptions) CheckClusterFlavorForBackupDriver() (constants.ClusterFlavor, error) {
-	clusterFlavor, err := utils.GetClusterFlavor(nil)
+	clusterFlavor, err := utils.RetrieveClusterFlavor(nil, o.Namespace)
 	if err != nil {
 		return constants.Unknown, errors.Wrap(err, "Failed to get cluster flavor for backup-driver")
 	}
@@ -242,7 +236,7 @@ func (o *InstallOptions) CheckClusterFlavorForBackupDriver() (constants.ClusterF
 		o.MasterAffinity = true
 		o.HostNetwork = true
 	}
-
+	fmt.Printf("BackupDriver: Determined the cluster flavor as: %s\n", clusterFlavor)
 	return clusterFlavor, nil
 }
 

--- a/pkg/cmd/backupdriver/cli/server/server.go
+++ b/pkg/cmd/backupdriver/cli/server/server.go
@@ -235,13 +235,14 @@ func newServer(f client.Factory, config serverConfig, logger *logrus.Logger) (*s
 	// Set snapshot manager configuration information
 	snapshotMgrConfig := make(map[string]string)
 	snapshotMgrConfig[constants.VolumeSnapshotterManagerLocation] = constants.VolumeSnapshotterDataServer
-	snapshotMgrConfig[constants.VolumeSnapshotterLocalMode] = strconv.FormatBool(utils.IsFeatureEnabled(constants.VSphereLocalModeFlag, false, logger))
+	snapshotMgrConfig[constants.VolumeSnapshotterLocalMode] = strconv.FormatBool(utils.IsFeatureEnabled(kubeClient, constants.VSphereLocalModeFlag, false, logger))
 
 	// If CLUSTER_FLAVOR is GUEST_CLUSTER, set up svcKubeConfig to communicate with the Supervisor Cluster
 	clusterFlavor, err := utils.GetClusterFlavor(clientConfig)
 	if err != nil {
 		return nil, err
 	}
+	logger.Infof("backup-driver detected cluster flavor: %s", clusterFlavor)
 	var svcConfig *rest.Config
 	var svcBackupdriverClient *backupdriver_clientset.BackupdriverV1alpha1Client
 	var svcKubeInformerFactory kubeinformers.SharedInformerFactory

--- a/pkg/cmd/datamgr/cli/install/install.go
+++ b/pkg/cmd/datamgr/cli/install/install.go
@@ -159,12 +159,6 @@ func (o *InstallOptions) Run(c *cobra.Command, f client.Factory) error {
 		return nil
 	}
 
-	// Check vSphere CSI driver version
-	err = cmd.CheckVSphereCSIDriverVersion(kubeClient, clusterFlavor)
-	if err != nil {
-		return err
-	}
-
 	// Check velero version
 	_ = cmd.CheckVeleroVersion(kubeClient, o.Namespace)
 
@@ -275,14 +269,14 @@ func (o *InstallOptions) getNumberOfNodes(kubeClient kubernetes.Interface) (int,
 }
 
 func (o *InstallOptions) CheckClusterFlavorForDataManager() constants.ClusterFlavor {
-	clusterFlavor, _ := utils.GetClusterFlavor(nil)
+	clusterFlavor, _ := utils.RetrieveClusterFlavor(nil, o.Namespace)
 
 	// In case of Guest or Supervisor cluster, skip installing data manager
 	if clusterFlavor == constants.TkgGuest || clusterFlavor == constants.Supervisor {
 		fmt.Printf("The Cluster Flavor: %s. Skipping data manager installation.\n", clusterFlavor)
 		o.SkipInstall = true
 	}
-
+	fmt.Printf("DataManager: Determined the cluster flavor as: %s\n", clusterFlavor)
 	return clusterFlavor
 }
 

--- a/pkg/cmd/datamgr/cli/server/server.go
+++ b/pkg/cmd/datamgr/cli/server/server.go
@@ -232,6 +232,13 @@ func newServer(f client.Factory, config serverConfig, logger *logrus.Logger) (*s
 		return nil, err
 	}
 
+	clusterFlavor, err := utils.GetClusterFlavor(clientConfig)
+	if err != nil {
+		logger.WithError(err).Error("failed to identify cluster flavor")
+		return nil, err
+	}
+	logger.Infof("data-manager detected cluster flavor: %s", clusterFlavor)
+
 	ivdParams := make(map[string]interface{})
 	if config.vcConfigFromSecret == true {
 		logger.Infof("VC Configuration will be retrieved from cluster secret")
@@ -269,11 +276,6 @@ func newServer(f client.Factory, config serverConfig, logger *logrus.Logger) (*s
 		return nil, err
 	}
 
-	clusterFlavor, err := utils.GetClusterFlavor(clientConfig)
-	if err != nil {
-		logger.WithError(err).Error("Failed tp identify cluster flavor")
-		return nil, err
-	}
 	// In supervisor/guest cluster, data manager is remote
 	externalDataMgr := false
 	if clusterFlavor != constants.VSphere {

--- a/pkg/cmd/utils.go
+++ b/pkg/cmd/utils.go
@@ -127,6 +127,7 @@ func CreateFeatureStateConfigMap(kubeClient kubernetes.Interface, features []str
 				Name:      constants.VSpherePluginFeatureStates,
 				Namespace: veleroNs,
 			},
+			Data: make(map[string]string),
 		}
 		create = true
 	}
@@ -138,6 +139,12 @@ func CreateFeatureStateConfigMap(kubeClient kubernetes.Interface, features []str
 	featuresString := strings.Join(features[:], ",")
 	if strings.Contains(featuresString, constants.VSphereLocalModeFeature) {
 		featureData[constants.VSphereLocalModeFlag] = strconv.FormatBool(true)
+	}
+	// Update the data to the default if the flag is not found
+	if decoupleVSphereCSIDriverFlag, ok := featureConfigMap.Data[constants.DecoupleVSphereCSIDriverFlag]; !ok {
+		featureData[constants.DecoupleVSphereCSIDriverFlag] = strconv.FormatBool(false)
+	} else {
+		featureData[constants.DecoupleVSphereCSIDriverFlag] = decoupleVSphereCSIDriverFlag
 	}
 	featureConfigMap.Data = featureData
 	if create {

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -109,7 +109,7 @@ const (
 	// Default image registry for the fall-back mechanism in the image-parsing workflow
 	// when installing backup-driver and data-manager-for-plug while installing velero-plugin-for-vsphere.
 	// Make sure to update it accordingly if the official image registry gets migrated.
-	DefaultImageRegistry          = "vsphereveleroplugin"
+	DefaultImageRegistry = "vsphereveleroplugin"
 )
 
 const (
@@ -147,8 +147,9 @@ const (
 
 // feature flog constants
 const (
-	VSphereLocalModeFlag    = "local-mode"
-	VSphereLocalModeFeature = "EnableLocalMode"
+	VSphereLocalModeFlag         = "local-mode"
+	DecoupleVSphereCSIDriverFlag = "decouple-vsphere-csi-driver"
+	VSphereLocalModeFeature      = "EnableLocalMode"
 )
 
 const (
@@ -376,7 +377,18 @@ const (
 )
 
 const (
-	VddkConfig = "vddk-config"
+	VddkConfig         = "vddk-config"
 	VddkConfigLabelKey = "velero.io/vddk-config"
-	VixDiskLib = "vix-disk-lib"
+	VixDiskLib         = "vix-disk-lib"
+)
+
+const DefaultVeleroNamespace = "velero"
+
+const (
+	ConfigClusterFlavorKey    = "cluster_flavor"
+	VeleroVSpherePluginConfig = "velero-vsphere-plugin-config"
+	VSphereSecretNamespaceKey = "vsphere_secret_namespace"
+	VSphereSecretNameKey      = "vsphere_secret_name"
+	DefaultSecretName         = "velero-vsphere-config-secret"
+	DefaultSecretNamespace    = "velero"
 )

--- a/pkg/plugin/backup_pvc_action_plugin.go
+++ b/pkg/plugin/backup_pvc_action_plugin.go
@@ -82,12 +82,13 @@ func (p *NewPVCBackupItemAction) Execute(item runtime.Unstructured, backup *vele
 
 	restConfig, err := utils.GetKubeClientConfig()
 	if err != nil {
-		p.Log.Error("Failed to get the rest config in k8s cluster: %v", err)
+		p.Log.Errorf("Failed to get the rest config in k8s cluster: %v", err)
 		return nil, nil, errors.WithStack(err)
 	}
 
 	kubeClient, err := kubernetes.NewForConfig(restConfig)
 	if err != nil {
+		p.Log.Errorf("failed to get the kubeclient: %v", err)
 		return nil, nil, errors.WithStack(err)
 	}
 
@@ -124,7 +125,7 @@ func (p *NewPVCBackupItemAction) Execute(item runtime.Unstructured, backup *vele
 
 	// Do not claim a backup repository in local mode
 	var backupRepositoryName string
-	isLocalMode := utils.IsFeatureEnabled(constants.VSphereLocalModeFlag, false, p.Log)
+	isLocalMode := utils.IsFeatureEnabled(kubeClient, constants.VSphereLocalModeFlag, false, p.Log)
 	if !isLocalMode {
 		p.Log.Info("Claiming backup repository during backup")
 		bslName := backup.Spec.StorageLocation


### PR DESCRIPTION
**What this PR does / why we need it**:
Decouple the velero plugin from it's vSphere CSI driver dependency for Vanilla.
The change does 2 things:
1. Looks for `velero-vsphere-plugin-config` to determine the cluster flavor, if not present it defaults to determining the cluster type from vSphere CSI driver deployment, if unavailable, it defaults to VANILLA.
2. Looks for `velero-vsphere-config-secret` if the cluster flavor is VANILLA. If not present there is an error during startup. The secret contains VC credentials, currently, the same information entered when deploying vSphere CSI driver is required.
3. Refactored code to enable unit testing.
4. Introduced fss `decouple-vsphere-csi-driver` in `velero-vsphere-plugin-feature-states`

Refer https://confluence.eng.vmware.com/display/~dkinni/Decouple+Plugin+from+vSphere+CSI+Driver for more details.

**Testing Done**:
Introduced 22 new unit tests:
```
--- PASS: TestRetrieveVcConfigSecret (0.00s)
    --- PASS: TestRetrieveVcConfigSecret/Decouple_CSI_driver_feature_enabled,_plugin_config_absent,_supervisor_csi_2.3,_csi_secret_present (0.00s)
    --- PASS: TestRetrieveVcConfigSecret/Decouple_CSI_driver_feature_enabled,_plugin_config_disabled,_supervisor_csi_2.3,_csi_secret_present (0.00s)
    --- PASS: TestRetrieveVcConfigSecret/Decouple_CSI_driver_feature_enabled,_plugin_config_present_but_no_secret_specified,_plugin_secret_present (0.00s)
    --- PASS: TestRetrieveVcConfigSecret/Decouple_CSI_driver_feature_enabled,_plugin_config_present,_plugin_secret_present (0.00s)
    --- PASS: TestRetrieveVcConfigSecret/Decouple_CSI_driver_feature_enabled,_plugin_config_absent,_default_plugin_secret_present (0.00s)
    --- PASS: TestRetrieveVcConfigSecret/Decouple_CSI_driver_feature_enabled,_plugin_config_absent,_default_plugin_secret_present#01 (0.00s)
    --- PASS: TestRetrieveVcConfigSecret/Decouple_CSI_driver_feature_enabled,_plugin_config_absent,_default_plugin_secret_absent (0.00s)
    --- PASS: TestRetrieveVcConfigSecret/Decouple_CSI_driver_feature_disabled,_vanilla_csi_2.3,_csi_secret_present (0.00s)
    --- PASS: TestRetrieveVcConfigSecret/Decouple_CSI_driver_feature_disabled,_vanilla_csi_2.3,_csi_secret_absent (0.00s)
    --- PASS: TestRetrieveVcConfigSecret/Decouple_CSI_driver_feature_disabled,_vanilla_csi_2.0.1,_csi_secret_present (0.00s)
    --- PASS: TestRetrieveVcConfigSecret/Decouple_CSI_driver_feature_disabled,_vanilla_csi_2.0.1,_csi_secret_present#01 (0.00s)
--- PASS: TestRetrieveClusterFlavor (0.00s)
    --- PASS: TestRetrieveClusterFlavor/Config_velero-vsphere-plugin-config_present_with_VANILLA_cluster_flavor_specified (0.00s)
    --- PASS: TestRetrieveClusterFlavor/Test_fallback_when_Config_velero-vsphere-plugin-config_present_with_cluster_flavor_INVALID_and_csi_2.3_Deployment_on_Vanilla (0.00s)
    --- PASS: TestRetrieveClusterFlavor/Test_fallback_when_Config_velero-vsphere-plugin-config_is_absent_and_csi_2.3_Deployment (0.00s)
    --- PASS: TestRetrieveClusterFlavor/Test_fallback_when_Config_velero-vsphere-plugin-config_is_absent_and_csi_2.0.1_Deployment (0.00s)
    --- PASS: TestRetrieveClusterFlavor/Test_fallback_when_Config_velero-vsphere-plugin-config_is_absent_and_csi_driver_is_absent (0.00s)
    --- PASS: TestRetrieveClusterFlavor/Test_fallback_when_Config_velero-vsphere-plugin-config_is_absent_and_csi_2.3_Deployment_on_Supervisor (0.00s)
    --- PASS: TestRetrieveClusterFlavor/Test_fallback_when_Config_velero-vsphere-plugin-config_is_absent_and_csi_2.3_Deployment_on_Guest (0.00s)
--- PASS: TestGetClusterTypeFromConfig (0.00s)
    --- PASS: TestGetClusterTypeFromConfig/VANILLA_specified_in_velero-vsphere-plugin-config (0.00s)
    --- PASS: TestGetClusterTypeFromConfig/GUEST_specified_in_velero-vsphere-plugin-config (0.00s)
    --- PASS: TestGetClusterTypeFromConfig/INVALID_specified_in_velero-vsphere-plugin-config (0.00s)
    --- PASS: TestGetClusterTypeFromConfig/No_velero-vsphere-plugin-config_ConfigMap_in_the_cluster (0.00s)
```

Existing Unit Tests:
```
make test
go test ./pkg/... -timeout=300s
Success!
```

Builds:
```
harbor-repo.vmware.com/dkinni/velero-plugin-for-vsphere:decoup_csi_v1-6eb4782-15.Sep.2021.15.29.31
harbor-repo.vmware.com/dkinni/data-manager-for-plugin:decoup_csi_v1-6eb4782-15.Sep.2021.15.29.31
harbor-repo.vmware.com/dkinni/backup-driver:decoup_csi_v1-6eb4782-15.Sep.2021.15.29.31
```


**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #DPCP-471

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
This change requires a `velero-vsphere-plugin-config` ConfigMap that contains the cluster type information to be created prior to plugin installation for all cluster favors. This change also requires a `velero-vsphere-config-secret` Secret to be created in the same namespace as velero which contains the VC credentials on Vanilla Cluster setups.
```
Signed-off-by: Deepak Kinni <dkinni@vmware.com>
