### PR TITLE
Fix datamgr Dockerfile

### DIFF
--- a/Dockerfile-datamgr
+++ b/Dockerfile-datamgr
@@ -15,7 +15,7 @@
 FROM busybox:1.33.1 AS busybox
 
 FROM photon:5.0
-ADD /bin/linux/amd64/data-* /datamgr/
+ADD /bin/linux/amd64/data-* /datamgr
 COPY /bin/linux/amd64/lib/vmware-vix-disklib/lib64/* /vddkLibs/
 COPY --from=busybox /bin/sh /bin/sh
 COPY --from=busybox /bin/cp /bin/cp


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix data manager Dockerfile

**Which issue(s) this PR fixes**:
data manager pod startup
Fixes #

```
root@k8s-control-500-1677685163:~# kubectl -n velero get pods
NAME                               READY   STATUS    RESTARTS   AGE
backup-driver-568cf7dc9-mmfsr      1/1     Running   0          6m23s
datamgr-for-vsphere-plugin-gq7lh   1/1     Running   0          4m55s
datamgr-for-vsphere-plugin-jgsss   1/1     Running   0          4m55s
datamgr-for-vsphere-plugin-ksnd7   1/1     Running   0          4m55s
velero-85cbf58cd-hkgfz             1/1     Running   0          7m46s
```

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Fix data manager Dockerfile
```
