### PR TITLE
When storageClass is empty string, treat it as no storageClass is given

### DIFF
--- a/pkg/backupdriver/backup_driver_controller.go
+++ b/pkg/backupdriver/backup_driver_controller.go
@@ -289,7 +289,7 @@ func (ctrl *backupDriverController) cloneFromSnapshot(cloneFromSnapshot *backupd
 		}
 		return err
 	}
-	if pvc.Spec.StorageClassName != nil {
+	if pvc.Spec.StorageClassName != nil && (*pvc.Spec.StorageClassName) != ""{
 		ctrl.logger.Infof("StorageClassName is %s for PVC %s/%s", *pvc.Spec.StorageClassName, pvc.Namespace, pvc.Name)
 	} else {
 		errMsg := fmt.Sprintf("cloneFromSnapshot PreCloneFromSnapshot: Failed for PVC %s/%s because StorageClassName is not set", pvc.Namespace, pvc.Name)


### PR DESCRIPTION
Signed-off-by: Yang Liu <liuy1@liuy1-a02.vmware.com>

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
When storageClass is empty string, treat it as no storageClass is given
```
