### PR TITLE
Omit NSX Operator VPC CRs from Backup

### DIFF
--- a/docs/supervisor-notes.md
+++ b/docs/supervisor-notes.md
@@ -84,6 +84,15 @@ The default list of blocked resources in configmap is:
  	nsxlocks.nsx.vmware.com
  	nsxnetworkconfigurations.nsx.vmware.com
  	nsxnetworkinterfaces.nsx.vmware.com
+ 	vpcnetworkconfigurations.nsx.vmware.com
+ 	networkinfos.nsx.vmware.com
+ 	subnets.nsx.vmware.com
+ 	subnetsets.nsx.vmware.com
+ 	subnetports.nsx.vmware.com
+ 	staticroutes.nsx.vmware.com
+ 	ippools.nsx.vmware.com
+ 	securitypolicies.nsx.vmware.com
+ 	nsxserviceaccounts.nsx.vmware.com
  	orders.acme.cert-manager.io
  	persistenceinstanceinfoes.psp.wcp.vmware.com
  	persistenceserviceconfigurations.psp.wcp.vmware.com
@@ -140,6 +149,9 @@ The following resources are handled during the restore on the Supervisor Cluster
     * vmware-system-image-references
     * vmware-system-vm-moid
     * vmware-system-vm-uuid
+    * vmware-system-network
+    * nsx.vmware.com/attachment
+    * nsx.vmware.com/mac
 
 ## vSphere Plugin resources
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -270,7 +270,15 @@ var ResourcesToBlock = map[string]bool{
 	//"nsxloadbalancermonitors.vmware.com":                    true, // DO NOT ADD IT BACK
 	"nsxlocks.nsx.vmware.com":                                 true,
 	"nsxnetworkinterfaces.nsx.vmware.com":                     true,
+	"vpcnetworkconfigurations.nsx.vmware.com":                 true,
+	"networkinfos.nsx.vmware.com":                             true,
+	"subnets.nsx.vmware.com":                                  true,
+	"subnetsets.nsx.vmware.com":                               true,
+	"subnetports.nsx.vmware.com":                              true,
+	"staticroutes.nsx.vmware.com":                             true,
+	"securitypolicies.nsx.vmware.com":                         true,
 	"nsxnetworkconfigurations.nsx.vmware.com":                 true,
+	"nsxserviceaccounts.nsx.vmware.com":                       true,
 	"orders.acme.cert-manager.io":                             true,
 	"persistenceinstanceinfoes.psp.wcp.vmware.com":            true,
 	"persistenceserviceconfigurations.psp.wcp.vmware.com":     true,
@@ -360,6 +368,8 @@ var PodAnnotationsToSkip = map[string]bool{
 	"vmware-system-vm-moid":             true,
 	"vmware-system-vm-uuid":             true,
 	"vmware-system-network":             true,
+	"nsx.vmware.com/attachment":         true,
+	"nsx.vmware.com/mac":                true,
 }
 
 // UUID of the VM on Supervisor Cluster


### PR DESCRIPTION
**What this PR does / why we need it**:

This change supports addition of [NSX Operator v1alpha1 APIs](https://github.com/vmware-tanzu/nsx-operator/tree/main/pkg/apis/nsx.vmware.com/v1alpha1) to be omitted from Velero backups. These resources are being introduced into Supervisor, and must be omitted in order to support an accurate restore, as networking resources are generated dynamically and these networking resources and rules associated with them (such as `securitypolicies`) might not accurately reflect the original backup anymore.

Additionally, removes a few annotations from being backed up on vSphere pods related to NSX VPC networking.

**Which issue(s) this PR fixes**:

n/a

**Special notes for your reviewer**:

n/a

**Does this PR introduce a user-facing change?**:

```release-note
For Supervisor's using NSX Operator with VPC Networking, Velero backups will omit all NSX Operator v1alpha1 VPC APIs. vSphere Pods, Services, and any other resource's networking-related properties will need to be re-created by NSX Operator upon restore.
```

**Testing Done**:

* Performed a backup of a Supervisor namespace, supporting these CRs, with a few vSphere Pods, Services, as well as a few custom Subnet(s), SubnetSet(s), SubnetPorts, etc.
* Inspected the backup JSON schema and validated none of these Custom Resource names are referenced in the backup.
* Applied a restore to a new namespace and verified that no networking resources were restored - rather, they were dynamically created. Additionally, validated that the vSphere Pods and Services were able to generate fresh IPs for consumption. All custom-generated networking resources in the original backup were not applied.
* Validated pods were given unique `nsx.vmware.com/mac` and `nsx.vmware.com/attachment` annotations.
* Validated the same restore to a new namespace with differing CIDR ranges applicable to ensure no overlap of IPs applied would occur.

-- 

I also performed a manual negative test by testing `main`, in which the above backup did retain the NSX VPC CRs, which caused issue on restore as vSphere Pods and services were not able to successfully retain their previous networking and NSX Operator was not able to fully apply networking resources to the existing Pods.