### PR TITLE
[cherry-pick]Failing the velero backup if pv is not supported

### DIFF
--- a/pkg/backupdriver/backup_driver_controller.go
+++ b/pkg/backupdriver/backup_driver_controller.go
@@ -289,7 +289,7 @@ func (ctrl *backupDriverController) cloneFromSnapshot(cloneFromSnapshot *backupd
 		}
 		return err
 	}
-	if pvc.Spec.StorageClassName != nil {
+	if pvc.Spec.StorageClassName != nil && (*pvc.Spec.StorageClassName) != ""{
 		ctrl.logger.Infof("StorageClassName is %s for PVC %s/%s", *pvc.Spec.StorageClassName, pvc.Namespace, pvc.Name)
 	} else {
 		errMsg := fmt.Sprintf("cloneFromSnapshot PreCloneFromSnapshot: Failed for PVC %s/%s because StorageClassName is not set", pvc.Namespace, pvc.Name)


### PR DESCRIPTION
Before this change, velero backup just skips the pv if the pv type is not supported
Afte this change, when the migration feature gate is enabled, an unsupported pv type fails the whole velero backup

Signed-off-by: Yang Liu <liuy1@liuy1-a02.vmware.com>

Co-authored-by: Yang Liu <liuy1@liuy1-a02.vmware.com>

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
This crossport includes following 2 changes
Cherry-pick #460: Return error to make velero backup partially failed, if the pv is not a supported volume type
Cherry-pick #461: When storageClass is empty string, treat it as no storageClass is given
```
