### PR TITLE
Update connnectEx to pick change in virtual-disk side

### DIFF
--- a/pkg/ivd/ivd_protected_entity.go
+++ b/pkg/ivd/ivd_protected_entity.go
@@ -171,7 +171,8 @@ func (this IVDProtectedEntity) getDiskConnectionParams(ctx context.Context, read
 		path,
 		flags,
 		readOnly,
-		transportMode)
+		transportMode,
+		"")
 
 	return params, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently in ConnectEx() we hardcoding snapshotRef as empty string, which is not resonable. This pr updates ConnectEx() and adds the snapshotRef parameter.

Pick up chnage in virtual-disk side.
**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
Add snapshotRef parameter in ConnectEx
```
