### PR TITLE
Updated the workflow of release.yml to rebuild when releasing a new version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,10 +24,18 @@ jobs:
           cd src/github.com/vmware-tanzu/velero-plugin-for-vsphere
           make ci
       - name: Make Pre-Release
-        if: github.event_name == 'release' && github.event.release.prerelease == true
+        if: github.event_name == 'release'
         env:
           GOPATH: ${GITHUB_WORKSPACE}
         run: |
           cd src/github.com/vmware-tanzu/velero-plugin-for-vsphere
           echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
           make push VERSION=${{ github.event.release.tag_name }}
+      - name: Make Release
+        if: github.event_name == 'release' && github.event.release.prerelease == false
+        env:
+          GOPATH: ${GITHUB_WORKSPACE}
+        run: |
+          cd src/github.com/vmware-tanzu/velero-plugin-for-vsphere
+          echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
+          make release QUALIFIED_TAG=${{ github.event.release.tag_name }} RELEASE_TAG=${{ github.event.release.tag_name }}


### PR DESCRIPTION

**What this PR does / why we need it**:

Updated the workflow of release.yml to rebuild images when releasing a new version. 

It is a tweak in the current release workflow. Currently, we just retag the latest qualified RC build instead of rebuilding. Since we compile the VERSION into binary when build the image(image retagging would not update the VERSION in binary), then the released binaries always come with unexpected version (i.e. pointing to its corresponding latest qualified RC version). Here is the change to fix it.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
None
```
