### PR TITLE
Remove NetworkAttachmentDefinition from skip list

### DIFF
--- a/docs/supervisor-notes.md
+++ b/docs/supervisor-notes.md
@@ -71,8 +71,6 @@ To avoid these errors, exclude the resources from your backups. The current list
  	members.registryagent.vmware.com
  	namespacenetworkinfos.nsx.vmware.com
  	ncpconfigs.nsx.vmware.com
- 	network-attachment-definitions.k8s.cni.cncf.io
- 	networkattachmentdefinitions.k8s.cni.cncf.io
  	networkinterfaces.netoperator.vmware.com
  	networks.netoperator.vmware.com
  	nsxerrors.nsx.vmware.com

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -247,8 +247,9 @@ var ResourcesToBlock = map[string]bool{
 	"members.registryagent.vmware.com":                   true,
 	"namespacenetworkinfos.nsx.vmware.com":               true,
 	"ncpconfigs.nsx.vmware.com":                          true,
-	"network-attachment-definitions.k8s.cni.cncf.io":     true, // real name of NetworkAttachmentDefinition
-	"networkattachmentdefinitions.k8s.cni.cncf.io":       true, // parsed name of NetworkAttachmentDefinition
+	// We comment the NetworkAttachmentDefinition resource out as it is not a vSphere specific resource
+	//"network-attachment-definitions.k8s.cni.cncf.io":     true, // real name of NetworkAttachmentDefinition
+	//"networkattachmentdefinitions.k8s.cni.cncf.io":       true, // parsed name of NetworkAttachmentDefinition
 	"networkinterfaces.netoperator.vmware.com":           true,
 	"networks.netoperator.vmware.com":                    true,
 	"nsxerrors.nsx.vmware.com":                           true,


### PR DESCRIPTION
Signed-off-by: xinyanw409 <wxinyan@vmware.com>

**What this PR does / why we need it**:
Velero backup failed for TKGm because the resource NetworkAttachmentDefinition is skipped during backup. Remove it from blocking list as it is not a vSphere specific resource.

**Test
Functional test:
In Supervisor cluster, backup a namespace with NetworkAttachmentDefinition resource,  without skipping NetworkAttachmentDefinition resource:
```
velero backup create test-ckjgaon-001 --include-namespaces test-ns-ckjgaon
```
The backup was completed successfully
```
velero backup get
NAME                  STATUS      ERRORS   WARNINGS   CREATED                         EXPIRES   STORAGE LOCATION   SELECTOR
test-ckjgaon-001      Completed   0        4          2022-05-06 17:05:28 +0000 UTC   29d       default            <none>
```
Precheck passed:
https://container-dp.svc.eng.vmware.com/job/Container_Precheck_Velero/1383/
https://container-dp.svc.eng.vmware.com/view/CNS-DP/job/Velero-Pipeline-WCP/850/

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
Remove NetworkAttachmentDefinition from skip list
```
