### PR TITLE
Omit NSX Operator VPC CRs from Backup

### DIFF
--- a/docs/supervisor-notes.md
+++ b/docs/supervisor-notes.md
@@ -84,14 +84,14 @@ The default list of blocked resources in configmap is:
  	nsxlocks.nsx.vmware.com
  	nsxnetworkconfigurations.nsx.vmware.com
  	nsxnetworkinterfaces.nsx.vmware.com
-    vpcnetworkconfigurations.nsx.vmware.com
-    networkinfoes.nsx.vmware.com
-    subnets.nsx.vmware.com
-    subnetsets.nsx.vmware.com
-    subnetports.nsx.vmware.com
-    staticroutes.nsx.vmware.com
-    ippools.nsx.vmware.com
-    securitypolicies.nsx.vmware.com
+ 	vpcnetworkconfigurations.nsx.vmware.com
+ 	networkinfoes.nsx.vmware.com
+ 	subnets.nsx.vmware.com
+ 	subnetsets.nsx.vmware.com
+ 	subnetports.nsx.vmware.com
+ 	staticroutes.nsx.vmware.com
+ 	ippools.nsx.vmware.com
+ 	securitypolicies.nsx.vmware.com
  	orders.acme.cert-manager.io
  	persistenceinstanceinfoes.psp.wcp.vmware.com
  	persistenceserviceconfigurations.psp.wcp.vmware.com
@@ -148,6 +148,8 @@ The following resources are handled during the restore on the Supervisor Cluster
     * vmware-system-image-references
     * vmware-system-vm-moid
     * vmware-system-vm-uuid
+    * nsx.vmware.com/attachment
+    * nsx.vmware.com/mac
 
 ## vSphere Plugin resources
 

--- a/docs/supervisor-notes.md
+++ b/docs/supervisor-notes.md
@@ -84,6 +84,14 @@ The default list of blocked resources in configmap is:
  	nsxlocks.nsx.vmware.com
  	nsxnetworkconfigurations.nsx.vmware.com
  	nsxnetworkinterfaces.nsx.vmware.com
+    vpcnetworkconfigurations.nsx.vmware.com
+    networkinfoes.nsx.vmware.com
+    subnets.nsx.vmware.com
+    subnetsets.nsx.vmware.com
+    subnetports.nsx.vmware.com
+    staticroutes.nsx.vmware.com
+    ippools.nsx.vmware.com
+    securitypolicies.nsx.vmware.com
  	orders.acme.cert-manager.io
  	persistenceinstanceinfoes.psp.wcp.vmware.com
  	persistenceserviceconfigurations.psp.wcp.vmware.com

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -270,6 +270,13 @@ var ResourcesToBlock = map[string]bool{
 	//"nsxloadbalancermonitors.vmware.com":                    true, // DO NOT ADD IT BACK
 	"nsxlocks.nsx.vmware.com":                                 true,
 	"nsxnetworkinterfaces.nsx.vmware.com":                     true,
+	"vpcnetworkconfigurations.nsx.vmware.com":                 true,
+	"networkinfoes.nsx.vmware.com":                            true,
+	"subnets.nsx.vmware.com":                                  true,
+	"subnetsets.nsx.vmware.com":                               true,
+	"subnetports.nsx.vmware.com":                              true,
+	"staticroutes.nsx.vmware.com":                             true,
+	"securitypolicies.nsx.vmware.com":                         true,
 	"nsxnetworkconfigurations.nsx.vmware.com":                 true,
 	"orders.acme.cert-manager.io":                             true,
 	"persistenceinstanceinfoes.psp.wcp.vmware.com":            true,
@@ -359,6 +366,8 @@ var PodAnnotationsToSkip = map[string]bool{
 	"vmware-system-image-references":    true,
 	"vmware-system-vm-moid":             true,
 	"vmware-system-vm-uuid":             true,
+	"nsx.vmware.com/attachment":         true,
+	"nsx.vmware.com/mac":                true,
 }
 
 // UUID of the VM on Supervisor Cluster


### PR DESCRIPTION
This change prevents Velero Backup from backing up the following NSX Operator CRs to support the VPC topology, which can be found at https://github.com/vmware-tanzu/nsx-operator/tree/main/pkg/apis.

* vpcnetworkconfigurations.nsx.vmware.com
* networkinfoes.nsx.vmware.com
* subnets.nsx.vmware.com
* subnetsets.nsx.vmware.com
* subnetports.nsx.vmware.com
* staticroutes.nsx.vmware.com
* ippools.nsx.vmware.com
* securitypolicies.nsx.vmware.com

Additionally, the following Pod annotations are stripped on backup, as added via
https://github.com/vmware-tanzu/nsx-operator/blob/main/pkg/controllers/pod/pod_controller.go.

* nsx.vmware.com/attachment
* nsx.vmware.com/mac

**What this PR does / why we need it**:

This change adds newly-constructed NSX Operator VPC-related Custom Resources to be omitted from Velero backups. This is important to remain consistent with other network topologies - desiring to prevent network-related backups in favor of a re-create of the underlying network connectivity upon Velero restore.

**Which issue(s) this PR fixes**:

n/a

**Special notes for your reviewer**:

n/a

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
