### PR TITLE
Fixed kubectl cp command from datamgr pods with distroless base image

### DIFF
--- a/Dockerfile-datamgr
+++ b/Dockerfile-datamgr
@@ -12,8 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+FROM busybox:1.33.1 AS busybox
+
 FROM gcr.io/distroless/base-debian10:nonroot
 ADD /bin/linux/amd64/data-* /datamgr
 COPY /bin/linux/amd64/lib/vmware-vix-disklib/lib64/* /vddkLibs/
+COPY --from=busybox /bin/sh /bin/sh
+COPY --from=busybox /bin/cp /bin/cp
+COPY --from=busybox /bin/tar /bin/tar
+COPY --from=busybox /bin/ls /bin/ls
 USER nonroot:nonroot
 ENTRYPOINT ["/datamgr"]


### PR DESCRIPTION
**What this PR does / why we need it**:

With the distroless base image, `kubectl cp` doesn't work any more in copying VDDK log out of data manager pods. In this case, users will not be able to collect VDDK log as documented at [Troubleshooting](https://github.com/vmware-tanzu/velero-plugin-for-vsphere/blob/main/docs/troubleshooting.md#generalvanilla) page.

This is a fix for it. In the long term, we need to improve the logging so that users have easier experience in viewing logs from different components, without collecting logs manually.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
Fixed kubectl cp command from datamgr pods with distroless base image
```
