### PR TITLE
Ignore logout errors when reloading configuration

### DIFF
--- a/pkg/ivd/ivd_protected_entity_type_manager.go
+++ b/pkg/ivd/ivd_protected_entity_type_manager.go
@@ -21,8 +21,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/vmware-tanzu/astrolabe/pkg/astrolabe"
-	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/common/vsphere"
 	"github.com/vmware-tanzu/astrolabe/pkg/util"
+	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/common/vsphere"
 	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
 	"github.com/vmware/govmomi/vslm"
@@ -346,8 +346,8 @@ func (this *IVDProtectedEntityTypeManager) ReloadConfig(ctx context.Context, par
 			// Disconnecting older vc instance.
 			err = this.vcenter.Disconnect(ctx)
 			if err != nil {
-				this.logger.Errorf("Failed to disconnect older vcenter instance.")
-				return err
+				this.logger.Warnf("Failed to disconnect older vcenter instance, " +
+					"ignoring and proceeding, err: %+v", err)
 			}
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
During ReloadConfiguration we currently return an error if there was a failure while disconnecting from vc(logout of vc session), as a side-effect, although the newly received credentials are valid, clients are not re-created with new credentials. Erroring out due to failures in disconnecting seems like a overkill, considering it's far more important to accept the new credentials and re-create the necessary clients.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
Ignore older vcenter logout errors when reloading configuration with a new username password.
```
Signed-off-by: Deepak Kinni <dkinni@vmware.com>