### PR TITLE
Fixed the issue with parsing NetworkAttachmentDefinition resource and ensure it is blocked in backup

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -235,7 +235,8 @@ var ResourcesToBlock = map[string]bool{
 	"machinesets.cluster.x-k8s.io":                       true,
 	"members.registryagent.vmware.com":                   true,
 	"ncpconfigs.nsx.vmware.com":                          true,
-	"network-attachment-definitions.k8s.cni.cncf.io":     true,
+	"network-attachment-definitions.k8s.cni.cncf.io":     true,  // real name of NetworkAttachmentDefinition
+	"networkattachmentdefinitions.k8s.cni.cncf.io":       true,  // parsed name of NetworkAttachmentDefinition
 	"networkinterfaces.netoperator.vmware.com":           true,
 	"networks.netoperator.vmware.com":                    true,
 	"nsxerrors.nsx.vmware.com":                           true,

--- a/pkg/plugin/backup_pvc_action_plugin.go
+++ b/pkg/plugin/backup_pvc_action_plugin.go
@@ -47,10 +47,10 @@ func (p *NewPVCBackupItemAction) Execute(item runtime.Unstructured, backup *vele
 	}
 
 	blocked, crdName, err := pluginUtil.IsObjectBlocked(item)
-
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "Failed during IsObjectBlocked check")
 	}
+	p.Log.Infof("Backing up resource %v: blocked = %v", crdName, blocked)
 
 	if blocked {
 		return nil, nil, errors.Errorf("Resource CRD %s is blocked in backup, skipping", crdName)


### PR DESCRIPTION
Signed-off-by: Lintong Jiang <lintongj@vmware.com>

**What this PR does / why we need it**:
Failed to parse and block the backup of network-attachment-definitions.k8s.cni.cncf.io resources effectively

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #389 

**Special notes for your reviewer**: N/A

**Test**:
Functional Test
*negative case*: backup a namespace with NetworkAttachmentDefinition resource
```
velero backup create test-backup-nad-001 --include-namespaces test-nad
```
It failed with expected error.
```
time="2021-09-16T18:56:37Z" level=info msg="Processing item" backup=velero/test-backup-nad-001 logSource="pkg/backup/backup.go:378" name=macvlan-conf namespace=test-nad progress= resource=network-attachment-definitions.k8s.cni.cncf.io
time="2021-09-16T18:56:37Z" level=info msg="Backing up item" backup=velero/test-backup-nad-001 logSource="pkg/backup/item_backupper.go:121" name=macvlan-conf namespace=test-nad resource=network-attachment-definitions.k8s.cni.cncf.io
time="2021-09-16T18:56:37Z" level=info msg="Executing custom action" backup=velero/test-backup-nad-001 logSource="pkg/backup/item_backupper.go:327" name=macvlan-conf namespace=test-nad resource=network-attachment-definitions.k8s.cni.cncf.io
time="2021-09-16T18:56:37Z" level=info msg="Backing up resource networkattachmentdefinitions.k8s.cni.cncf.io: blocked = true" backup=velero/test-backup-nad-001 cmd=/plugins/velero-plugin-for-vsphere logSource="/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/plugin/backup_pvc_action_plugin.go:53" pluginName=velero-plugin-for-vsphere
time="2021-09-16T18:56:37Z" level=info msg="1 errors encountered backup up item" backup=velero/test-backup-nad-001 logSource="pkg/backup/backup.go:451" name=macvlan-conf
time="2021-09-16T18:56:37Z" level=error msg="Error backing up item" backup=velero/test-backup-nad-001 error="error executing custom action (groupResource=network-attachment-definitions.k8s.cni.cncf.io, namespace=test-nad, name=macvlan-conf): rpc error: code = Unknown desc = Resource CRD networkattachmentdefinitions.k8s.cni.cncf.io is blocked in backup, skipping" error.file="/go/src/github.com/vmware-tanzu/velero/pkg/backup/item_backupper.go:331" error.function="github.com/vmware-tanzu/velero/pkg/backup.(*itemBackupper).executeActions" logSource="pkg/backup/backup.go:455" name=macvlan-conf
```

*positive case*: backup a namespace with NetworkAttachmentDefinition resource while exclude NetworkAttachmentDefinition resource.
```
velero backup create test-backup-nad-002 --include-namespaces test-ns-rmohhby --exclude-resources network-attachment-definitions.k8s.cni.cncf.io
```
The backup was completed successfully.
```
$velero backup get test-backup-nad-002
NAME                  STATUS      ERRORS   WARNINGS   CREATED                         EXPIRES   STORAGE LOCATION   SELECTOR
test-backup-nad-002   Completed   0        5          2021-09-16 11:59:52 -0700 PDT   29d       default            <none>
```


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
Fixed the issue with parsing NetworkAttachmentDefinition resource and ensure it is blocked in backup
```
