### PR TITLE
1.24 support for backup-driver Deployment

### DIFF
--- a/pkg/install/deployment.go
+++ b/pkg/install/deployment.go
@@ -154,6 +154,11 @@ func Deployment(namespace string, opts ...podTemplateOption) *appsv1.Deployment 
 			},
 			corev1.Toleration{
 				Effect:   "NoSchedule",
+				Key:      "node-role.kubernetes.io/control-plane",
+				Operator: "Exists",
+			},
+			corev1.Toleration{
+				Effect:   "NoSchedule",
 				Key:      "kubeadmNode",
 				Operator: "Equal",
 				Value:    "master",
@@ -161,7 +166,7 @@ func Deployment(namespace string, opts ...podTemplateOption) *appsv1.Deployment 
 		)
 
 		deployment.Spec.Template.Spec.NodeSelector = make(map[string]string)
-		deployment.Spec.Template.Spec.NodeSelector["node-role.kubernetes.io/master"] = ""
+		deployment.Spec.Template.Spec.NodeSelector["node-role.kubernetes.io/control-plane"] = ""
 	}
 
 	if c.hostNetwork {


### PR DESCRIPTION
**What this PR does / why we need it**:
1.24 k8s support for backup-driver Deployment

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Testing**

1.22
```
dkinni@dkinniCMD6R ~ % kubectl get nodes
NAME                         STATUS   ROLES                  AGE     VERSION
k8s-control-109-1674070860   Ready    control-plane,master   6h9m    v1.22.13
k8s-control-15-1674070849    Ready    control-plane,master   6h10m   v1.22.13
k8s-control-456-1674070871   Ready    control-plane,master   6h8m    v1.22.13
k8s-node-249-1674070893      Ready    <none>                 6h7m    v1.22.13
k8s-node-597-1674070882      Ready    <none>                 6h7m    v1.22.13
k8s-node-664-1674070905      Ready    <none>                 6h6m    v1.22.13

dkinni@dkinniCMD6R ~ % kubectl -n velero get pods
NAME                               READY   STATUS    RESTARTS   AGE
backup-driver-54bf57dd45-6gszx     1/1     Running   0          4m1s
datamgr-for-vsphere-plugin-4kmfd   1/1     Running   0          2m36s
datamgr-for-vsphere-plugin-cx8js   1/1     Running   0          2m36s
datamgr-for-vsphere-plugin-j8htw   1/1     Running   0          2m36s
node-agent-4bjgr                   1/1     Running   0          7m21s
node-agent-8b8g5                   1/1     Running   0          7m21s
node-agent-b7hmv                   1/1     Running   0          7m22s
velero-76cd5695cf-8tsfb            1/1     Running   0          5m19s
```

1.23
```
dkinni@dkinniCMD6R ~ % kubectl get nodes
NAME                         STATUS   ROLES                  AGE    VERSION
k8s-control-228-1674071943   Ready    control-plane,master   6h6m   v1.23.10
k8s-control-396-1674071928   Ready    control-plane,master   6h7m   v1.23.10
k8s-control-614-1674071957   Ready    control-plane,master   6h4m   v1.23.10
k8s-node-183-1674072000      Ready    <none>                 6h3m   v1.23.10
k8s-node-353-1674071971      Ready    <none>                 6h4m   v1.23.10
k8s-node-509-1674071986      Ready    <none>                 6h3m   v1.23.10

dkinni@dkinniCMD6R ~ % kubectl get pods -n velero
NAME                               READY   STATUS    RESTARTS       AGE
backup-driver-5dd879bfff-pm9q6     1/1     Running   5 (116s ago)   3m34s
datamgr-for-vsphere-plugin-bssxh   1/1     Running   2 (82s ago)    94s
datamgr-for-vsphere-plugin-l6qqd   1/1     Running   2 (82s ago)    94s
datamgr-for-vsphere-plugin-p9q8v   1/1     Running   2 (82s ago)    94s
node-agent-n4p6r                   1/1     Running   0              5m44s
node-agent-rzrzl                   1/1     Running   0              5m44s
node-agent-t2lcd                   1/1     Running   0              5m44s
velero-68ff5578b5-lpbfb            1/1     Running   0              4m57s
```

1.24
```
dkinni@dkinniCMD6R ~ % kubectl get nodes
NAME                         STATUS   ROLES           AGE     VERSION
k8s-control-441-1674074115   Ready    control-plane   5h43m   v1.24.4
k8s-control-45-1674074100    Ready    control-plane   5h45m   v1.24.4
k8s-control-575-1674074129   Ready    control-plane   5h42m   v1.24.4
k8s-node-292-1674074163      Ready    <none>          5h40m   v1.24.4
k8s-node-417-1674074145      Ready    <none>          5h41m   v1.24.4
k8s-node-826-1674074178      Ready    <none>          5h39m   v1.24.4

dkinni@dkinniCMD6R ~ % kubectl get pods -n velero
NAME                               READY   STATUS    RESTARTS   AGE
backup-driver-545c55f9c7-jcntf     1/1     Running   0          4m32s
datamgr-for-vsphere-plugin-2zvkt   1/1     Running   0          2m56s
datamgr-for-vsphere-plugin-k5k82   1/1     Running   0          2m56s
datamgr-for-vsphere-plugin-m58cg   1/1     Running   0          2m56s
node-agent-2q8tl                   1/1     Running   0          6m36s
node-agent-5z887                   1/1     Running   0          6m36s
node-agent-j48zm                   1/1     Running   0          6m36s
velero-968b87599-khl4m             1/1     Running   0          5m59s
```

**Does this PR introduce a user-facing change?**:
```release-note
1.24 support for backup-driver Deployment
```
Signed-off-by: Deepak Kinni <dkinni@vmware.com>