### PR TITLE
Add vmware-system-network to pod annotations to skip

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -359,6 +359,7 @@ var PodAnnotationsToSkip = map[string]bool{
 	"vmware-system-image-references":    true,
 	"vmware-system-vm-moid":             true,
 	"vmware-system-vm-uuid":             true,
+	"vmware-system-network":             true,
 }
 
 // UUID of the VM on Supervisor Cluster


### PR DESCRIPTION
**What this PR does / why we need it**:

Velero back up would partially fail in VDS setup on Supervisor. With this fix, backup can successfully complete.

Velero backup command:
```
velero backup create vds-backup8 --exclude-resources kubeadmconfigtemplates.bootstrap.cluster.x-k8s.io,clusterclasses.cluster.x-k8s.io,contentsourcebindings.vmoperator.vmware.com,namespacenetworkinfos.nsx.vmware.com,cnscsisvfeaturestates.cns.vmware.com,networks.netoperator.vmware.com,networkinterfaces.netoperator.vmware.com,gateways.networking.x-k8s.io --include-namespaces test-ns
```

Velero backup:
```
Name:         vds-backup8
Namespace:    velero
Labels:       velero.io/storage-location=default
Annotations:  velero.io/resource-timeout=10m0s
              velero.io/source-cluster-k8s-gitversion=v1.28.3+vmware.wcp.1
              velero.io/source-cluster-k8s-major-version=1
              velero.io/source-cluster-k8s-minor-version=28

Phase:  Completed


Warnings:
  Velero:     <none>
  Cluster:   resource: /persistentvolumes name: /pvc-bd27382c-2cb2-4435-b30c-07b1aed0c302 message: /No volume ID returned by volume snapshotter for persistent volume
  Namespaces: <none>

Namespaces:
  Included:  test-ns
  Excluded:  <none>

Resources:
  Included:        *
  Excluded:        kubeadmconfigtemplates.bootstrap.cluster.x-k8s.io, clusterclasses.cluster.x-k8s.io, contentsourcebindings.vmoperator.vmware.com, namespacenetworkinfos.nsx.vmware.com, cnscsisvfeaturestates.cns.vmware.com, networks.netoperator.vmware.com, networkinterfaces.netoperator.vmware.com, gateways.networking.x-k8s.io
  Cluster-scoped:  auto

Label selector:  <none>

Or label selector:  <none>

Storage Location:  default

Velero-Native Snapshot PVs:  auto
Snapshot Move Data:          false
Data Mover:                  velero

TTL:  720h0m0s

CSISnapshotTimeout:    10m0s
ItemOperationTimeout:  4h0m0s

Hooks:  <none>

Backup Format Version:  1.1.0

Started:    2024-05-21 20:34:04 +0000 UTC
Completed:  2024-05-21 20:34:19 +0000 UTC

Expiration:  2024-06-20 20:34:04 +0000 UTC

Total items to be backed up:  201
Items backed up:              201

Backup Volumes:
  Velero-Native Snapshots: <none included>

  CSI Snapshots: <none included>

  Pod Volume Backups: <none included>

HooksAttempted:  0
HooksFailed:     0
```

Velero upload CR:
```
apiVersion: datamover.cnsdp.vmware.com/v1alpha1
kind: Upload
metadata:
  creationTimestamp: "2024-05-21T20:34:15Z"
  generation: 3
  labels:
    velero.io/exclude-from-backup: "true"
  name: upload-c281ff52-7313-4dc8-a7b4-3b294fff5c3b
  namespace: velero
  resourceVersion: "5554649"
  uid: 55979c20-a222-4da7-9fd1-cd366a0a2d75
spec:
  backupRepository: br-dd69c0f6-c587-478c-83d5-3693ce2e7288
  backupTimestamp: "2024-05-21T20:34:15Z"
  snapshotID: ivd:f0518a03-1b4d-49c0-8176-4164641116fc:c281ff52-7313-4dc8-a7b4-3b294fff5c3b
  snapshotReference: test-ns/snap-84e1f38c-1006-4803-b771-d2ed013c64df
status:
  completionTimestamp: "2024-05-21T20:34:26Z"
  message: Upload completed
  nextRetryTimestamp: "2024-05-21T20:34:15Z"
  phase: Completed
  processingNode: 10.182.3.172-00:50:56:a1:e4:64
  progress: {}
  startTimestamp: "2024-05-21T20:34:15Z"
```

Velero restore:
```
Name:         vds-backup8
Namespace:    velero
Labels:       <none>
Annotations:  <none>

Phase:                       Completed
Total items to be restored:  199
Items restored:              199

Started:    2024-05-21 20:36:41 +0000 UTC
Completed:  2024-05-21 20:40:20 +0000 UTC

Warnings:
  Velero:     <none>
  Cluster:  could not restore, CustomResourceDefinition "images.imagecontroller.vmware.com" already exists. Warning: the in-cluster version is different than the backed-up version
            could not restore, CustomResourceDefinition "internalpackagemetadatas.internal.packaging.carvel.dev" already exists. Warning: the in-cluster version is different than the backed-up version
            could not restore, CustomResourceDefinition "internalpackages.internal.packaging.carvel.dev" already exists. Warning: the in-cluster version is different than the backed-up version
            could not restore, CustomResourceDefinition "kubeadmcontrolplanetemplates.controlplane.cluster.x-k8s.io" already exists. Warning: the in-cluster version is different than the backed-up version
            could not restore, CustomResourceDefinition "storagepolicyquotas.cns.vmware.com" already exists. Warning: the in-cluster version is different than the backed-up version
            could not restore, CustomResourceDefinition "storagepolicyusages.cns.vmware.com" already exists. Warning: the in-cluster version is different than the backed-up version
            could not restore, CustomResourceDefinition "vsphereclustertemplates.vmware.infrastructure.cluster.x-k8s.io" already exists. Warning: the in-cluster version is different than the backed-up version
            could not restore, CustomResourceDefinition "vspheremachinetemplates.vmware.infrastructure.cluster.x-k8s.io" already exists. Warning: the in-cluster version is different than the backed-up version
  Namespaces:
    test-ns:  could not restore, ResourceQuota "test-ns-storagequota" already exists. Warning: the in-cluster version is different than the backed-up version
              could not restore, StoragePolicyQuota "wcpglobal-storage-profile-storagepolicyquota" already exists. Warning: the in-cluster version is different than the backed-up version
              could not restore, StoragePolicyUsage "wcpglobal-storage-profile-pvc-usage" already exists. Warning: the in-cluster version is different than the backed-up version

Backup:  vds-backup8

Namespaces:
  Included:  all namespaces found in the backup
  Excluded:  <none>

Resources:
  Included:        *
  Excluded:        nodes, events, events.events.k8s.io, backups.velero.io, restores.velero.io, resticrepositories.velero.io, csinodes.storage.k8s.io, volumeattachments.storage.k8s.io, backuprepositories.velero.io
  Cluster-scoped:  auto

Namespace mappings:  <none>

Label selector:  <none>

Or label selector:  <none>

Restore PVs:  auto

Existing Resource Policy:   <none>
ItemOperationTimeout:       4h0m0s

Preserve Service NodePorts:  auto


HooksAttempted:   0
HooksFailed:      0
```

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note

```
