### PR TITLE
[Crossport] Fixed kubectl cp command from datamgr pods with distroless base image

### DIFF
--- a/Dockerfile-datamgr
+++ b/Dockerfile-datamgr
@@ -12,8 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+FROM busybox:1.33.1 AS busybox
+
 FROM gcr.io/distroless/base-debian10:nonroot
 ADD /bin/linux/amd64/data-* /datamgr
 COPY /bin/linux/amd64/lib/vmware-vix-disklib/lib64/* /vddkLibs/
+COPY --from=busybox /bin/sh /bin/sh
+COPY --from=busybox /bin/cp /bin/cp
+COPY --from=busybox /bin/tar /bin/tar
+COPY --from=busybox /bin/ls /bin/ls
 USER nonroot:nonroot
 ENTRYPOINT ["/datamgr"]


### PR DESCRIPTION
Signed-off-by: Lintong Jiang <lintongj@vmware.com>

**What this PR does / why we need it**:
Crossport #407 

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
None
```
