### PR TITLE
Add doc that WaitForFirstConsumer is not supported at restore time

### DIFF
--- a/docs/vanilla.md
+++ b/docs/vanilla.md
@@ -364,6 +364,8 @@ Below is an example command of Velero restore.
 velero restore create --from-backup <your-backup-name>
 ```
 
+Note that a StorageClass with the WaitForFirstConsumer Volume Binding Mode is not supported at restore time. Only a StorageClass with the Immediate Volume Binding Mode is supported at restore time. You'll have to change the Volume Binding Mode from WaitForFirstConsumer to Immediate for restore to work.
+
 For the volume restores with changing storage class, please refer to [StorageClass Mapping](storageclass-mapping.md)
 
 For more restore options, please refer to [Velero Document](https://velero.io/docs/v1.5/).


### PR DESCRIPTION
**What this PR does / why we need it**:
At restore time, StorageClass with WaitForFirstConsumer VolumeBindingMode is not supported. Only StorageClass with Immediate VolumeBindingMode is supported at restore time.  Add documentation for this.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
When StorageClass with WaitForFirstConsumer VolumeBindingMode was used at restore time, we got the following "PVC did not become Bound" error.
```
error preparing persistentvolumeclaims/ivt/nginx-pvc: rpc error: code = Unknown desc = Failed to create a CloneFromSnapshot CR: Phase=Failed, err=cloneFromSnapshot: Failed at calling SnapshotManager CreateVolumeFromSnapshotWithMetadata with peId pvc:ivt/nginx-pvc, err: PVC "nginx-pvc" did not become Bound: PersistentVolumeClaims [nginx-pvc] not all in phase Bound within 3m0s
Error creating volume from metadata
github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/snapshotmgr.(*SnapshotManager).CreateVolumeFromSnapshotWithMetadata
  /go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/snapshotmgr/snapshot_manager.go:779
github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/backupdriver.(*backupDriverController).cloneFromSnapshot
  /go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/backupdriver/backup_driver_controller.go:311
github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/backupdriver.(*backupDriverController).syncCloneFromSnapshotByKey
  /go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/backupdriver/backup_driver_controller_base.go:617
github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/backupdriver.(*backupDriverController).cloneFromSnapshotWorker
  /go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/backupdriver/backup_driver_controller_base.go:562
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1
  /go/pkg/mod/k8s.io/apimachinery@v0.24.2/pkg/util/wait/wait.go:155
k8s.io/apimachinery/pkg/util/wait.BackoffUntil
  /go/pkg/mod/k8s.io/apimachinery@v0.24.2/pkg/util/wait/wait.go:156
k8s.io/apimachinery/pkg/util/wait.JitterUntil
  /go/pkg/mod/k8s.io/apimachinery@v0.24.2/pkg/util/wait/wait.go:133
k8s.io/apimachinery/pkg/util/wait.Until
  /go/pkg/mod/k8s.io/apimachinery@v0.24.2/pkg/util/wait/wait.go:90
runtime.goexit
  /usr/local/go/src/runtime/asm_amd64.s:1571
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
NONE
```
