### PR TITLE
Make resources to block list configurable

### DIFF
--- a/Dockerfile-datamgr
+++ b/Dockerfile-datamgr
@@ -15,7 +15,7 @@
 FROM busybox:1.33.1 AS busybox
 
 FROM photon:4.0
-ADD /bin/linux/amd64/data-* /datamgr
+ADD /bin/linux/amd64/data-* /datamgr/
 COPY /bin/linux/amd64/lib/vmware-vix-disklib/lib64/* /vddkLibs/
 COPY --from=busybox /bin/sh /bin/sh
 COPY --from=busybox /bin/cp /bin/cp

--- a/pkg/cmd/backupdriver/cli/install/install.go
+++ b/pkg/cmd/backupdriver/cli/install/install.go
@@ -140,6 +140,11 @@ func (o *InstallOptions) Run(c *cobra.Command, f client.Factory) error {
 
 	fmt.Println("The prerequisite checks for backup-driver completed")
 
+	// Create configmap for skip resources list
+	if err := cmd.CreateBlockListConfigMap(kubeClient, o.Namespace, constants.ResourcesToBlock); err != nil {
+		return err
+	}
+
 	vo, err := o.AsBackupDriverOptions()
 	if err != nil {
 		return err
@@ -254,3 +259,4 @@ func (o *InstallOptions) CheckFeatureFlagsForBackupDriver(kubeClient kubernetes.
 
 	return nil
 }
+

--- a/pkg/cmd/utils_e2e_test.go
+++ b/pkg/cmd/utils_e2e_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2023 the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"k8s.io/client-go/kubernetes"
+	"os"
+	"reflect"
+	"strconv"
+	"testing"
+	"time"
+	"k8s.io/client-go/tools/clientcmd"
+	"github.com/sirupsen/logrus"
+)
+
+func TestCreateBlockListConfigMap(t *testing.T) {
+	path := os.Getenv("KUBECONFIG")
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		t.Skipf("The KubeConfig file, %v, is not exist", path)
+	}
+
+	config, err := clientcmd.BuildConfigFromFlags("", path)
+	if err != nil {
+		t.Fatalf("Failed to build k8s config from kubeconfig file: %+v ", err)
+	}
+	kubeClient, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		t.Fatalf("Failed to retrieve kubeclient from config: %+v ", err)
+	}
+
+	// Setup Logger
+	logger := logrus.New()
+	formatter := new(logrus.TextFormatter)
+	formatter.TimestampFormat = time.RFC3339Nano
+	formatter.FullTimestamp = true
+	logger.SetFormatter(formatter)
+	logger.SetLevel(logrus.DebugLevel)
+
+	// using velero ns for testing.
+	veleroNs := "velero"
+
+	resourcesToBlockForTest := map[string]bool{
+		"agentinstalls.installers.tmc.cloud.vmware.com": true,
+		"availabilityzones.topology.tanzu.vmware.com":   true,
+		"aviloadbalancerconfigs.netoperator.vmware.com": true,
+		"blockaffinities.crd.projectcalico.org":         true,
+	}
+
+	// Case 1: if there is not blocklist configmap created before
+
+    err = CreateBlockListConfigMap(kubeClient, veleroNs, resourcesToBlockForTest)
+    if err != nil {
+		t.Fatalf("Failed to create blocklist configmap: %+v ", err)
+	}
+
+    blockListMap, err := RetrieveBlockListConfigMap()
+    if err != nil {
+    	t.Fatal("Failed to retrieve blocklist configmap.")
+	}
+    if len(blockListMap) != len(resourcesToBlockForTest) {
+    	t.Fatal("The length of blocklist configmap created does not equal to resourcesToBlockForTest input length.")
+	}
+
+    for crdName, isBlocked := range resourcesToBlockForTest{
+    	val, ok := blockListMap[crdName]
+    	if !ok {
+			t.Fatal("Failed to create blocklist configmap from given resourcesToBlockForTest input.")
+		}
+    	isBlockedConfigMap, err := strconv.ParseBool(val)
+    	if err != nil {
+    		t.Fatal("Failed to create blocklist configmap from given resourcesToBlockForTest input.")
+		}
+    	if isBlocked != isBlockedConfigMap {
+			t.Fatal("Failed to create blocklist configmap from given resourcesToBlockForTest input.")
+		}
+	}
+
+    t.Log("Blocklist configmap created successfully.")
+
+	// Case 2: if there is already blocklist configmap created before, it should be unchanged.
+	resourcesToBlockForTest_2 := map[string]bool{
+		"agentinstalls.installers.tmc.cloud.vmware.com": true,
+		"availabilityzones.topology.tanzu.vmware.com":   true,
+		"aviloadbalancerconfigs.netoperator.vmware.com": true,
+		"blockaffinities.crd.projectcalico.org":         true,
+		"ccsplugins.appplatform.wcp.vmware.com":         true,
+	}
+
+	err = CreateBlockListConfigMap(kubeClient, veleroNs, resourcesToBlockForTest_2)
+	if err != nil {
+		t.Fatalf("Failed to create blocklist configmap: %+v ", err)
+	}
+	blockListMap_2, err := RetrieveBlockListConfigMap()
+	if err != nil {
+		t.Fatal("Failed to retrieve blocklist configmap.")
+	}
+	//blockListMap_2 should be equal to blockListMap
+	eq := reflect.DeepEqual(blockListMap_2, blockListMap)
+	if !eq {
+		t.Fatal("ConfigMap for blocking list should keeps unchanged.")
+	}
+
+	t.Log("Blocklist configmap updated successfully.")
+}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -187,6 +187,11 @@ const (
 	SupervisorResourcePoolKey = "SupervisorResourcePool"
 )
 
+// Name for skip resources list configmap
+const (
+	ResourcesToBlockListName = "velero-vsphere-plugin-blocked-resources-list"
+)
+
 // We are currently translating Group + Kind -> the names below.  This involves
 // a singular to plural conversion.  When adding new resources, ensure that they
 // work with the singular to plural rule of words ending in "y" the "y" becomes "ies" and other

--- a/pkg/plugin/util/util_unit_test.go
+++ b/pkg/plugin/util/util_unit_test.go
@@ -702,3 +702,55 @@ func TestIsMigratedCSIVolume(t *testing.T) {
 		})
 	}
 }
+
+func TestIsResourceBlocked(t *testing.T) {
+	var resourcesToBlockForTest = map[string]string{
+		"agentinstalls.installers.tmc.cloud.vmware.com": "true",
+		"availabilityzones.topology.tanzu.vmware.com":   "false",
+	}
+
+	testCases := []struct {
+		name               string
+		crdName            string
+		resourceToBlock    map[string]string
+		expectedResult     bool
+	}{
+		{
+			name:            "crd is blocked",
+			crdName:         "agentinstalls.installers.tmc.cloud.vmware.com",
+			resourceToBlock: resourcesToBlockForTest,
+			expectedResult:  true,
+		},
+		{
+			name:            "crd is not blocked",
+			crdName:         "availabilityzones.topology.tanzu.vmware.com",
+			resourceToBlock: resourcesToBlockForTest,
+			expectedResult:  false,
+		},
+		{
+			name:            "crd is not included in skip list",
+			crdName:         "donotexist",
+			resourceToBlock: resourcesToBlockForTest,
+			expectedResult:  false,
+		},
+		{
+			name:            "block list is nil",
+			crdName:         "agentinstalls.installers.tmc.cloud.vmware.com",
+			resourceToBlock: nil,
+			expectedResult:  false,
+		},
+		{
+			name:            "block list is empty",
+			crdName:         "availabilityzones.topology.tanzu.vmware.com",
+			resourceToBlock: make(map[string]string),
+			expectedResult:  false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			isBlocked := IsResourceBlocked(tc.crdName, tc.resourceToBlock)
+			assert.Equal(t, tc.expectedResult, isBlocked)
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently we hardcode the skip list as a map constant. If we want to edit skip crd resources list we need to build a new image every time. To make it more flexible, we're going to create a configmap for the skip list during backup-driver installation so we can add or delete skip list after plugin is deployed.
**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
Tests done:
| Test case      | Result |
| ----------- | ----------- |
| Install velero vsphere plugin | ConfigMap velero-vsphere-plugin-block-list is created. |
| Edit configmap, then reboot velero pod | No new configmap created, the previous one keeps unchanged. |
| Delete configmap, then reboot velero pod | New configmap will be created from the default blocking list. |
| Delete configmap, then only reboot backup-driver pod | No new configmap created. |
| Backup without configmap | Succeed. |
| Restore using backup which created without configmap | Completed, but with 10 Warnings.|
| Backup with configmap, excluded resource `velero backup create test-0208-03 --include-namespaces=test-namespace-mapping-1 --exclude-resources=namespacenetworkinfos.nsx.vmware.com,contentsourcebindings.vmoperator.vmware.com,kubeadmconfigtemplates.bootstrap.cluster.x-k8s.io,clusterclasses.cluster.x-k8s.io,cnscsisvfeaturestates.cns.vmware.com --snapshot-volumes`| Succeed. |
| Restore using backup which created with configmap | Complete with 4 warnings. |
| Backup with configmap, not exclude resource `velero backup create test-0208-02 --include-namespaces=test-skip-list` | PartiallyFailed. 5 Errors. |

```
# kubectl get configmap velero-vsphere-plugin-block-list -n velero -o yaml
apiVersion: v1
data:
  agentinstalls.installers.tmc.cloud.vmware.com: "true"
  availabilityzones.topology.tanzu.vmware.com: "true"
  aviloadbalancerconfigs.netoperator.vmware.com: "true"
  backuprepositories.backupdriver.cnsdp.vmware.com: "true"
  backuprepositoryclaims.backupdriver.cnsdp.vmware.com: "true"
  blockaffinities.crd.projectcalico.org: "true"
  ccsplugins.appplatform.wcp.vmware.com: "true"
  certificaterequests.cert-manager.io: "true"
  certificates.cert-manager.io: "true"
  challenges.acme.cert-manager.io: "true"
  clonefromsnapshots.backupdriver.cnsdp.vmware.com: "true"
  clusterclasses.cluster.x-k8s.io: "true"
  clusterissuers.cert-manager.io: "true"
  clusternetworkinfos.nsx.vmware.com: "true"
  clusterresourcesetbindings.addons.cluster.x-k8s.io: "true"
  clusterresourcesets.addons.cluster.x-k8s.io: "true"
  clusters.cluster.x-k8s.io: "true"
  cnscsisvfeaturestates.cns.vmware.com: "true"
  cnsfileaccessconfigs.cns.vmware.com: "true"
  cnsfilevolumeclients.cns.vmware.com: "true"
  cnsnodevmattachments.cns.vmware.com: "true"
  cnsregistervolumes.cns.vmware.com: "true"
  cnsvolumemetadatas.cns.vmware.com: "true"
  compatibilities.run.tanzu.vmware.com: "true"
  contentlibraryproviders.vmoperator.vmware.com: "true"
  contentsourcebindings.vmoperator.vmware.com: "true"
  contentsources.vmoperator.vmware.com: "true"
  deletesnapshots.backupdriver.cnsdp.vmware.com: "true"
  downloads.datamover.cnsdp.vmware.com: "true"
  drainrequests.psp.wcp.vmware.com: "true"
  gatewayclasses.networking.x-k8s.io: "true"
  gateways.networking.x-k8s.io: "true"
  haproxyloadbalancerconfigs.netoperator.vmware.com: "true"
  httproutes.networking.x-k8s.io: "true"
  imagedisks.imagecontroller.vmware.com: "true"
  installoptions.appplatform.wcp.vmware.com: "true"
  installrequirements.appplatform.wcp.vmware.com: "true"
  ipamblocks.crd.projectcalico.org: "true"
  ipamconfigs.crd.projectcalico.org: "true"
  ipamhandles.crd.projectcalico.org: "true"
  ippools.crd.projectcalico.org: "true"
  ippools.netoperator.vmware.com: "true"
  ippools.nsx.vmware.com: "true"
  issuers.cert-manager.io: "true"
  kubeadmconfigs.bootstrap.cluster.x-k8s.io: "true"
  kubeadmconfigtemplates.bootstrap.cluster.x-k8s.io: "true"
  kubeadmcontrolplanes.controlplane.cluster.x-k8s.io: "true"
  kuberneteslicenses.licenseoperator.vmware.com: "true"
  loadbalancerconfigs.netoperator.vmware.com: "true"
  loadbalancers.vmware.com: "true"
  machinedeployments.cluster.x-k8s.io: "true"
  machinehealthchecks.cluster.x-k8s.io: "true"
  machinepools.exp.cluster.x-k8s.io: "true"
  machines.cluster.x-k8s.io: "true"
  machinesets.cluster.x-k8s.io: "true"
  members.registryagent.vmware.com: "true"
  namespacenetworkinfos.nsx.vmware.com: "true"
  ncpconfigs.nsx.vmware.com: "true"
  networkinterfaces.netoperator.vmware.com: "true"
  networks.netoperator.vmware.com: "true"
  nsxerrors.nsx.vmware.com: "true"
  nsxlocks.nsx.vmware.com: "true"
  nsxnetworkconfigurations.nsx.vmware.com: "true"
  nsxnetworkinterfaces.nsx.vmware.com: "true"
  orders.acme.cert-manager.io: "true"
  persistenceinstanceinfoes.psp.wcp.vmware.com: "true"
  persistenceserviceconfigurations.psp.wcp.vmware.com: "true"
  projects.registryagent.vmware.com: "true"
  providerserviceaccounts.run.tanzu.vmware.com: "true"
  psprecencyrequests.psp.wcp.vmware.com: "true"
  pvcdisruptionbudgets.psp.wcp.vmware.com: "true"
  registries.registryagent.vmware.com: "true"
  resourcecheckreports.psp.wcp.vmware.com: "true"
  resourcechecks.psp.wcp.vmware.com: "true"
  routesets.nsx.vmware.com: "true"
  snapshots.backupdriver.cnsdp.vmware.com: "true"
  statefuldrainnodes.psp.wcp.vmware.com: "true"
  statefulreadynodes.psp.wcp.vmware.com: "true"
  storagepolicies.appplatform.wcp.vmware.com: "true"
  storagepolicies.psp.wcp.vmware.com: "true"
  storagepools.cns.vmware.com: "true"
  supervisorservices.appplatform.wcp.vmware.com: "true"
  tanzukubernetesaddons.run.tanzu.vmware.com: "true"
  tanzukubernetesclusters.run.tanzu.vmware.com: "true"
  tanzukubernetesreleases.run.tanzu.vmware.com: "true"
  tcproutes.networking.x-k8s.io: "true"
  tkgserviceconfigurations.run.tanzu.vmware.com: "true"
  uploads.datamover.cnsdp.vmware.com: "true"
  vcuiplugins.appplatform.wcp.vmware.com: "true"
  veleroservices.veleroappoperator.vmware.com: "true"
  virtualmachineclassbindings.vmoperator.vmware.com: "true"
  virtualmachineclasses.vmoperator.vmware.com: "true"
  virtualmachineimages.vmoperator.vmware.com: "true"
  virtualmachines.vmoperator.vmware.com: "true"
  virtualmachineservices.vmoperator.vmware.com: "true"
  virtualmachinesetresourcepolicies.vmoperator.vmware.com: "true"
  virtualnetworkinterfaces.vmware.com: "true"
  virtualnetworks.vmware.com: "true"
  vmxnet3networkinterfaces.netoperator.vmware.com: "true"
  vspheredistributednetworks.netoperator.vmware.com: "true"
  wcpclusters.infrastructure.cluster.vmware.com: "true"
  wcpmachines.infrastructure.cluster.vmware.com: "true"
  wcpmachinetemplates.infrastructure.cluster.vmware.com: "true"
  wcpnamespaces.appplatform.wcp.vmware.com: "true"
  webconsolerequests.vmoperator.vmware.com: "true"
kind: ConfigMap
metadata:
  creationTimestamp: "2023-01-26T02:59:41Z"
  name: velero-vsphere-plugin-block-list
  namespace: velero
  resourceVersion: "4828873"
  uid: 3f0d70e3-787a-46f7-b552-428da16729c0
```
2. Unit test
```
go test ./pkg/... -timeout=300s
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/apis/backupdriver/v1alpha1	[no test files]
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/apis/datamover/v1alpha1	[no test files]
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/backupdriver	[no test files]
ok  	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/backuprepository	0.217s
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/builder	[no test files]
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/buildinfo	[no test files]
ok  	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/cmd	0.224s
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/cmd/backupdriver	[no test files]
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/cmd/backupdriver/cli/install	[no test files]
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/cmd/backupdriver/cli/server	[no test files]
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/cmd/datamgr	[no test files]
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/cmd/datamgr/cli/install	[no test files]
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/cmd/datamgr/cli/server	[no test files]
ok  	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/common/vsphere	0.115s
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/constants	[no test files]
ok  	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/controller	0.231s
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/dataMover	[no test files]
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned	[no test files]
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/fake	[no test files]
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/scheme	[no test files]
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/typed/backupdriver/v1alpha1	[no test files]
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/typed/backupdriver/v1alpha1/fake	[no test files]
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/typed/datamover/v1alpha1	[no test files]
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/typed/datamover/v1alpha1/fake	[no test files]
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/crds	[no test files]
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/informers/externalversions	[no test files]
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/informers/externalversions/backupdriver	[no test files]
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/informers/externalversions/backupdriver/v1alpha1	[no test files]
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/informers/externalversions/datamover	[no test files]
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/informers/externalversions/datamover/v1alpha1	[no test files]
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/informers/externalversions/internalinterfaces	[no test files]
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/listers/backupdriver/v1alpha1	[no test files]
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/listers/datamover/v1alpha1	[no test files]
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/install	[no test files]
ok  	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/ivd	0.086s
ok  	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/paravirt	0.130s
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/plugin	[no test files]
ok  	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/plugin/util	0.117s
ok  	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/snapshotUtils	0.139s
ok  	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/snapshotmgr	0.069s
?   	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/test	[no test files]
ok  	github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/utils	0.062s
Success!
```
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
Make resources to block list configurable.
```
