### PR TITLE
Remove health annotation from PVC

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -414,3 +414,11 @@ const (
 	DefaultSecretName         = "velero-vsphere-config-secret"
 	DefaultSecretNamespace    = "velero"
 )
+
+const (
+	// AnnVolumeHealth is the key for HealthStatus annotation on volume claim
+	// for vSphere CSI Driver.
+	AnnVolumeHealth = "volumehealth.storage.kubernetes.io/health"
+        // key for expressing timestamp for volume health annotation
+        AnnVolumeHealthTS = "volumehealth.storage.kubernetes.io/health-timestamp"
+)

--- a/pkg/plugin/backup_pvc_action_plugin.go
+++ b/pkg/plugin/backup_pvc_action_plugin.go
@@ -191,6 +191,13 @@ func (p *NewPVCBackupItemAction) Execute(item runtime.Unstructured, backup *vele
 	}
 
 	p.Log.Infof("Persisting snapshot with snapshotID :%s under label: %s Snapshot: %v", updatedSnapshot.Status.SnapshotID, constants.ItemSnapshotLabel, updatedSnapshot)
+
+	// Remove the volume health annotations before the backup
+	// because vSphere CSI driver has a webhook that prevents this annotation
+	// from being created/updated by a non-CSI driver system service account
+	healthAnnotations := []string{constants.AnnVolumeHealth, constants.AnnVolumeHealthTS}
+	pluginUtil.RemoveAnnotations(&pvc.ObjectMeta, healthAnnotations)
+
 	// Persist the snapshot blob as an annotation of PVC
 	snapshotAnnotation, err := pluginUtil.GetAnnotationFromSnapshot(updatedSnapshot)
 	if err != nil {

--- a/pkg/plugin/util/util.go
+++ b/pkg/plugin/util/util.go
@@ -44,6 +44,15 @@ func GetAnnotationFromSnapshot(itemSnapshot interface{}) (string, error) {
 	return base64.StdEncoding.EncodeToString(itemSnapshotByteArray), nil
 }
 
+// RemoveAnnotations removes the supplied keys from the annotations on the object
+func RemoveAnnotations(o *metav1.ObjectMeta, keys []string) {
+	if o.Annotations != nil {
+		for _, k := range keys {
+			delete(o.Annotations, k)
+		}
+	}
+}
+
 // AddAnnotations adds the supplied key-values to the annotations on the object
 func AddAnnotations(o *metav1.ObjectMeta, vals map[string]string) {
 	if o.Annotations == nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
The problem:
- The restore operation on WCP 8.0 setup failed with an error restoring persistentvolumeclaims/test-cns-dp-wcp-ns-jlcownk/etcd0-pv-claim: admission webhook "validation.csi.vsphere.vmware.com" denied the request: PVC Annotation volumehealth.storage.kubernetes.io/health cannot be created by user system:serviceaccount:velero:velero

This is due to a change in vSphere CSI Driver:
- In vSphere CSI Driver, there is a new webhook logic that prevents any non system csi service account from creating/updating the volume health annotation: https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/1683

The fix:
- In the PR, this volume health annotation was removed before the backup. It does not make sense to restore this annotation as it is stale info.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
Remove volume health annotation from PVC before the backup.
```
