### PR TITLE
[Crossport]Enable decouple-vsphere-csi-driver by default (#411)

### DIFF
--- a/pkg/cmd/utils.go
+++ b/pkg/cmd/utils.go
@@ -140,9 +140,9 @@ func CreateFeatureStateConfigMap(kubeClient kubernetes.Interface, features []str
 	if strings.Contains(featuresString, constants.VSphereLocalModeFeature) {
 		featureData[constants.VSphereLocalModeFlag] = strconv.FormatBool(true)
 	}
-	// Update the data to the default if the flag is not found
+	// Update the data to the default if the flag is not found, the default is true.
 	if decoupleVSphereCSIDriverFlag, ok := featureConfigMap.Data[constants.DecoupleVSphereCSIDriverFlag]; !ok {
-		featureData[constants.DecoupleVSphereCSIDriverFlag] = strconv.FormatBool(false)
+		featureData[constants.DecoupleVSphereCSIDriverFlag] = strconv.FormatBool(true)
 	} else {
 		featureData[constants.DecoupleVSphereCSIDriverFlag] = decoupleVSphereCSIDriverFlag
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -91,7 +91,7 @@ func RetrieveVcConfigSecret(params map[string]interface{}, config *rest.Config, 
 		ns = constants.VCSecretNsSupervisor
 		vSphereSecrets = append(vSphereSecrets, constants.VCSecret, constants.VCSecretTKG)
 	} else { // constants.VSphere
-		if IsFeatureEnabled(clientset, constants.DecoupleVSphereCSIDriverFlag, false, logger) {
+		if IsFeatureEnabled(clientset, constants.DecoupleVSphereCSIDriverFlag, true, logger) {
 			// Retrieve the vc credentials secret name and namespace from velero-vsphere-plugin-config
 			ns, name = GetSecretNamespaceAndName(clientset, veleroNs, constants.VeleroVSpherePluginConfig)
 			vSphereSecrets = append(vSphereSecrets, name)
@@ -1059,7 +1059,7 @@ func GetVcConfigSecretFilterFunc(logger logrus.FieldLogger) func(obj interface{}
 		ns = constants.VCSecretNsSupervisor
 		name = constants.VCSecret
 	} else if clusterFlavor == constants.VSphere {
-		if IsFeatureEnabled(clientset, constants.DecoupleVSphereCSIDriverFlag, false, logger) {
+		if IsFeatureEnabled(clientset, constants.DecoupleVSphereCSIDriverFlag, true, logger) {
 			// Retrieve the vc credentials secret name and namespace from velero-vsphere-plugin-config
 			ns, name = GetSecretNamespaceAndName(clientset, veleroNs, constants.VeleroVSpherePluginConfig)
 			logger.Infof("RetrieveVcConfigSecret: Namespace: %s Name: %s", ns, name)


### PR DESCRIPTION
**What this PR does / why we need it**:
Crossport #411. Enabling the feature flag by default.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Enable decouple-vsphere-csi-driver as default.
```
Signed-off-by: Deepak Kinni <dkinni@vmware.com>