### PR TITLE
Rely on only container name while parsing feature flags

### DIFF
--- a/pkg/cmd/utils.go
+++ b/pkg/cmd/utils.go
@@ -86,7 +86,7 @@ func GetVeleroFeatureFlags(kubeClient kubernetes.Interface, ns string) ([]string
 func GetFeatureFlagsFromImage(containers []v1.Container, containerName string) ([]string, error) {
 	var containerArgs = []string{}
 	for _, container := range containers {
-		if containerName == container.Name && containerName == utils.GetComponentFromImage(container.Image, constants.ImageContainerComponent) {
+		if containerName == container.Name {
 			containerArgs = container.Args[1:]
 			break
 		}

--- a/pkg/cmd/utils_test.go
+++ b/pkg/cmd/utils_test.go
@@ -314,6 +314,60 @@ func TestGetVeleroFeatureFlags(t *testing.T) {
 			expectedFeatureFlags: []string{},
 			expectedError:        nil,
 		},
+		{
+			name: "VeleroImageWithSha256",
+			veleroDeployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "velero",
+					Name:      constants.VeleroDeployment,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "velero",
+									Image: "velero/velero@sha256:934dae8b2e17b4298bca95f45ec3620a283647297fb8ba8c0f5977e8238a97ee",
+									Args: []string{
+										"server",
+										"--features=EnableLocalMode",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedFeatureFlags: []string{"EnableLocalMode"},
+			expectedError:        nil,
+		},
+		{
+			name: "VeleroImageWithSha256MultipleFlags",
+			veleroDeployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "velero",
+					Name:      constants.VeleroDeployment,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "velero",
+									Image: "velero/velero@sha256:934dae8b2e17b4298bca95f45ec3620a283647297fb8ba8c0f5977e8238a97ee",
+									Args: []string{
+										"server",
+										"--features=EnableVSphereItemActionPlugin,EnableLocalMode",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedFeatureFlags: []string{"EnableVSphereItemActionPlugin", "EnableLocalMode"},
+			expectedError:        nil,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
The PR ensures that the plugin uses only the container name to determine `velero` container.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #421 

**Special notes for your reviewer**:
Added 2 unit tests to emulate the scenario.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
Signed-off-by: Deepak Kinni <dkinni@vmware.com>