### PR TITLE
Remove busybox reference from Dockerfiles

### DIFF
--- a/Dockerfile-datamgr
+++ b/Dockerfile-datamgr
@@ -12,13 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM busybox:1.33.1 AS busybox
 
 FROM photon:5.0
 ADD /bin/linux/amd64/data-* /datamgr
 COPY /bin/linux/amd64/lib/vmware-vix-disklib/lib64/* /vddkLibs/
-COPY --from=busybox /bin/sh /bin/sh
-COPY --from=busybox /bin/cp /bin/cp
-COPY --from=busybox /bin/tar /bin/tar
-COPY --from=busybox /bin/ls /bin/ls
 ENTRYPOINT ["/datamgr"]

--- a/Dockerfile-plugin
+++ b/Dockerfile-plugin
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM busybox:1.33.1 AS busybox
 
 FROM photon:5.0
 ADD /bin/linux/amd64/velero-* /plugins/
@@ -21,8 +20,5 @@ ADD /bin/linux/amd64/backup-driver* /
 COPY /bin/linux/amd64/install.sh /scripts/
 COPY /bin/linux/amd64/lib/vmware-vix-disklib/lib64/* /plugins/
 ENV LD_LIBRARY_PATH=/plugins
-COPY --from=busybox /bin/sh /bin/sh
-COPY --from=busybox /bin/chmod /bin/chmod
-COPY --from=busybox /bin/cp /bin/cp
 RUN ["chmod", "+x", "/scripts/install.sh"]
 ENTRYPOINT ["/bin/sh","/scripts/install.sh"]

--- a/changelogs/CHANGELOG-1.4.md
+++ b/changelogs/CHANGELOG-1.4.md
@@ -360,6 +360,7 @@ Date: 2022-03-16
 - Process DeleteSnapshot CRs without explicit Phase set ([#441](https://github.com/vmware-tanzu/velero-plugin-for-vsphere/pull/441), [@deepakkinni](https://github.com/deepakkinni))
 - Support creating snapshot for migrated CSI volume ([#443](https://github.com/vmware-tanzu/velero-plugin-for-vsphere/pull/443), [@liuy1vmware](https://github.com/liuy1vmware))
 - Upgrade golang version to 1.17 ([#448](https://github.com/vmware-tanzu/velero-plugin-for-vsphere/pull/448), [@xinyanw409](https://github.com/xinyanw409))
+- Remove busybox from Dockerfile ([#523](https://github.com/vmware-tanzu/velero-plugin-for-vsphere/pull/523), [@deepakkinni](https://github.com/deepakkinni))
 
 ## Dependencies
 

--- a/changelogs/CHANGELOG-1.5.md
+++ b/changelogs/CHANGELOG-1.5.md
@@ -17,6 +17,7 @@ Date: 2022-2-22
   CVE-2022-46908 ([#514](https://github.com/vmware-tanzu/velero-plugin-for-vsphere/pull/514), [@deepakkinni](https://github.com/deepakkinni))
 - Update supervisor deployment doc to indicate that velero-vsphere-plugin-config needs to be created. ([#509](https://github.com/vmware-tanzu/velero-plugin-for-vsphere/pull/509), [@deepakkinni](https://github.com/deepakkinni))
 - Fix datamgr Dockerfile ([#518](https://github.com/vmware-tanzu/velero-plugin-for-vsphere/pull/518), [@deepakkinni](https://github.com/deepakkinni))
+- Remove busybox reference from Dockerfiles ([#524](https://github.com/vmware-tanzu/velero-plugin-for-vsphere/pull/524), [@deepakkinni](https://github.com/deepakkinni))
 
 ## Dependencies
 


### PR DESCRIPTION
**What this PR does / why we need it**:
- Removes busybox references from Dockerfiles
- Updates changelog

**Which issue(s) this PR fixes**:
Fixes #

**Testing**
images:
```
harbor-repo.vmware.com/velero/velero-plugin-for-vsphere:main_rem_bb_v1-ea5170c-13.Apr.2023.18.01.00
harbor-repo.vmware.com/velero/data-manager-for-plugin:main_rem_bb_v1-ea5170c-13.Apr.2023.18.01.00
harbor-repo.vmware.com/velero/backup-driver:main_rem_bb_v1-ea5170c-13.Apr.2023.18.01.00
```

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
Removes busybox reference from Dockerfile
```
