### PR TITLE
Updated docs to add a column for velero vsphere operator version in supervisor compatibility matrix.

### DIFF
--- a/docs/supervisor.md
+++ b/docs/supervisor.md
@@ -11,15 +11,15 @@
 
 ## Compatibility
 
-| Velero Plugin for vSphere Version | vSphere Version    | Kubernetes Version                                                | vSphere CSI Driver Version | Velero Version | Deprecated | EOL Date      |
-|-----------------------------------|--------------------|-------------------------------------------------------------------|----------------------------|----------------|------------|---------------|
-| 1.4.0                             | 7.0U1c/P02 - 7.0U3 | Bundled with vSphere (1.16-1.19, 1.18-1.20, 1.19-1.22)            | Bundled with vSphere       | 1.8.1          | No         | N/A
-| 1.3.1                             | 7.0U1c/P02 - 7.0U3 | Bundled with vSphere (1.16-1.19, 1.18-1.20, 1.19-1.21)            | Bundled with vSphere       | 1.5.1          | No         | N/A           |
-| 1.3.0                             | 7.0U1c/P02 - 7.0U3 | Bundled with vSphere (1.16-1.19, 1.18-1.20, 1.19-1.21)            | Bundled with vSphere       | 1.5.1          | Yes        | December 2022 |
-| 1.2.1                             | 7.0U1c/P02 - 7.0U2 | Bundled with vSphere (1.16-1.19, 1.18-1.20)                       | Bundled with vSphere       | 1.5.1          | Yes        | June 2023     |
-| 1.2.0                             | 7.0U1c/P02 - 7.0U2 | Bundled with vSphere (1.16-1.19, 1.18-1.20)                       | Bundled with vSphere       | 1.5.1          | Yes        | December 2022 |
-| 1.1.1                             | 7.0U1c/P02         | Bundled with vSphere (1.16-1.19)                                  | Bundled with vSphere       | 1.5.1          | No         | N/A           |
-| 1.1.0                             | 7.0U1c/P02         | Bundled with vSphere (1.16-1.19)                                  | Bundled with vSphere       | 1.5.1          | Yes        | December 2022 |
+| Velero Plugin for vSphere Version | vSphere Version     | Kubernetes Version                                                | vSphere CSI Driver Version | Velero Version | Velero vSphere Operator Version | Deprecated | EOL Date      |
+|-----------------------------------|---------------------|-------------------------------------------------------------------|----------------------------|----------------|---------------------------------|------------|---------------|
+| 1.4.0                             | 7.0U3e/f/h          | Bundled with vSphere (1.22)                                       | Bundled with vSphere       | 1.8.1          | 1.2.0                           | No         | N/A           |
+| 1.3.1                             | 7.0U1c/P02 - 7.0U3d | Bundled with vSphere (1.16-1.19, 1.18-1.20, 1.19-1.21)            | Bundled with vSphere       | 1.5.1          | 1.1.0                           | No         | N/A           |
+| 1.3.0                             | 7.0U1c/P02 - 7.0U3d | Bundled with vSphere (1.16-1.19, 1.18-1.20, 1.19-1.21)            | Bundled with vSphere       | 1.5.1          | 1.1.0                           | Yes        | December 2022 |
+| 1.2.1                             | 7.0U1c/P02 - 7.0U2  | Bundled with vSphere (1.16-1.19, 1.18-1.20)                       | Bundled with vSphere       | 1.5.1          | 1.1.0                           | Yes        | June 2023     |
+| 1.2.0                             | 7.0U1c/P02 - 7.0U2  | Bundled with vSphere (1.16-1.19, 1.18-1.20)                       | Bundled with vSphere       | 1.5.1          | 1.1.0                           | Yes        | December 2022 |
+| 1.1.1                             | 7.0U1c/P02          | Bundled with vSphere (1.16-1.19)                                  | Bundled with vSphere       | 1.5.1          | 1.1.0                           | No         | N/A           |
+| 1.1.0                             | 7.0U1c/P02          | Bundled with vSphere (1.16-1.19)                                  | Bundled with vSphere       | 1.5.1          | 1.1.0                           | Yes        | December 2022 |
 
 ## Prerequisites
 


### PR DESCRIPTION
**What this PR does / why we need it**:
In 1.4.0 we tested with vSphere 7.0U3. Remove the lowest version 7.0U1c/P02 to avoid confusion and add a column for velero vsphere operator version which is tested with velero plugin for vsphere.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
NONE
```
