### PR TITLE
Use Photon 4.0 base image in Dockerfiles

### DIFF
--- a/Dockerfile-backup-driver
+++ b/Dockerfile-backup-driver
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM photon:5.0
+FROM photon:4.0
+RUN tdnf -y upgrade && tdnf clean all
 COPY /bin/linux/amd64/lib/vmware-vix-disklib/lib64/* /vddkLibs/
 ADD /bin/linux/amd64/backup-driver* /backup-driver
 ENTRYPOINT ["/backup-driver"]

--- a/Dockerfile-datamgr
+++ b/Dockerfile-datamgr
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 
-FROM photon:5.0
+FROM photon:4.0
+RUN tdnf -y upgrade && tdnf clean all
 ADD /bin/linux/amd64/data-* /datamgr
 COPY /bin/linux/amd64/lib/vmware-vix-disklib/lib64/* /vddkLibs/
 ENTRYPOINT ["/datamgr"]

--- a/Dockerfile-plugin
+++ b/Dockerfile-plugin
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 
-FROM photon:5.0
+FROM photon:4.0
+RUN tdnf -y upgrade && tdnf clean all
 ADD /bin/linux/amd64/velero-* /plugins/
 ADD /bin/linux/amd64/data-* /
 ADD /bin/linux/amd64/backup-driver* /

--- a/changelogs/CHANGELOG-1.5.md
+++ b/changelogs/CHANGELOG-1.5.md
@@ -2,11 +2,12 @@
 
 ## v1.5.1
 
-Date: 2022-4-27
+Date: 2022-5-2
 
 ### Changes
 
 - Remove busybox reference from Dockerfiles ([#524](https://github.com/vmware-tanzu/velero-plugin-for-vsphere/pull/524), [@deepakkinni](https://github.com/deepakkinni))
+- Use Photon 4.0 base image in Dockerfiles ([#528](https://github.com/vmware-tanzu/velero-plugin-for-vsphere/pull/528), [@deepakkinni](https://github.com/deepakkinni))
 
 ## v1.5.0
 


### PR DESCRIPTION
**What this PR does / why we need it**:
- Switch to using Photon 4.0 image
- Photon 5.0 was causing data-manager container to fail startup in the data manager vm
- Switching to 4.0 resolves the issue.

**Which issue(s) this PR fixes**:
Fixes #

**Testing**
Trivy Scan
```
dkinni@dkinniCMD6R ~ % docker run aquasec/trivy image harbor-repo.vmware.com/velero/data-manager-for-plugin:test_dm_v1-139c855-02.May.2023.12.32.48
2023-05-02T20:05:06.684Z	INFO	Need to update DB
2023-05-02T20:05:06.684Z	INFO	DB Repository: ghcr.io/aquasecurity/trivy-db
2023-05-02T20:05:06.684Z	INFO	Downloading DB...
6.49 MiB / 36.57 MiB [---------->___________________________________________________] 17.74% ? p/s ?18.97 MiB / 36.57 MiB [------------------------------->_____________________________] 51.88% ? p/s ?22.80 MiB / 36.57 MiB [-------------------------------------->______________________] 62.34% ? p/s ?22.80 MiB / 36.57 MiB [----------------------------->__________________] 62.34% 27.36 MiB p/s ETA 0s22.80 MiB / 36.57 MiB [----------------------------->__________________] 62.34% 27.36 MiB p/s ETA 0s22.80 MiB / 36.57 MiB [----------------------------->__________________] 62.34% 27.36 MiB p/s ETA 0s22.80 MiB / 36.57 MiB [----------------------------->__________________] 62.34% 25.59 MiB p/s ETA 0s30.50 MiB / 36.57 MiB [---------------------------------------->_______] 83.41% 25.59 MiB p/s ETA 0s36.57 MiB / 36.57 MiB [---------------------------------------------->] 100.00% 25.59 MiB p/s ETA 0s36.57 MiB / 36.57 MiB [---------------------------------------------->] 100.00% 25.42 MiB p/s ETA 0s36.57 MiB / 36.57 MiB [---------------------------------------------->] 100.00% 25.42 MiB p/s ETA 0s36.57 MiB / 36.57 MiB [---------------------------------------------->] 100.00% 25.42 MiB p/s ETA 0s36.57 MiB / 36.57 MiB [---------------------------------------------->] 100.00% 23.78 MiB p/s ETA 0s36.57 MiB / 36.57 MiB [---------------------------------------------->] 100.00% 23.78 MiB p/s ETA 0s36.57 MiB / 36.57 MiB [---------------------------------------------->] 100.00% 23.78 MiB p/s ETA 0s36.57 MiB / 36.57 MiB [-------------------------------------------------] 100.00% 13.07 MiB p/s 3.0s2023-05-02T20:05:11.522Z	INFO	Vulnerability scanning is enabled
2023-05-02T20:05:11.522Z	INFO	Secret scanning is enabled
2023-05-02T20:05:11.522Z	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2023-05-02T20:05:11.522Z	INFO	Please see also https://aquasecurity.github.io/trivy/v0.41/docs/secret/scanning/#recommendation for faster secret detection
2023-05-02T20:05:17.539Z	INFO	Detected OS: photon
2023-05-02T20:05:17.539Z	INFO	Detecting Photon Linux vulnerabilities...
2023-05-02T20:05:17.540Z	INFO	Number of language-specific files: 1
2023-05-02T20:05:17.540Z	INFO	Detecting gobinary vulnerabilities...

harbor-repo.vmware.com/velero/data-manager-for-plugin:test_dm_v1-139c855-02.May.2023.12.32.48 (photon 4.0)
==========================================================================================================
Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)


datamgr (gobinary)
==================
Total: 2 (UNKNOWN: 0, LOW: 1, MEDIUM: 1, HIGH: 0, CRITICAL: 0)

┌───────────────────────────┬───────────────┬──────────┬───────────────────┬───────────────┬────────────────────────────────────────────────────────────┐
│          Library          │ Vulnerability │ Severity │ Installed Version │ Fixed Version │                           Title                            │
├───────────────────────────┼───────────────┼──────────┼───────────────────┼───────────────┼────────────────────────────────────────────────────────────┤
│ github.com/aws/aws-sdk-go │ CVE-2020-8911 │ MEDIUM   │ v1.44.207         │               │ aws/aws-sdk-go: CBC padding oracle issue in AWS S3 Crypto  │
│                           │               │          │                   │               │ SDK for golang...                                          │
│                           │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2020-8911                  │
│                           ├───────────────┼──────────┤                   ├───────────────┼────────────────────────────────────────────────────────────┤
│                           │ CVE-2020-8912 │ LOW      │                   │               │ aws-sdk-go: In-band key negotiation issue in AWS S3 Crypto │
│                           │               │          │                   │               │ SDK for golang...                                          │
│                           │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2020-8912                  │
└───────────────────────────┴───────────────┴──────────┴───────────────────┴───────────────┴────────────────────────────────────────────────────────────┘

dkinni@dkinniCMD6R ~ % docker run aquasec/trivy image harbor-repo.vmware.com/velero/backup-driver:test_dm_v1-139c855-02.May.2023.12.32.48
2023-05-02T20:06:10.183Z	INFO	Need to update DB
2023-05-02T20:06:10.183Z	INFO	DB Repository: ghcr.io/aquasecurity/trivy-db
2023-05-02T20:06:10.183Z	INFO	Downloading DB...
4.44 MiB / 36.57 MiB [------->______________________________________________________] 12.13% ? p/s ?12.83 MiB / 36.57 MiB [--------------------->_______________________________________] 35.08% ? p/s ?18.03 MiB / 36.57 MiB [------------------------------>______________________________] 49.31% ? p/s ?23.86 MiB / 36.57 MiB [------------------------------->________________] 65.24% 32.35 MiB p/s ETA 0s28.20 MiB / 36.57 MiB [------------------------------------->__________] 77.12% 32.35 MiB p/s ETA 0s31.89 MiB / 36.57 MiB [----------------------------------------->______] 87.20% 32.35 MiB p/s ETA 0s36.42 MiB / 36.57 MiB [----------------------------------------------->] 99.59% 31.61 MiB p/s ETA 0s36.57 MiB / 36.57 MiB [---------------------------------------------->] 100.00% 31.61 MiB p/s ETA 0s36.57 MiB / 36.57 MiB [---------------------------------------------->] 100.00% 31.61 MiB p/s ETA 0s36.57 MiB / 36.57 MiB [---------------------------------------------->] 100.00% 29.59 MiB p/s ETA 0s36.57 MiB / 36.57 MiB [---------------------------------------------->] 100.00% 29.59 MiB p/s ETA 0s36.57 MiB / 36.57 MiB [---------------------------------------------->] 100.00% 29.59 MiB p/s ETA 0s36.57 MiB / 36.57 MiB [-------------------------------------------------] 100.00% 15.86 MiB p/s 2.5s2023-05-02T20:06:14.212Z	INFO	Vulnerability scanning is enabled
2023-05-02T20:06:14.212Z	INFO	Secret scanning is enabled
2023-05-02T20:06:14.212Z	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2023-05-02T20:06:14.212Z	INFO	Please see also https://aquasecurity.github.io/trivy/v0.41/docs/secret/scanning/#recommendation for faster secret detection
2023-05-02T20:06:20.356Z	INFO	Detected OS: photon
2023-05-02T20:06:20.356Z	INFO	Detecting Photon Linux vulnerabilities...
2023-05-02T20:06:20.357Z	INFO	Number of language-specific files: 1
2023-05-02T20:06:20.357Z	INFO	Detecting gobinary vulnerabilities...

harbor-repo.vmware.com/velero/backup-driver:test_dm_v1-139c855-02.May.2023.12.32.48 (photon 4.0)
================================================================================================
Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)


backup-driver (gobinary)
========================
Total: 2 (UNKNOWN: 0, LOW: 1, MEDIUM: 1, HIGH: 0, CRITICAL: 0)

┌───────────────────────────┬───────────────┬──────────┬───────────────────┬───────────────┬────────────────────────────────────────────────────────────┐
│          Library          │ Vulnerability │ Severity │ Installed Version │ Fixed Version │                           Title                            │
├───────────────────────────┼───────────────┼──────────┼───────────────────┼───────────────┼────────────────────────────────────────────────────────────┤
│ github.com/aws/aws-sdk-go │ CVE-2020-8911 │ MEDIUM   │ v1.44.207         │               │ aws/aws-sdk-go: CBC padding oracle issue in AWS S3 Crypto  │
│                           │               │          │                   │               │ SDK for golang...                                          │
│                           │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2020-8911                  │
│                           ├───────────────┼──────────┤                   ├───────────────┼────────────────────────────────────────────────────────────┤
│                           │ CVE-2020-8912 │ LOW      │                   │               │ aws-sdk-go: In-band key negotiation issue in AWS S3 Crypto │
│                           │               │          │                   │               │ SDK for golang...                                          │
│                           │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2020-8912                  │
└───────────────────────────┴───────────────┴──────────┴───────────────────┴───────────────┴────────────────────────────────────────────────────────────┘



dkinni@dkinniCMD6R ~ % docker run aquasec/trivy image harbor-repo.vmware.com/velero/velero-plugin-for-vsphere:test_dm_v1-139c855-02.May.2023.12.32.48
2023-05-02T20:06:52.287Z	INFO	Need to update DB
2023-05-02T20:06:52.287Z	INFO	DB Repository: ghcr.io/aquasecurity/trivy-db
2023-05-02T20:06:52.287Z	INFO	Downloading DB...
8.14 MiB / 36.57 MiB [------------->________________________________________________] 22.26% ? p/s ?26.25 MiB / 36.57 MiB [------------------------------------------->_________________] 71.78% ? p/s ?32.44 MiB / 36.57 MiB [------------------------------------------------------>______] 88.70% ? p/s ?36.57 MiB / 36.57 MiB [---------------------------------------------->] 100.00% 48.13 MiB p/s ETA 0s36.57 MiB / 36.57 MiB [---------------------------------------------->] 100.00% 48.13 MiB p/s ETA 0s36.57 MiB / 36.57 MiB [---------------------------------------------->] 100.00% 48.13 MiB p/s ETA 0s36.57 MiB / 36.57 MiB [---------------------------------------------->] 100.00% 45.02 MiB p/s ETA 0s36.57 MiB / 36.57 MiB [---------------------------------------------->] 100.00% 45.02 MiB p/s ETA 0s36.57 MiB / 36.57 MiB [---------------------------------------------->] 100.00% 45.02 MiB p/s ETA 0s36.57 MiB / 36.57 MiB [---------------------------------------------->] 100.00% 42.12 MiB p/s ETA 0s36.57 MiB / 36.57 MiB [-------------------------------------------------] 100.00% 18.91 MiB p/s 2.1s2023-05-02T20:06:55.376Z	INFO	Vulnerability scanning is enabled
2023-05-02T20:06:55.376Z	INFO	Secret scanning is enabled
2023-05-02T20:06:55.376Z	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2023-05-02T20:06:55.376Z	INFO	Please see also https://aquasecurity.github.io/trivy/v0.41/docs/secret/scanning/#recommendation for faster secret detection
2023-05-02T20:07:07.201Z	INFO	Detected OS: photon
2023-05-02T20:07:07.201Z	INFO	Detecting Photon Linux vulnerabilities...
2023-05-02T20:07:07.205Z	INFO	Number of language-specific files: 3
2023-05-02T20:07:07.205Z	INFO	Detecting gobinary vulnerabilities...

harbor-repo.vmware.com/velero/velero-plugin-for-vsphere:test_dm_v1-139c855-02.May.2023.12.32.48 (photon 4.0)
============================================================================================================
Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)


backup-driver (gobinary)
========================
Total: 2 (UNKNOWN: 0, LOW: 1, MEDIUM: 1, HIGH: 0, CRITICAL: 0)

┌───────────────────────────┬───────────────┬──────────┬───────────────────┬───────────────┬────────────────────────────────────────────────────────────┐
│          Library          │ Vulnerability │ Severity │ Installed Version │ Fixed Version │                           Title                            │
├───────────────────────────┼───────────────┼──────────┼───────────────────┼───────────────┼────────────────────────────────────────────────────────────┤
│ github.com/aws/aws-sdk-go │ CVE-2020-8911 │ MEDIUM   │ v1.44.207         │               │ aws/aws-sdk-go: CBC padding oracle issue in AWS S3 Crypto  │
│                           │               │          │                   │               │ SDK for golang...                                          │
│                           │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2020-8911                  │
│                           ├───────────────┼──────────┤                   ├───────────────┼────────────────────────────────────────────────────────────┤
│                           │ CVE-2020-8912 │ LOW      │                   │               │ aws-sdk-go: In-band key negotiation issue in AWS S3 Crypto │
│                           │               │          │                   │               │ SDK for golang...                                          │
│                           │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2020-8912                  │
└───────────────────────────┴───────────────┴──────────┴───────────────────┴───────────────┴────────────────────────────────────────────────────────────┘

data-manager-for-plugin (gobinary)
==================================
Total: 2 (UNKNOWN: 0, LOW: 1, MEDIUM: 1, HIGH: 0, CRITICAL: 0)

┌───────────────────────────┬───────────────┬──────────┬───────────────────┬───────────────┬────────────────────────────────────────────────────────────┐
│          Library          │ Vulnerability │ Severity │ Installed Version │ Fixed Version │                           Title                            │
├───────────────────────────┼───────────────┼──────────┼───────────────────┼───────────────┼────────────────────────────────────────────────────────────┤
│ github.com/aws/aws-sdk-go │ CVE-2020-8911 │ MEDIUM   │ v1.44.207         │               │ aws/aws-sdk-go: CBC padding oracle issue in AWS S3 Crypto  │
│                           │               │          │                   │               │ SDK for golang...                                          │
│                           │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2020-8911                  │
│                           ├───────────────┼──────────┤                   ├───────────────┼────────────────────────────────────────────────────────────┤
│                           │ CVE-2020-8912 │ LOW      │                   │               │ aws-sdk-go: In-band key negotiation issue in AWS S3 Crypto │
│                           │               │          │                   │               │ SDK for golang...                                          │
│                           │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2020-8912                  │
└───────────────────────────┴───────────────┴──────────┴───────────────────┴───────────────┴────────────────────────────────────────────────────────────┘

plugins/velero-plugin-for-vsphere (gobinary)
============================================
Total: 2 (UNKNOWN: 0, LOW: 1, MEDIUM: 1, HIGH: 0, CRITICAL: 0)

┌───────────────────────────┬───────────────┬──────────┬───────────────────┬───────────────┬────────────────────────────────────────────────────────────┐
│          Library          │ Vulnerability │ Severity │ Installed Version │ Fixed Version │                           Title                            │
├───────────────────────────┼───────────────┼──────────┼───────────────────┼───────────────┼────────────────────────────────────────────────────────────┤
│ github.com/aws/aws-sdk-go │ CVE-2020-8911 │ MEDIUM   │ v1.44.207         │               │ aws/aws-sdk-go: CBC padding oracle issue in AWS S3 Crypto  │
│                           │               │          │                   │               │ SDK for golang...                                          │
│                           │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2020-8911                  │
│                           ├───────────────┼──────────┤                   ├───────────────┼────────────────────────────────────────────────────────────┤
│                           │ CVE-2020-8912 │ LOW      │                   │               │ aws-sdk-go: In-band key negotiation issue in AWS S3 Crypto │
│                           │               │          │                   │               │ SDK for golang...                                          │
│                           │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2020-8912                  │
└───────────────────────────┴───────────────┴──────────┴───────────────────┴───────────────┴────────────────────────────────────────────────────────────┘
```

Vanilla:
```
dkinni@dkinniCMD6R ~ % kubectl get pods -n velero
NAME                               READY   STATUS    RESTARTS   AGE
backup-driver-84bb9d748-zf9b8      1/1     Running   0          15m
datamgr-for-vsphere-plugin-2znpl   1/1     Running   0          14m
datamgr-for-vsphere-plugin-hclgf   1/1     Running   0          14m
datamgr-for-vsphere-plugin-k7t7c   1/1     Running   0          14m
node-agent-jcpws                   1/1     Running   0          20h
node-agent-rvn7q                   1/1     Running   0          20h
node-agent-xbtsn                   1/1     Running   0          20h
velero-785b44858d-2qqmj            1/1     Running   0          17m
```

Data manager container on VM:
```
root@photon-cnsdp [ /bin ]# docker ps
CONTAINER ID        IMAGE                                                                                           COMMAND                  CREATED             STATUS              PORTS               NAMES
b3a54e8ae065        harbor-repo.vmware.com/velero/data-manager-for-plugin:test_dm_v1-139c855-02.May.2023.12.32.48   "/datamgr server --u…"   3 seconds ago       Up 2 seconds                            velero-datamgr
```

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
Reverting to use Photon 4.0 base image due to data-manager container startup failure when using Photon 5.0
The updated Photon 4.0 image has previously known CVEs resolved.
```
