### PR TITLE
Remove busybox from Dockerfile

### DIFF
--- a/Dockerfile-backup-driver
+++ b/Dockerfile-backup-driver
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM photon:4.0
+FROM photon:5.0
 COPY /bin/linux/amd64/lib/vmware-vix-disklib/lib64/* /vddkLibs/
 ADD /bin/linux/amd64/backup-driver* /backup-driver
 ENTRYPOINT ["/backup-driver"]

--- a/Dockerfile-datamgr
+++ b/Dockerfile-datamgr
@@ -12,13 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM busybox:1.33.1 AS busybox
-
-FROM photon:4.0
+FROM photon:5.0
 ADD /bin/linux/amd64/data-* /datamgr
 COPY /bin/linux/amd64/lib/vmware-vix-disklib/lib64/* /vddkLibs/
-COPY --from=busybox /bin/sh /bin/sh
-COPY --from=busybox /bin/cp /bin/cp
-COPY --from=busybox /bin/tar /bin/tar
-COPY --from=busybox /bin/ls /bin/ls
 ENTRYPOINT ["/datamgr"]

--- a/Dockerfile-plugin
+++ b/Dockerfile-plugin
@@ -12,17 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM busybox:1.33.1 AS busybox
 
-FROM photon:4.0
+FROM photon:5.0
 ADD /bin/linux/amd64/velero-* /plugins/
 ADD /bin/linux/amd64/data-* /
 ADD /bin/linux/amd64/backup-driver* /
 COPY /bin/linux/amd64/install.sh /scripts/
 COPY /bin/linux/amd64/lib/vmware-vix-disklib/lib64/* /plugins/
 ENV LD_LIBRARY_PATH=/plugins
-COPY --from=busybox /bin/sh /bin/sh
-COPY --from=busybox /bin/chmod /bin/chmod
-COPY --from=busybox /bin/cp /bin/cp
 RUN ["chmod", "+x", "/scripts/install.sh"]
 ENTRYPOINT ["/bin/sh","/scripts/install.sh"]


### PR DESCRIPTION
**What this PR does / why we need it**:
- Remove busybox. Photon already contains the necessary binaries.
- Update to Photon 5.0

**Which issue(s) this PR fixes**:
Fixes #

**Testing**
Images:
```
harbor-repo.vmware.com/velero/backup-driver:rem_busybox_v1-d330fef-13.Apr.2023.17.14.41
harbor-repo.vmware.com/velero/velero-plugin-for-vsphere:rem_busybox_v1-d330fef-13.Apr.2023.17.14.41
harbor-repo.vmware.com/velero/data-manager-for-plugin:rem_busybox_v1-d330fef-13.Apr.2023.17.14.41
```

Deployed it on a cluster:
```
dkinni@dkinniCMD6R ~ % kubectl -n velero get pods
NAME                               READY   STATUS    RESTARTS   AGE
backup-driver-6499d799cd-4xs6m     1/1     Running   0          4m30s
datamgr-for-vsphere-plugin-h7krb   1/1     Running   0          3m2s
datamgr-for-vsphere-plugin-pwh2h   1/1     Running   0          3m2s
datamgr-for-vsphere-plugin-t2gwx   1/1     Running   0          3m2s
node-agent-g6kjm                   1/1     Running   0          11m
node-agent-msq96                   1/1     Running   0          11m
node-agent-wrnnr                   1/1     Running   0          11m
velero-8ffd68b6b-bn9v2             1/1     Running   0          6m4s
```


Unit Tests:
```
Running tests: ./pkg/...
go test ./pkg/... -timeout=300s
go: downloading github.com/stretchr/testify v1.7.0
go: downloading github.com/agiledragon/gomonkey v2.0.1+incompatible
go: downloading github.com/pmezard/go-difflib v1.0.0
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/apis/backupdriver/v1alpha1        [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/apis/datamover/v1alpha1   [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/backupdriver      [no test files]
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/backuprepository  0.157s
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/builder   [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/buildinfo [no test files]
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/cmd       0.148s
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/cmd/backupdriver  [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/cmd/backupdriver/cli/install      [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/cmd/backupdriver/cli/server       [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/cmd/datamgr       [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/cmd/datamgr/cli/install   [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/cmd/datamgr/cli/server    [no test files]
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/common/vsphere    0.058s
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/constants [no test files]
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/controller        0.097s
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/dataMover [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned     [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/fake        [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/scheme      [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/typed/backupdriver/v1alpha1 [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/typed/backupdriver/v1alpha1/fake    [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/typed/datamover/v1alpha1    [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/typed/datamover/v1alpha1/fake       [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/crds    [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/informers/externalversions      [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/informers/externalversions/backupdriver [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/informers/externalversions/backupdriver/v1alpha1        [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/informers/externalversions/datamover    [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/informers/externalversions/datamover/v1alpha1   [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/informers/externalversions/internalinterfaces   [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/listers/backupdriver/v1alpha1   [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/listers/datamover/v1alpha1      [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/install   [no test files]
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/ivd       0.127s
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/paravirt  0.141s
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/plugin    [no test files]
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/plugin/util       0.060s
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/snapshotUtils     0.071s
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/snapshotmgr       0.064s
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/test      [no test files]
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/utils     0.055s
Success!

```


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Remove busybox references from Dockerfiles
```
