### PR TITLE
Update Snapshot and upload CR status in doc.

### DIFF
--- a/docs/vanilla.md
+++ b/docs/vanilla.md
@@ -281,6 +281,7 @@ Snapshot CRD has a number of phases for the `.status.phase` field:
 * Canceling: the upload of snapshot is being cancelled
 * Canceled: the upload of snapshot is cancelled
 * CleanupAfterUploadFailed: the Cleanup of local snapshot after the upload of snapshot was failed
+* UploadFailedAfterRetry: the snapshot is failed to be uploaded after retries, and local snapshot is deleted
 
 #### Uploads
 
@@ -331,6 +332,7 @@ Upload CRD has a number of phases for the `.status.phase` field:
 * CleanupFailed: delete local snapshot failed after the upload, this case will also be retried
 * Canceling:  upload is being cancelled. It would happen if `velero backup delete` is called while the upload of snapshot is in progress.
 * Canceled: upload is cancelled.
+* UploadFailedAfterRetry: Upload failed after retries and local snapshot is deleted.
 
 UploadError uploads will be periodically retried.  At that point their phase will return to InProgress.  After an upload has been
 successfully completed, its record will remain for a period of time and eventually be removed.


### PR DESCRIPTION
Signed-off-by: Liping Xue lipingx@vmware.com

**What this PR does / why we need it**:
Update snapshot and upload CR status in doc.  The new status was introduced with this https://github.com/vmware-tanzu/velero-plugin-for-vsphere/pull/532
**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```NONE

```
