### PR TITLE
Update photon 4.0 image to resolve CVEs

### DIFF
--- a/Dockerfile-backup-driver
+++ b/Dockerfile-backup-driver
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM photon:4.0
+FROM photon:4.0-20230603
 RUN tdnf -y upgrade && tdnf clean all
 COPY /bin/linux/amd64/lib/vmware-vix-disklib/lib64/* /vddkLibs/
 ADD /bin/linux/amd64/backup-driver* /backup-driver

--- a/Dockerfile-datamgr
+++ b/Dockerfile-datamgr
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-FROM photon:4.0
+FROM photon:4.0-20230603
 RUN tdnf -y upgrade && tdnf clean all
 ADD /bin/linux/amd64/data-* /datamgr
 COPY /bin/linux/amd64/lib/vmware-vix-disklib/lib64/* /vddkLibs/

--- a/Dockerfile-plugin
+++ b/Dockerfile-plugin
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-FROM photon:4.0
+FROM photon:4.0-20230603
 RUN tdnf -y upgrade && tdnf clean all
 ADD /bin/linux/amd64/velero-* /plugins/
 ADD /bin/linux/amd64/data-* /


### PR DESCRIPTION
**What this PR does / why we need it**:
Resolve [CVE-2023-2603](https://nvd.nist.gov/vuln/detail/CVE-2023-2603)


**Which issue(s) this PR fixes**:

Fixes #

**Testing**:
Scan Results:
```
❯ docker run aquasec/trivy image harbor-repo.vmware.com/dkinni/velero-plugin-for-vsphere:cve_fix_v1-96b0940-26.Jun.2023.21.08.24
2023-06-27T04:29:31.374Z	INFO	Need to update DB
2023-06-27T04:29:31.374Z	INFO	DB Repository: ghcr.io/aquasecurity/trivy-db
2023-06-27T04:29:31.374Z	INFO	Downloading DB...
8.10 MiB / 37.87 MiB [------------->________________________________________________] 21.39% ? p/s ?20.39 MiB / 37.87 MiB [-------------------------------->____________________________] 53.85% ? p/s ?35.09 MiB / 37.87 MiB [-------------------------------------------------------->____] 92.67% ? p/s ?37.87 MiB / 37.87 MiB [---------------------------------------------->] 100.00% 49.61 MiB p/s ETA 0s37.87 MiB / 37.87 MiB [---------------------------------------------->] 100.00% 49.61 MiB p/s ETA 0s37.87 MiB / 37.87 MiB [---------------------------------------------->] 100.00% 49.61 MiB p/s ETA 0s37.87 MiB / 37.87 MiB [---------------------------------------------->] 100.00% 46.41 MiB p/s ETA 0s37.87 MiB / 37.87 MiB [---------------------------------------------->] 100.00% 46.41 MiB p/s ETA 0s37.87 MiB / 37.87 MiB [---------------------------------------------->] 100.00% 46.41 MiB p/s ETA 0s37.87 MiB / 37.87 MiB [-------------------------------------------------] 100.00% 22.60 MiB p/s 1.9s2023-06-27T04:29:34.500Z	INFO	Vulnerability scanning is enabled
2023-06-27T04:29:34.500Z	INFO	Secret scanning is enabled
2023-06-27T04:29:34.500Z	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2023-06-27T04:29:34.500Z	INFO	Please see also https://aquasecurity.github.io/trivy/v0.41/docs/secret/scanning/#recommendation for faster secret detection
2023-06-27T04:29:45.744Z	INFO	Detected OS: photon
2023-06-27T04:29:45.744Z	INFO	Detecting Photon Linux vulnerabilities...
2023-06-27T04:29:45.745Z	INFO	Number of language-specific files: 3
2023-06-27T04:29:45.745Z	INFO	Detecting gobinary vulnerabilities...

harbor-repo.vmware.com/dkinni/velero-plugin-for-vsphere:cve_fix_v1-96b0940-26.Jun.2023.21.08.24 (photon 4.0)
============================================================================================================
Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)


backup-driver (gobinary)
========================
Total: 2 (UNKNOWN: 0, LOW: 1, MEDIUM: 1, HIGH: 0, CRITICAL: 0)

┌───────────────────────────┬───────────────┬──────────┬───────────────────┬───────────────┬────────────────────────────────────────────────────────────┐
│          Library          │ Vulnerability │ Severity │ Installed Version │ Fixed Version │                           Title                            │
├───────────────────────────┼───────────────┼──────────┼───────────────────┼───────────────┼────────────────────────────────────────────────────────────┤
│ github.com/aws/aws-sdk-go │ CVE-2020-8911 │ MEDIUM   │ v1.44.207         │               │ aws/aws-sdk-go: CBC padding oracle issue in AWS S3 Crypto  │
│                           │               │          │                   │               │ SDK for golang...                                          │
│                           │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2020-8911                  │
│                           ├───────────────┼──────────┤                   ├───────────────┼────────────────────────────────────────────────────────────┤
│                           │ CVE-2020-8912 │ LOW      │                   │               │ aws-sdk-go: In-band key negotiation issue in AWS S3 Crypto │
│                           │               │          │                   │               │ SDK for golang...                                          │
│                           │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2020-8912                  │
└───────────────────────────┴───────────────┴──────────┴───────────────────┴───────────────┴────────────────────────────────────────────────────────────┘

data-manager-for-plugin (gobinary)
==================================
Total: 2 (UNKNOWN: 0, LOW: 1, MEDIUM: 1, HIGH: 0, CRITICAL: 0)

┌───────────────────────────┬───────────────┬──────────┬───────────────────┬───────────────┬────────────────────────────────────────────────────────────┐
│          Library          │ Vulnerability │ Severity │ Installed Version │ Fixed Version │                           Title                            │
├───────────────────────────┼───────────────┼──────────┼───────────────────┼───────────────┼────────────────────────────────────────────────────────────┤
│ github.com/aws/aws-sdk-go │ CVE-2020-8911 │ MEDIUM   │ v1.44.207         │               │ aws/aws-sdk-go: CBC padding oracle issue in AWS S3 Crypto  │
│                           │               │          │                   │               │ SDK for golang...                                          │
│                           │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2020-8911                  │
│                           ├───────────────┼──────────┤                   ├───────────────┼────────────────────────────────────────────────────────────┤
│                           │ CVE-2020-8912 │ LOW      │                   │               │ aws-sdk-go: In-band key negotiation issue in AWS S3 Crypto │
│                           │               │          │                   │               │ SDK for golang...                                          │
│                           │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2020-8912                  │
└───────────────────────────┴───────────────┴──────────┴───────────────────┴───────────────┴────────────────────────────────────────────────────────────┘

plugins/velero-plugin-for-vsphere (gobinary)
============================================
Total: 2 (UNKNOWN: 0, LOW: 1, MEDIUM: 1, HIGH: 0, CRITICAL: 0)

┌───────────────────────────┬───────────────┬──────────┬───────────────────┬───────────────┬────────────────────────────────────────────────────────────┐
│          Library          │ Vulnerability │ Severity │ Installed Version │ Fixed Version │                           Title                            │
├───────────────────────────┼───────────────┼──────────┼───────────────────┼───────────────┼────────────────────────────────────────────────────────────┤
│ github.com/aws/aws-sdk-go │ CVE-2020-8911 │ MEDIUM   │ v1.44.207         │               │ aws/aws-sdk-go: CBC padding oracle issue in AWS S3 Crypto  │
│                           │               │          │                   │               │ SDK for golang...                                          │
│                           │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2020-8911                  │
│                           ├───────────────┼──────────┤                   ├───────────────┼────────────────────────────────────────────────────────────┤
│                           │ CVE-2020-8912 │ LOW      │                   │               │ aws-sdk-go: In-band key negotiation issue in AWS S3 Crypto │
│                           │               │          │                   │               │ SDK for golang...                                          │
│                           │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2020-8912                  │
└───────────────────────────┴───────────────┴──────────┴───────────────────┴───────────────┴────────────────────────────────────────────────────────────┘
```


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
Update to photon:4.0-20230603 image
```
