### PR TITLE
Retry if there are errors retrieving download CR

### DIFF
--- a/pkg/snapshotmgr/snapshot_manager.go
+++ b/pkg/snapshotmgr/snapshot_manager.go
@@ -691,17 +691,17 @@ func (this *SnapshotManager) CreateVolumeFromSnapshot(sourcePEID astrolabe.Prote
 		}
 		download, err = pluginClient.DatamoverV1alpha1().Downloads(veleroNs).Get(context.TODO(), downloadRecordName, metav1.GetOptions{})
 		if err != nil {
-			this.Errorf("Retrieve download record %s failed with err %v", downloadRecordName, err)
-			return false, errors.Wrapf(err, "Failed to retrieve download record %s", downloadRecordName)
+			this.Errorf("Retrieve download record %s failed with err %v, retrying..", downloadRecordName, err)
+			return false, nil
 		}
 		if download.Status.Phase == v1api.DownloadPhaseCompleted {
 			this.Infof("Download record %s completed", downloadRecordName)
 			return true, nil
 		} else if download.Status.Phase == v1api.DownloadPhaseFailed {
-			return false, errors.Errorf("Create download cr failed.")
+			return false, errors.Errorf("Download Failed.")
 		} else {
 			if infoLog {
-				this.Infof("Retrieve phase %s for download record %s", download.Status.Phase, downloadRecordName)
+				this.Infof("Retrieved phase %s for download record %s, waiting..", download.Status.Phase, downloadRecordName)
 			}
 			return false, nil
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
If there is some network flakiness, it could be possible that there are errors retrieving the download CR.
In such a scenario, instead of erroring out entirely we will retry fetching the download CR.

Updated some error messages.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Testing Done**:
Made a local change to simulate a failed download CR retrieve:

```
time="2021-12-17T19:46:35Z" level=info msg="Creating Download CR: velero/download-83ca5125-aa86-4d5f-9d05-743e2170aeca-0577c901-1a44-4f35-b609-33817a447269" logSource="/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/snapshotmgr/snapshot_manager.go:657"
time="2021-12-17T19:46:35Z" level=info msg="Ready to create download CR. Will retry on network issue every 5 seconds for 5 retries at maximum" logSource="/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/snapshotmgr/snapshot_manager.go:669"


time="2021-12-17T19:46:35Z" level=error msg="Simulated: Retrieve download record download-83ca5125-aa86-4d5f-9d05-743e2170aeca-0577c901-1a44-4f35-b609-33817a447269 failed with err <nil>, retrying.." logSource="/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/snapshotmgr/snapshot_manager.go:700"


time="2021-12-17T19:47:18Z" level=info msg="Download record download-83ca5125-aa86-4d5f-9d05-743e2170aeca-0577c901-1a44-4f35-b609-33817a447269 completed" logSource="/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/snapshotmgr/snapshot_manager.go:704"
2021/12/17 19:47:18 pei = ivd:c6478297-931b-4ea3-b405-20023eef4958
time="2021-12-17T19:47:18Z" level=info msg="CreateFromMetadata: retrieved ProtectedEntity for ID pvc:demo-app/nginx-logs" logSource="/go/pkg/mod/github.com/vmware-tanzu/astrolabe@v0.4.1-0.20210813185044-12eb18c3f6d5/pkg/pvc/pvc_protected_entity_type_manager.go:238"
time="2021-12-17T19:47:18Z" level=info msg="CreateVolumeFromSnapshotWithMetadata: PE returned by CreateFromMetadata: pvc:demo-app/nginx-logs" logSource="/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/snapshotmgr/snapshot_manager.go:787"
time="2021-12-17T19:47:18Z" level=info msg="A new volume demo-app/nginx-logs with type being pvc was just created from the call of SnapshotManager CreateVolumeFromSnapshotWithMetadata" controller=BackupDriverController logSource="/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/backupdriver/backup_driver_controller.go:327"
```

verified that restore is successful:
```
dkinni@dkinni-a02 vanilla-testing % velero restore describe retry-12-17-1-20211217114619
Name:         retry-12-17-1-20211217114619
Namespace:    velero
Labels:       <none>
Annotations:  <none>

Phase:  Completed

Started:    2021-12-17 11:46:19 -0800 PST
Completed:  2021-12-17 11:47:19 -0800 PST

Backup:  retry-12-17-1

Namespaces:
  Included:  all namespaces found in the backup
  Excluded:  <none>

Resources:
  Included:        *
  Excluded:        nodes, events, events.events.k8s.io, backups.velero.io, restores.velero.io, resticrepositories.velero.io
  Cluster-scoped:  auto

Namespace mappings:  <none>

Label selector:  <none>

Restore PVs:  auto

Preserve Service NodePorts:  auto
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
Retry if there are errors retrieving download CR
```
Signed-off-by: Deepak Kinni <dkinni@vmware.com>