### PR TITLE
Block Storage Quota related CRs from Supervisor namespace backup

### DIFF
--- a/docs/supervisor-notes.md
+++ b/docs/supervisor-notes.md
@@ -135,6 +135,10 @@ The default list of blocked resources in configmap is:
  	wcpmachinetemplates.infrastructure.cluster.vmware.com
  	wcpnamespaces.appplatform.wcp.vmware.com
  	webconsolerequests.vmoperator.vmware.com
+ 	storagequotaperiodicsyncs.cns.vmware.com
+ 	storagepolicyusages.cns.vmware.com
+ 	storagepolicyquotas.cns.vmware.com
+ 	storagequotas.cns.vmware.com
 
 For example, the backup of a Supervisor ```namespace``` with **Tanzu Kubernetes Grid Service** will fail since it contains some of restricted resources listed above.
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -331,6 +331,12 @@ var ResourcesToBlock = map[string]bool{
 	"downloads.datamover.cnsdp.vmware.com":                 true,
 	"snapshots.backupdriver.cnsdp.vmware.com":              true,
 	"uploads.datamover.cnsdp.vmware.com":                   true,
+
+	// StorageQuota resources
+	"storagequotaperiodicsyncs.cns.vmware.com": true,
+	"storagepolicyusages.cns.vmware.com":       true,
+	"storagepolicyquotas.cns.vmware.com":       true,
+	"storagequotas.cns.vmware.com":             true,
 }
 
 var ResourcesToBlockOnRestore = map[string]bool{


### PR DESCRIPTION
**What this PR does / why we need it**:
Blocking StorageQuota related CRs from Supervisor Namespace backup

**Testing**
```
go test ./pkg/... -timeout=300s
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/apis/backupdriver/v1alpha1        [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/apis/datamover/v1alpha1   [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/backupdriver      [no test files]
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/backuprepository  0.700s
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/builder   [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/buildinfo [no test files]
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/cmd       0.726s
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/cmd/backupdriver  [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/cmd/backupdriver/cli/install      [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/cmd/backupdriver/cli/server       [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/cmd/datamgr       [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/cmd/datamgr/cli/install   [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/cmd/datamgr/cli/server    [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/common/config     [no test files]
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/common/vsphere    0.243s
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/constants [no test files]
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/controller        0.604s
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/dataMover [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned     [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/fake        [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/scheme      [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/typed/backupdriver/v1alpha1 [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/typed/backupdriver/v1alpha1/fake    [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/typed/datamover/v1alpha1    [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/typed/datamover/v1alpha1/fake       [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/crds    [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/informers/externalversions      [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/informers/externalversions/backupdriver [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/informers/externalversions/backupdriver/v1alpha1        [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/informers/externalversions/datamover    [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/informers/externalversions/datamover/v1alpha1   [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/informers/externalversions/internalinterfaces   [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/listers/backupdriver/v1alpha1   [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/listers/datamover/v1alpha1      [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/install   [no test files]
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/ivd       0.317s
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/paravirt  0.550s
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/plugin    [no test files]
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/plugin/util       0.195s
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/snapshotUtils     0.197s
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/snapshotmgr       0.295s
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/test      [no test files]
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/utils     0.202s
Success!


```


**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Block StorageQuota related CRDs from backup
```
