### PR TITLE
Only skip PVC creation if --namespace-mapping flag is not used

### DIFF
--- a/pkg/plugin/restore_pvc_action_plugin.go
+++ b/pkg/plugin/restore_pvc_action_plugin.go
@@ -3,22 +3,23 @@ package plugin
 import (
 	"context"
 	"fmt"
+	"os"
+
 	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/cmd"
 	"k8s.io/client-go/kubernetes"
-	"os"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	backupdriverv1 "github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/apis/backupdriver/v1alpha1"
 	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/backuprepository"
 	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/constants"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	backupdriverTypedV1 "github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/typed/backupdriver/v1alpha1"
 	pluginItem "github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/plugin/util"
 	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/snapshotUtils"
 	"github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/utils"
 	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -176,9 +177,10 @@ func (p *NewPVCRestoreItemAction) Execute(input *velero.RestoreItemActionExecute
 	bSkipPVC, err := pluginItem.SkipPVCCreation(ctx, restConfig, &pvc, p.Log)
 	if err != nil {
 		return nil, errors.WithStack(err)
-	} else if bSkipPVC {
+	} else if bSkipPVC && input.Restore.Spec.NamespaceMapping == nil {
 		// Skip PVCRestoreItemAction for PVC creation
 		// as it already exists
+		// and Restore is not remapping namespace
 		return &velero.RestoreItemActionExecuteOutput{
 			UpdatedItem: item,
 		}, nil

--- a/pkg/plugin/restore_pvc_action_plugin.go
+++ b/pkg/plugin/restore_pvc_action_plugin.go
@@ -174,10 +174,11 @@ func (p *NewPVCRestoreItemAction) Execute(input *velero.RestoreItemActionExecute
 		return nil, errors.WithStack(err)
 	}
 
-	bSkipPVC, err := pluginItem.SkipPVCCreation(ctx, restConfig, &pvc, p.Log)
+	bSkipPVC, err := pluginItem.SkipPVCCreation(ctx, restConfig, &pvc, targetNamespace, p.Log)
 	if err != nil {
 		return nil, errors.WithStack(err)
-	} else if bSkipPVC && input.Restore.Spec.NamespaceMapping == nil {
+	}
+	if bSkipPVC {
 		// Skip PVCRestoreItemAction for PVC creation
 		// as it already exists
 		// and Restore is not remapping namespace


### PR DESCRIPTION
**What this PR does / why we need it**:
When a Velero user uses the `--namespace-mapping` flag, PVC's should be recreated in the target namespace. Velero vSphere Plugin currently skips PVC creation if the PVC already exists in the cluster. The intended behavior of Velero restore is to recreate the PVC in the target namespace even if the PVC already exists in the cluster. This PR will check the Restore CRD and will only skip PVC creation if the user does not restore with the `--namespace-mapping` flag.

**Testing:**

**Case 1:** Logs when namespace mapping flag is used:
```
time="2024-02-22T00:12:36Z" level=info msg="Updating target PVC namespace based on the namespace mapping option in the Restore Spec" cmd=/plugins/velero-plugin-for-vsphere logSource="/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/plugin/restore_pvc_action_plugin.go:135" pluginName=velero-plugin-for-vsphere restore=velero/finalmaptest-20240222001233
time="2024-02-22T00:12:36Z" level=info msg="Updated the target PVC namespace from nsmlog to newnsmlog based on the namespace mapping in the Restore Spec" cmd=/plugins/velero-plugin-for-vsphere logSource="/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/plugin/restore_pvc_action_plugin.go:146" pluginName=velero-plugin-for-vsphere restore=velero/finalmaptest-20240222001233
time="2024-02-22T00:12:36Z" level=info msg="VSphere PVCRestoreItemAction for PVC newnsmlog/nginx-logs started" cmd=/plugins/velero-plugin-for-vsphere logSource="/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/plugin/restore_pvc_action_plugin.go:150" pluginName=velero-plugin-for-vsphere restore=velero/finalmaptest-20240222001233
time="2024-02-22T00:12:36Z" level=info msg="Check if PVC newnsmlog/nginx-logs creation should be skipped" cmd=/plugins/velero-plugin-for-vsphere logSource="/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/plugin/util/util.go:410" pluginName=velero-plugin-for-vsphere restore=velero/finalmaptest-20240222001233
time="2024-02-22T00:12:36Z" level=info msg="Creating PVC as it does not exist newnsmlog/nginx-logs" cmd=/plugins/velero-plugin-for-vsphere logSource="/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/plugin/util/util.go:431" pluginName=velero-plugin-for-vsphere restore=velero/finalmaptest-20240222001233
```
**Case 2:** Logs when namespace mapping flag is not used and backed-up namespace & PVC are deleted:
```
time="2024-02-22T00:17:37Z" level=info msg="Updating target PVC namespace based on the namespace mapping option in the Restore Spec" cmd=/plugins/velero-plugin-for-vsphere logSource="/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/plugin/restore_pvc_action_plugin.go:135" pluginName=velero-plugin-for-vsphere restore=velero/finalmaptest2
time="2024-02-22T00:17:37Z" level=info msg="VSphere PVCRestoreItemAction for PVC newnsmlog/nginx-logs started" cmd=/plugins/velero-plugin-for-vsphere logSource="/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/plugin/restore_pvc_action_plugin.go:150" pluginName=velero-plugin-for-vsphere restore=velero/finalmaptest2
time="2024-02-22T00:17:37Z" level=info msg="Check if PVC newnsmlog/nginx-logs creation should be skipped" cmd=/plugins/velero-plugin-for-vsphere logSource="/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/plugin/util/util.go:410" pluginName=velero-plugin-for-vsphere restore=velero/finalmaptest2
time="2024-02-22T00:17:37Z" level=info msg="Creating PVC as it does not exist newnsmlog/nginx-logs" cmd=/plugins/velero-plugin-for-vsphere logSource="/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/plugin/util/util.go:431" pluginName=velero-plugin-for-vsphere restore=velero/finalmaptest2
```

**Case 3:** Logs when namespace mapping flag is not used and namespace & PVC exists in cluster:
```
time="2024-02-21T23:49:25Z" level=info msg="Updating target PVC namespace based on the namespace mapping option in the Restore Spec" cmd=/plugins/velero-plugin-for-vsphere logSource="/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/plugin/restore_pvc_action_plugin.go:135" pluginName=velero-plugin-for-vsphere restore=velero/nodeletecase
time="2024-02-21T23:49:25Z" level=info msg="VSphere PVCRestoreItemAction for PVC nsmlog/nginx-logs started" cmd=/plugins/velero-plugin-for-vsphere logSource="/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/plugin/restore_pvc_action_plugin.go:156" pluginName=velero-plugin-for-vsphere restore=velero/nodeletecase
time="2024-02-21T23:49:25Z" level=info msg="Check if PVC nsmlog/nginx-logs creation should be skipped" cmd=/plugins/velero-plugin-for-vsphere logSource="/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/plugin/util/util.go:410" pluginName=velero-plugin-for-vsphere restore=velero/nodeletecase
time="2024-02-21T23:49:25Z" level=warning msg="Skipping PVC nsmlog/nginx-logs creation since it already exists." cmd=/plugins/velero-plugin-for-vsphere logSource="/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/plugin/util/util.go:424" pluginName=velero-plugin-for-vsphere restore=velero/nodeletecase
time="2024-02-21T23:49:25Z" level=info msg="VSphere PVCRestoreItemAction for PVC nsmlog/nginx-logs completed with err: <nil>" cmd=/plugins/velero-plugin-for-vsphere logSource="/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/plugin/restore_pvc_action_plugin.go:158" pluginName=velero-plugin-for-vsphere restore=velero/nodeletecase
```


**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #410 
https://github.com/vmware-tanzu/velero/issues/7318

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
This change will allow users to restore PVC's in the target namespace when the --namespace-mapping flag is used when creating a restore with Velero.
```
