### PR TITLE
create snapshot CR for migrated csi volume

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -376,6 +376,7 @@ const VsphereVolumeSnapshotLocationProvider = "velero.io/vsphere"
 
 const (
 	VSphereCSIDriverName = "csi.vsphere.vmware.com"
+	VSphereCSIDriverMigrationAnnotation = "pv.kubernetes.io/migrated-to"
 )
 
 const (

--- a/pkg/plugin/util/util.go
+++ b/pkg/plugin/util/util.go
@@ -408,3 +408,9 @@ func SkipPVCCreation(ctx context.Context, config *rest.Config, pvc *corev1.Persi
 	// Create a new PVC
 	return false, nil
 }
+
+func IsMigratedCSIVolume(pv *corev1.PersistentVolume) bool {
+	isProvisionedByVCP := pv.Spec.VsphereVolume != nil
+	isAnnotatedByVsphereCSI := pv.Annotations[constants.VSphereCSIDriverMigrationAnnotation] == constants.VSphereCSIDriverName
+	return isProvisionedByVCP && isAnnotatedByVsphereCSI
+}


### PR DESCRIPTION
WHen detecting pv is provisioned is in-tree vcp and pv annotation shows it is migrated to csi, allow creating a velero snapshot CR for later backup

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
Support creating snapshot for migrated CSI volume
```
