### PR TITLE
Enable decouple-vsphere-csi-driver by default

### DIFF
--- a/pkg/cmd/utils.go
+++ b/pkg/cmd/utils.go
@@ -140,9 +140,9 @@ func CreateFeatureStateConfigMap(kubeClient kubernetes.Interface, features []str
 	if strings.Contains(featuresString, constants.VSphereLocalModeFeature) {
 		featureData[constants.VSphereLocalModeFlag] = strconv.FormatBool(true)
 	}
-	// Update the data to the default if the flag is not found
+	// Update the data to the default if the flag is not found, the default is true.
 	if decoupleVSphereCSIDriverFlag, ok := featureConfigMap.Data[constants.DecoupleVSphereCSIDriverFlag]; !ok {
-		featureData[constants.DecoupleVSphereCSIDriverFlag] = strconv.FormatBool(false)
+		featureData[constants.DecoupleVSphereCSIDriverFlag] = strconv.FormatBool(true)
 	} else {
 		featureData[constants.DecoupleVSphereCSIDriverFlag] = decoupleVSphereCSIDriverFlag
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -91,7 +91,7 @@ func RetrieveVcConfigSecret(params map[string]interface{}, config *rest.Config, 
 		ns = constants.VCSecretNsSupervisor
 		vSphereSecrets = append(vSphereSecrets, constants.VCSecret, constants.VCSecretTKG)
 	} else { // constants.VSphere
-		if IsFeatureEnabled(clientset, constants.DecoupleVSphereCSIDriverFlag, false, logger) {
+		if IsFeatureEnabled(clientset, constants.DecoupleVSphereCSIDriverFlag, true, logger) {
 			// Retrieve the vc credentials secret name and namespace from velero-vsphere-plugin-config
 			ns, name = GetSecretNamespaceAndName(clientset, veleroNs, constants.VeleroVSpherePluginConfig)
 			vSphereSecrets = append(vSphereSecrets, name)
@@ -1059,7 +1059,7 @@ func GetVcConfigSecretFilterFunc(logger logrus.FieldLogger) func(obj interface{}
 		ns = constants.VCSecretNsSupervisor
 		name = constants.VCSecret
 	} else if clusterFlavor == constants.VSphere {
-		if IsFeatureEnabled(clientset, constants.DecoupleVSphereCSIDriverFlag, false, logger) {
+		if IsFeatureEnabled(clientset, constants.DecoupleVSphereCSIDriverFlag, true, logger) {
 			// Retrieve the vc credentials secret name and namespace from velero-vsphere-plugin-config
 			ns, name = GetSecretNamespaceAndName(clientset, veleroNs, constants.VeleroVSpherePluginConfig)
 			logger.Infof("RetrieveVcConfigSecret: Namespace: %s Name: %s", ns, name)


### PR DESCRIPTION
**What this PR does / why we need it**:
Enabling the feature flag by default.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Testing**
```
Running tests: ./pkg/...
go test ./pkg/... -timeout=300s
go: downloading github.com/stretchr/testify v1.7.0
go: downloading k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/apis/backupdriver/v1alpha1	[no test files]
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/apis/datamover/v1alpha1	[no test files]
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/backupdriver	[no test files]
ok  	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/backuprepository	0.222s
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/builder	[no test files]
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/buildinfo	[no test files]
ok  	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/cmd	0.181s
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/cmd/backupdriver	[no test files]
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/cmd/backupdriver/cli/install	[no test files]
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/cmd/backupdriver/cli/server	[no test files]
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/cmd/datamgr	[no test files]
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/cmd/datamgr/cli/install	[no test files]
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/cmd/datamgr/cli/server	[no test files]
ok  	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/common/vsphere	0.039s
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/constants	[no test files]
ok  	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/controller	0.207s
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/dataMover	[no test files]
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned	[no test files]
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/fake	[no test files]
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/scheme	[no test files]
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/typed/backupdriver/v1alpha1	[no test files]
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/typed/backupdriver/v1alpha1/fake	[no test files]
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/typed/datamover/v1alpha1	[no test files]
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/typed/datamover/v1alpha1/fake	[no test files]
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/crds	[no test files]
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/informers/externalversions	[no test files]
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/informers/externalversions/backupdriver	[no test files]
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/informers/externalversions/backupdriver/v1alpha1	[no test files]
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/informers/externalversions/datamover	[no test files]
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/informers/externalversions/datamover/v1alpha1	[no test files]
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/informers/externalversions/internalinterfaces	[no test files]
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/listers/backupdriver/v1alpha1	[no test files]
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/listers/datamover/v1alpha1	[no test files]
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/install	[no test files]
ok  	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/ivd	0.126s
ok  	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/paravirt	0.205s
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/plugin	[no test files]
ok  	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/plugin/util	0.072s
ok  	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/snapshotUtils	0.091s
ok  	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/snapshotmgr	0.071s
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/test	[no test files]
ok  	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/utils	0.085s
Success!
```


**Does this PR introduce a user-facing change?**:
```release-note
Enables behavior specified in PR 391 as default. 
```
Signed-off-by: Deepak Kinni <dkinni@vmware.com>