### PR TITLE
Remove unnecessary config values when reading vc config secret

### DIFF
--- a/pkg/cmd/datamgr/cli/server/server.go
+++ b/pkg/cmd/datamgr/cli/server/server.go
@@ -26,7 +26,6 @@ import (
 	"net/http"
 	"net/http/pprof"
 	"os"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -207,7 +206,6 @@ func getVCConfigParams(config serverConfig, params map[string]interface{}, logge
 
 	// Below vc configuration params are optional
 	params[vsphere.PortVcParamKey] = config.port
-	params[vsphere.InsecureFlagVcParamKey] = strconv.FormatBool(config.insecureFlag)
 
 	return nil
 }

--- a/pkg/common/vsphere/vcenter_utils.go
+++ b/pkg/common/vsphere/vcenter_utils.go
@@ -37,20 +37,8 @@ func GetPortFromParamsMap(params map[string]interface{}) (string, error) {
 	return GetStringFromParamsMap(params, PortVcParamKey)
 }
 
-func GetDatacenterFromParamsMap(params map[string]interface{}) (string, error) {
-	return GetStringFromParamsMap(params, DatacenterVcParamKey)
-}
-
 func GetClusterFromParamsMap(params map[string]interface{}) (string, error) {
 	return GetStringFromParamsMap(params, ClusterVcParamKey)
-}
-
-func GetInsecureFlagFromParamsMap(params map[string]interface{}) (bool, error) {
-	insecureStr, err := GetStringFromParamsMap(params, InsecureFlagVcParamKey)
-	if err == nil {
-		return strconv.ParseBool(insecureStr)
-	}
-	return false, err
 }
 
 func GetVirtualCenterConfigFromParams(params map[string]interface{}, logger logrus.FieldLogger) (*VirtualCenterConfig, error) {
@@ -74,10 +62,6 @@ func GetVirtualCenterConfigFromParams(params map[string]interface{}, logger logr
 	if err != nil {
 		return nil, err
 	}
-	insecure, err := GetInsecureFlagFromParamsMap(params)
-	if err != nil {
-		return nil, err
-	}
 	clusterId, err := GetClusterFromParamsMap(params)
 	if err != nil {
 		return nil, err
@@ -91,7 +75,6 @@ func GetVirtualCenterConfigFromParams(params map[string]interface{}, logger logr
 		Username:        vcUser,
 		Password:        vcPassword,
 		ClusterId:       clusterId,
-		Insecure:        insecure,
 		VCClientTimeout: DefaultVCClientTimeoutInMinutes,
 	}
 	return vcConfig, nil

--- a/pkg/common/vsphere/virtual_center.go
+++ b/pkg/common/vsphere/virtual_center.go
@@ -25,6 +25,8 @@ const (
 	DefaultVCClientTimeoutInMinutes = 30
 	// DefaultAuthErrorRetryCount is the number of retries
 	DefaultAuthErrorRetryCount = 1
+	// DefaultInsecure is the current default value for insecure flag
+	DefaultInsecure bool = true
 )
 
 // Keys for VCenter parameters
@@ -33,8 +35,6 @@ const (
 	UserVcParamKey         = "user"
 	PasswordVcParamKey     = "password"
 	PortVcParamKey         = "port"
-	DatacenterVcParamKey   = "datacenters"
-	InsecureFlagVcParamKey = "insecure-flag"
 	ClusterVcParamKey      = "cluster-id"
 )
 
@@ -68,9 +68,6 @@ type VirtualCenterConfig struct {
 	Password string
 	// Cluster-id
 	ClusterId string
-	// Specifies whether to verify the server's certificate chain. Set to true to
-	// skip verification.
-	Insecure bool
 	// RoundTripperCount is the SOAP round tripper count. (retries = RoundTripperCount - 1)
 	RoundTripperCount int
 	// VCClientTimeout is the time limit in minutes for requests made by vCenter client
@@ -119,12 +116,8 @@ func (this *VirtualCenter) newClient(ctx context.Context) (*govmomi.Client, erro
 		log.Errorf("failed to parse URL %s with err: %v", url, err)
 		return nil, err
 	}
-	if this.Config.Insecure == false {
-		log.Warnf("The vCenter Configuration states secure connection, overriding to use insecure connection..")
-		this.Config.Insecure = true
-		// TODO: support vCenter connection using certs.
-	}
-	soapClient := soap.NewClient(url, this.Config.Insecure)
+	// Always use insecure connection.
+	soapClient := soap.NewClient(url, DefaultInsecure)
 	soapClient.Timeout = time.Duration(this.Config.VCClientTimeout) * time.Minute
 	log.Debugf("Setting vCenter soap client timeout to %v", soapClient.Timeout)
 	vimClient, err := vim25.NewClient(ctx, soapClient)

--- a/pkg/ivd/ivd_protected_entity_test.go
+++ b/pkg/ivd/ivd_protected_entity_test.go
@@ -23,8 +23,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/sirupsen/logrus"
 	"github.com/vmware-tanzu/astrolabe/pkg/astrolabe"
-	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/common/vsphere"
 	"github.com/vmware-tanzu/astrolabe/pkg/s3repository"
+	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/common/vsphere"
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/pbm"
@@ -92,7 +92,6 @@ func TestSnapshotOpsUnderRaceCondition(t *testing.T) {
 	params[vsphere.UserVcParamKey] = vcUrl.User.Username()
 	password, _ := vcUrl.User.Password()
 	params[vsphere.PasswordVcParamKey] = password
-	params[vsphere.InsecureFlagVcParamKey] = true
 	params[vsphere.ClusterVcParamKey] = ""
 
 	ivdPETM := getIVDProtectedEntityTypeManager(t, err, params, s3Config, logger)
@@ -561,7 +560,6 @@ func TestBackupEncryptedIVD(t *testing.T) {
 	params[vsphere.UserVcParamKey] = vcUrl.User.Username()
 	password, _ := vcUrl.User.Password()
 	params[vsphere.PasswordVcParamKey] = password
-	params[vsphere.InsecureFlagVcParamKey] = true
 	params[vsphere.ClusterVcParamKey] = ""
 
 	ivdPETM := getIVDProtectedEntityTypeManager(t, err, params, s3Config, logger)

--- a/pkg/snapshotmgr/snapshot_manager.go
+++ b/pkg/snapshotmgr/snapshot_manager.go
@@ -20,8 +20,8 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/common/vsphere"
 	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/backuprepository"
+	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/common/vsphere"
 	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/constants"
 	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/ivd"
 	v1 "k8s.io/api/core/v1"
@@ -80,8 +80,6 @@ func NewSnapshotManagerFromCluster(params map[string]interface{}, config map[str
 		ivdParams[vsphere.UserVcParamKey] = params[vsphere.UserVcParamKey]
 		ivdParams[vsphere.PasswordVcParamKey] = params[vsphere.PasswordVcParamKey]
 		ivdParams[vsphere.PortVcParamKey] = params[vsphere.PortVcParamKey]
-		ivdParams[vsphere.DatacenterVcParamKey] = params[vsphere.DatacenterVcParamKey]
-		ivdParams[vsphere.InsecureFlagVcParamKey] = params[vsphere.InsecureFlagVcParamKey]
 		ivdParams[vsphere.ClusterVcParamKey] = params[vsphere.ClusterVcParamKey]
 	}
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1057,6 +1057,7 @@ func GetVcConfigSecretFilterFunc(logger logrus.FieldLogger) func(obj interface{}
 	clusterFlavor, err := retrieveClusterFlavor(clientset, veleroNs)
 	if clusterFlavor == constants.Supervisor {
 		ns = constants.VCSecretNsSupervisor
+		name = constants.VCSecret
 	} else if clusterFlavor == constants.VSphere {
 		if IsFeatureEnabled(clientset, constants.DecoupleVSphereCSIDriverFlag, false, logger) {
 			// Retrieve the vc credentials secret name and namespace from velero-vsphere-plugin-config
@@ -1079,7 +1080,7 @@ func GetVcConfigSecretFilterFunc(logger logrus.FieldLogger) func(obj interface{}
 			name = constants.VCSecret
 		}
 	}
-	logger.Infof("VC Configuration Secret: Namespace: %s Name: %s", ns, constants.VCSecret)
+	logger.Infof("VC Configuration Secret: Namespace: %s Name: %s", ns, name)
 	return func(obj interface{}) bool {
 		switch obj.(type) {
 		case *k8sv1.Secret:


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, we do not use datacenter and we support only `insecure=true`. Removing these params to simplify the values that need to be entered by users.
Also fixed `GetVcConfigSecretFilterFunc` function by setting the default name of the Secret on the supervisor cluster.

**Testing Done**:
Enabled the `decouple-vsphere-csi-driver` flag.
Created the Secret:
```
dkinni@dkinni-a02 vanilla-testing % cat my-secret-vc.conf 
[Global]
cluster-id = "csi1"

[VirtualCenter "10.187.132.221"]
user = "User"
password = "Pass"
port = "443"

dkinni@dkinni-a02 kubectl create secret generic velero-vsphere-config-secret --from-file=my-secret-vc.conf --namespace=velero
```
Verified Backup/Restore on the same cluster as well as cross-cluster restore.


**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
insecure and data-center params need not be specified when creating velero-vsphere-config-secret that contain vc credentials.
```
Signed-off-by: Deepak Kinni <dkinni@vmware.com>