### PR TITLE
Add updated NSX Operator CRDs

### DIFF
--- a/docs/supervisor-notes.md
+++ b/docs/supervisor-notes.md
@@ -26,6 +26,7 @@ The default list of blocked resources in configmap is:
 
 ### vSphere with Tanzu Supervisor Cluster resources
 
+ 	addressbindings.crd.nsx.vmware.com
  	agentinstalls.installers.tmc.cloud.vmware.com
  	availabilityzones.topology.tanzu.vmware.com
  	aviloadbalancerconfigs.netoperator.vmware.com
@@ -57,9 +58,11 @@ The default list of blocked resources in configmap is:
  	imagedisks.imagecontroller.vmware.com
  	installoptions.appplatform.wcp.vmware.com
  	installrequirements.appplatform.wcp.vmware.com
+ 	ipaddressallocations.crd.nsx.vmware.com
  	ipamblocks.crd.projectcalico.org
  	ipamconfigs.crd.projectcalico.org
  	ipamhandles.crd.projectcalico.org
+ 	ipblocksinfos.crd.nsx.vmware.com
  	ippools.crd.projectcalico.org
  	ippools.netoperator.vmware.com
  	ippools.nsx.vmware.com
@@ -78,20 +81,13 @@ The default list of blocked resources in configmap is:
  	members.registryagent.vmware.com
  	namespacenetworkinfos.nsx.vmware.com
  	ncpconfigs.nsx.vmware.com
+ 	networkinfos.crd.nsx.vmware.com
  	networkinterfaces.netoperator.vmware.com
  	networks.netoperator.vmware.com
  	nsxerrors.nsx.vmware.com
  	nsxlocks.nsx.vmware.com
  	nsxnetworkconfigurations.nsx.vmware.com
  	nsxnetworkinterfaces.nsx.vmware.com
- 	vpcnetworkconfigurations.nsx.vmware.com
- 	networkinfos.nsx.vmware.com
- 	subnets.nsx.vmware.com
- 	subnetsets.nsx.vmware.com
- 	subnetports.nsx.vmware.com
- 	staticroutes.nsx.vmware.com
- 	ippools.nsx.vmware.com
- 	securitypolicies.nsx.vmware.com
  	nsxserviceaccounts.nsx.vmware.com
  	orders.acme.cert-manager.io
  	persistenceinstanceinfoes.psp.wcp.vmware.com
@@ -104,11 +100,17 @@ The default list of blocked resources in configmap is:
  	resourcecheckreports.psp.wcp.vmware.com
  	resourcechecks.psp.wcp.vmware.com
  	routesets.nsx.vmware.com
+ 	securitypolicies.crd.nsx.vmware.com
+ 	securitypolicies.nsx.vmware.com
  	statefuldrainnodes.psp.wcp.vmware.com
  	statefulreadynodes.psp.wcp.vmware.com
+ 	staticroutes.crd.nsx.vmware.com
  	storagepolicies.appplatform.wcp.vmware.com
  	storagepolicies.psp.wcp.vmware.com
  	storagepools.cns.vmware.com
+ 	subnets.crd.nsx.vmware.com
+ 	subnetports.crd.nsx.vmware.com
+ 	subnetsets.crd.nsx.vmware.com
  	supervisorservices.appplatform.wcp.vmware.com
  	tanzukubernetesaddons.run.tanzu.vmware.com
  	tanzukubernetesclusters.run.tanzu.vmware.com
@@ -126,6 +128,7 @@ The default list of blocked resources in configmap is:
  	virtualnetworkinterfaces.vmware.com
  	virtualnetworks.vmware.com
  	vmxnet3networkinterfaces.netoperator.vmware.com
+ 	vpcnetworkconfigurations.crd.nsx.vmware.com
  	vspheredistributednetworks.netoperator.vmware.com
  	wcpclusters.infrastructure.cluster.vmware.com
  	wcpmachines.infrastructure.cluster.vmware.com

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -206,6 +206,7 @@ const (
 // words get an "s" attached.
 var ResourcesToBlock = map[string]bool{
 	// Kubernetes with vSphere Supervisor Cluster resources
+	"addressbindings.crd.nsx.vmware.com":                 true,
 	"agentinstalls.installers.tmc.cloud.vmware.com":      true,
 	"availabilityzones.topology.tanzu.vmware.com":        true,
 	"aviloadbalancerconfigs.netoperator.vmware.com":      true,
@@ -239,9 +240,11 @@ var ResourcesToBlock = map[string]bool{
 	//"images.imagecontroller.vmware.com":                     true, // DO NOT ADD IT BACK
 	"installoptions.appplatform.wcp.vmware.com":          true,
 	"installrequirements.appplatform.wcp.vmware.com":     true,
+	"ipaddressallocations.crd.nsx.vmware.com":            true,
 	"ipamblocks.crd.projectcalico.org":                   true,
 	"ipamconfigs.crd.projectcalico.org":                  true,
 	"ipamhandles.crd.projectcalico.org":                  true,
+	"ipblocksinfos.crd.nsx.vmware.com":                   true,
 	"ippools.crd.projectcalico.org":                      true,
 	"ippools.netoperator.vmware.com":                     true,
 	"ippools.nsx.vmware.com":                             true,
@@ -263,6 +266,7 @@ var ResourcesToBlock = map[string]bool{
 	// We comment the NetworkAttachmentDefinition resource out as it is not a vSphere specific resource
 	//"network-attachment-definitions.k8s.cni.cncf.io":     true, // real name of NetworkAttachmentDefinition
 	//"networkattachmentdefinitions.k8s.cni.cncf.io":       true, // parsed name of NetworkAttachmentDefinition
+	"networkinfos.crd.nsx.vmware.com":          true,
 	"networkinterfaces.netoperator.vmware.com": true,
 	"networks.netoperator.vmware.com":          true,
 	"nsxerrors.nsx.vmware.com":                 true,
@@ -270,13 +274,6 @@ var ResourcesToBlock = map[string]bool{
 	//"nsxloadbalancermonitors.vmware.com":                    true, // DO NOT ADD IT BACK
 	"nsxlocks.nsx.vmware.com":                                 true,
 	"nsxnetworkinterfaces.nsx.vmware.com":                     true,
-	"vpcnetworkconfigurations.nsx.vmware.com":                 true,
-	"networkinfos.nsx.vmware.com":                             true,
-	"subnets.nsx.vmware.com":                                  true,
-	"subnetsets.nsx.vmware.com":                               true,
-	"subnetports.nsx.vmware.com":                              true,
-	"staticroutes.nsx.vmware.com":                             true,
-	"securitypolicies.nsx.vmware.com":                         true,
 	"nsxnetworkconfigurations.nsx.vmware.com":                 true,
 	"nsxserviceaccounts.nsx.vmware.com":                       true,
 	"orders.acme.cert-manager.io":                             true,
@@ -290,11 +287,17 @@ var ResourcesToBlock = map[string]bool{
 	"resourcecheckreports.psp.wcp.vmware.com":                 true,
 	"resourcechecks.psp.wcp.vmware.com":                       true,
 	"routesets.nsx.vmware.com":                                true,
+	"securitypolicies.crd.nsx.vmware.com":                     true,
+	"securitypolicies.nsx.vmware.com":                         true,
 	"statefuldrainnodes.psp.wcp.vmware.com":                   true,
 	"statefulreadynodes.psp.wcp.vmware.com":                   true,
+	"staticroutes.crd.nsx.vmware.com":                         true,
 	"storagepolicies.appplatform.wcp.vmware.com":              true,
 	"storagepolicies.psp.wcp.vmware.com":                      true,
 	"storagepools.cns.vmware.com":                             true,
+	"subnetports.crd.nsx.vmware.com":                          true,
+	"subnets.crd.nsx.vmware.com":                              true,
+	"subnetsets.crd.nsx.vmware.com":                           true,
 	"supervisorservices.appplatform.wcp.vmware.com":           true,
 	"tanzukubernetesaddons.run.tanzu.vmware.com":              true,
 	"tanzukubernetesclusters.run.tanzu.vmware.com":            true,
@@ -312,6 +315,7 @@ var ResourcesToBlock = map[string]bool{
 	"virtualnetworkinterfaces.vmware.com":                     true,
 	"virtualnetworks.vmware.com":                              true,
 	"vmxnet3networkinterfaces.netoperator.vmware.com":         true,
+	"vpcnetworkconfigurations.crd.nsx.vmware.com":             true,
 	"vspheredistributednetworks.netoperator.vmware.com":       true,
 	"wcpclusters.infrastructure.cluster.vmware.com":           true,
 	"wcpnamespaces.appplatform.wcp.vmware.com":                true,


### PR DESCRIPTION
**What this PR does / why we need it**:

This change addresses some updates to NSX Operator CRDs. NSX Operator has updated their API Group from "nsx.vmware.com" to "crd.nsx.vmware.com" for a handful of their CRDs - particularly related to VPCs. Additionally, a few CRDs have been removed/added. These CRDs are yet to be released, so there is no breaking change here.

NSX T1-based CRDs are unchanged.

**Which issue(s) this PR fixes**:

n/a

**Special notes for your reviewer**:

n/a

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

## Testing Done

### Setup

I deployed a Supervisor with NSX VPC. I created a namespace with corresponding resources updated in this ConfigMap. Additionally, `subnetsets.crd.nsx.vmware.com` and `networkinfos.crd.nsx.vmware.com` are already present by default. Finally, I installed Velero with this custom Velero vSphere Plugin.

### Tests

* [x] Validated the `velero-vsphere-plugin-blocked-resources-list` successfully shows the resources I added in this PR.

```shell
$ kubectl -n velero get configmap velero-vsphere-plugin-blocked-resources-list -o yaml | grep "crd.nsx.vmware.com"
  addressbindings.crd.nsx.vmware.com: "true"
  ipaddressallocations.crd.nsx.vmware.com: "true"
  ipblocksinfos.crd.nsx.vmware.com: "true"
  networkinfos.crd.nsx.vmware.com: "true"
  securitypolicies.crd.nsx.vmware.com: "true"
  staticroutes.crd.nsx.vmware.com: "true"
  subnetports.crd.nsx.vmware.com: "true"
  subnets.crd.nsx.vmware.com: "true"
  subnetsets.crd.nsx.vmware.com: "true"
  vpcnetworkconfigurations.crd.nsx.vmware.com: "true"
```

* [x] Created a backup of a namespace with no manual exclusions. Validated that the resources in the backup show an error on the resources I added to be blocked (sample below), and that the `--details` view shows that no NSX CRDs are backed up.

```shell
Errors:
...
             name: /pod-default message: /Error backing up item error: /error executing custom action (groupResource=subnetsets.crd.nsx.vmware.com, namespace=popularimages-ns, name=pod-default): rpc error: code = Unknown desc = Resource CRD subnetsets.crd.nsx.vmware.com is blocked in backup, skipping
...
```

Logs also indicated this:

```shell
time="2024-09-17T16:38:26Z" level=info msg="Backing up resource subnetsets.crd.nsx.vmware.com: blocked = true" backup=velero/backup cmd=/plugins/velero-plugin-for-vsphere logSource="/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/plugin/backup_pvc_action_plugin.go:66" pluginName=velero-plugin-for-vsphere
time="2024-09-17T16:38:26Z" level=error msg="Error backing up item" backup=velero/backup error="error executing custom action (groupResource=subnetsets.crd.nsx.vmware.com, namespace=popularimages-ns, name=vm-default): rpc error: code = Unknown desc = Resource CRD subnetsets.crd.nsx.vmware.com is blocked in backup, skipping" error.file="/go/src/github.com/vmware-tanzu/velero/pkg/backup/item_backupper.go:380" error.function="github.com/vmware-tanzu/velero/pkg/backup.(*itemBackupper).executeActions" logSource="pkg/backup/backup.go:461" name=vm-default
```

* [x] Validated that restoring the resources did not create new NSX CRDs that were blocked from the backup.