### PR TITLE
Cherry-pick #520, #524, #525 and #526

### DIFF
--- a/Dockerfile-datamgr
+++ b/Dockerfile-datamgr
@@ -12,13 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM busybox:1.33.1 AS busybox
 
 FROM photon:5.0
 ADD /bin/linux/amd64/data-* /datamgr
 COPY /bin/linux/amd64/lib/vmware-vix-disklib/lib64/* /vddkLibs/
-COPY --from=busybox /bin/sh /bin/sh
-COPY --from=busybox /bin/cp /bin/cp
-COPY --from=busybox /bin/tar /bin/tar
-COPY --from=busybox /bin/ls /bin/ls
 ENTRYPOINT ["/datamgr"]

--- a/Dockerfile-plugin
+++ b/Dockerfile-plugin
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM busybox:1.33.1 AS busybox
 
 FROM photon:5.0
 ADD /bin/linux/amd64/velero-* /plugins/
@@ -21,8 +20,5 @@ ADD /bin/linux/amd64/backup-driver* /
 COPY /bin/linux/amd64/install.sh /scripts/
 COPY /bin/linux/amd64/lib/vmware-vix-disklib/lib64/* /plugins/
 ENV LD_LIBRARY_PATH=/plugins
-COPY --from=busybox /bin/sh /bin/sh
-COPY --from=busybox /bin/chmod /bin/chmod
-COPY --from=busybox /bin/cp /bin/cp
 RUN ["chmod", "+x", "/scripts/install.sh"]
 ENTRYPOINT ["/bin/sh","/scripts/install.sh"]

--- a/changelogs/CHANGELOG-1.4.md
+++ b/changelogs/CHANGELOG-1.4.md
@@ -1,5 +1,13 @@
 # Changelog since v1.3.0
 
+## v1.4.3
+
+Date: 2023-17-4
+
+### Changes
+
+- Remove busybox from Dockerfile ([#523](https://github.com/vmware-tanzu/velero-plugin-for-vsphere/pull/523), [@deepakkinni](https://github.com/deepakkinni))
+
 ## v1.4.2
 
 Date: 2022-12-5
@@ -360,7 +368,6 @@ Date: 2022-03-16
 - Process DeleteSnapshot CRs without explicit Phase set ([#441](https://github.com/vmware-tanzu/velero-plugin-for-vsphere/pull/441), [@deepakkinni](https://github.com/deepakkinni))
 - Support creating snapshot for migrated CSI volume ([#443](https://github.com/vmware-tanzu/velero-plugin-for-vsphere/pull/443), [@liuy1vmware](https://github.com/liuy1vmware))
 - Upgrade golang version to 1.17 ([#448](https://github.com/vmware-tanzu/velero-plugin-for-vsphere/pull/448), [@xinyanw409](https://github.com/xinyanw409))
-- Remove busybox from Dockerfile ([#523](https://github.com/vmware-tanzu/velero-plugin-for-vsphere/pull/523), [@deepakkinni](https://github.com/deepakkinni))
 
 ## Dependencies
 

--- a/changelogs/CHANGELOG-1.4.md
+++ b/changelogs/CHANGELOG-1.4.md
@@ -360,6 +360,7 @@ Date: 2022-03-16
 - Process DeleteSnapshot CRs without explicit Phase set ([#441](https://github.com/vmware-tanzu/velero-plugin-for-vsphere/pull/441), [@deepakkinni](https://github.com/deepakkinni))
 - Support creating snapshot for migrated CSI volume ([#443](https://github.com/vmware-tanzu/velero-plugin-for-vsphere/pull/443), [@liuy1vmware](https://github.com/liuy1vmware))
 - Upgrade golang version to 1.17 ([#448](https://github.com/vmware-tanzu/velero-plugin-for-vsphere/pull/448), [@xinyanw409](https://github.com/xinyanw409))
+- Remove busybox from Dockerfile ([#523](https://github.com/vmware-tanzu/velero-plugin-for-vsphere/pull/523), [@deepakkinni](https://github.com/deepakkinni))
 
 ## Dependencies
 

--- a/changelogs/CHANGELOG-1.5.md
+++ b/changelogs/CHANGELOG-1.5.md
@@ -17,6 +17,7 @@ Date: 2022-2-22
   CVE-2022-46908 ([#514](https://github.com/vmware-tanzu/velero-plugin-for-vsphere/pull/514), [@deepakkinni](https://github.com/deepakkinni))
 - Update supervisor deployment doc to indicate that velero-vsphere-plugin-config needs to be created. ([#509](https://github.com/vmware-tanzu/velero-plugin-for-vsphere/pull/509), [@deepakkinni](https://github.com/deepakkinni))
 - Fix datamgr Dockerfile ([#518](https://github.com/vmware-tanzu/velero-plugin-for-vsphere/pull/518), [@deepakkinni](https://github.com/deepakkinni))
+- Remove busybox reference from Dockerfiles ([#524](https://github.com/vmware-tanzu/velero-plugin-for-vsphere/pull/524), [@deepakkinni](https://github.com/deepakkinni))
 
 ## Dependencies
 

--- a/changelogs/CHANGELOG-1.5.md
+++ b/changelogs/CHANGELOG-1.5.md
@@ -1,5 +1,13 @@
 # Changelog since v1.4.0
 
+## v1.5.1
+
+Date: 2022-4-27
+
+### Changes
+
+- Remove busybox reference from Dockerfiles ([#524](https://github.com/vmware-tanzu/velero-plugin-for-vsphere/pull/524), [@deepakkinni](https://github.com/deepakkinni))
+
 ## v1.5.0
 
 Date: 2022-2-22
@@ -17,7 +25,6 @@ Date: 2022-2-22
   CVE-2022-46908 ([#514](https://github.com/vmware-tanzu/velero-plugin-for-vsphere/pull/514), [@deepakkinni](https://github.com/deepakkinni))
 - Update supervisor deployment doc to indicate that velero-vsphere-plugin-config needs to be created. ([#509](https://github.com/vmware-tanzu/velero-plugin-for-vsphere/pull/509), [@deepakkinni](https://github.com/deepakkinni))
 - Fix datamgr Dockerfile ([#518](https://github.com/vmware-tanzu/velero-plugin-for-vsphere/pull/518), [@deepakkinni](https://github.com/deepakkinni))
-- Remove busybox reference from Dockerfiles ([#524](https://github.com/vmware-tanzu/velero-plugin-for-vsphere/pull/524), [@deepakkinni](https://github.com/deepakkinni))
 
 ## Dependencies
 

--- a/changelogs/CHANGELOG-1.5.md
+++ b/changelogs/CHANGELOG-1.5.md
@@ -16,6 +16,7 @@ Date: 2022-2-22
   CVE-2022-4304, CVE-2022-4450, CVE-2023-0215, CVE-2023-0216, CVE-2023-0217, CVE-2023-0401,
   CVE-2022-46908 ([#514](https://github.com/vmware-tanzu/velero-plugin-for-vsphere/pull/514), [@deepakkinni](https://github.com/deepakkinni))
 - Update supervisor deployment doc to indicate that velero-vsphere-plugin-config needs to be created. ([#509](https://github.com/vmware-tanzu/velero-plugin-for-vsphere/pull/509), [@deepakkinni](https://github.com/deepakkinni))
+- Fix datamgr Dockerfile ([#518](https://github.com/vmware-tanzu/velero-plugin-for-vsphere/pull/518), [@deepakkinni](https://github.com/deepakkinni))
 
 ## Dependencies
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Cherry-pick multiple PRs.

**Which issue(s) this PR fixes**:
Fixes #

**Testing**
```
harbor-repo.vmware.com/velero/data-manager-for-plugin:xport-6-6e29034-26.Apr.2023.12.43.08
harbor-repo.vmware.com/velero/backup-driver:xport-6-6e29034-26.Apr.2023.12.43.08
harbor-repo.vmware.com/velero/velero-plugin-for-vsphere:xport-6-6e29034-26.Apr.2023.12.43.08


Running tests: ./pkg/...
go test ./pkg/... -timeout=300s
go: downloading github.com/stretchr/testify v1.7.1
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/apis/backupdriver/v1alpha1        [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/apis/datamover/v1alpha1   [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/backupdriver      [no test files]
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/backuprepository  0.178s
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/builder   [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/buildinfo [no test files]
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/cmd       0.174s
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/cmd/backupdriver  [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/cmd/backupdriver/cli/install      [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/cmd/backupdriver/cli/server       [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/cmd/datamgr       [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/cmd/datamgr/cli/install   [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/cmd/datamgr/cli/server    [no test files]
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/common/vsphere    0.143s
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/constants [no test files]
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/controller        0.137s
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/dataMover [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned     [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/fake        [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/scheme      [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/typed/backupdriver/v1alpha1 [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/typed/backupdriver/v1alpha1/fake    [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/typed/datamover/v1alpha1    [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/typed/datamover/v1alpha1/fake       [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/crds    [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/informers/externalversions      [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/informers/externalversions/backupdriver [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/informers/externalversions/backupdriver/v1alpha1        [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/informers/externalversions/datamover    [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/informers/externalversions/datamover/v1alpha1   [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/informers/externalversions/internalinterfaces   [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/listers/backupdriver/v1alpha1   [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/listers/datamover/v1alpha1      [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/install   [no test files]
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/ivd       0.091s
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/paravirt  0.166s
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/plugin    [no test files]
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/plugin/util       0.074s
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/snapshotUtils     0.135s
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/snapshotmgr       0.070s
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/test      [no test files]
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/utils     0.070s
Success!

```

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
None
```
