### PR TITLE
Update to Photon 5

### DIFF
--- a/Dockerfile-backup-driver
+++ b/Dockerfile-backup-driver
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM photon:4.0
+FROM photon:5.0
 RUN tdnf -y upgrade && tdnf clean all
 COPY /bin/linux/amd64/lib/vmware-vix-disklib/lib64/* /vddkLibs/
 ADD /bin/linux/amd64/backup-driver* /backup-driver

--- a/Dockerfile-datamgr
+++ b/Dockerfile-datamgr
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-FROM photon:4.0
+FROM photon:5.0
 RUN tdnf -y upgrade && tdnf clean all
 ADD /bin/linux/amd64/data-* /datamgr
 COPY /bin/linux/amd64/lib/vmware-vix-disklib/lib64/* /vddkLibs/

--- a/Dockerfile-plugin
+++ b/Dockerfile-plugin
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-FROM photon:4.0
+FROM photon:5.0
 RUN tdnf -y upgrade && tdnf clean all
 ADD /bin/linux/amd64/velero-* /plugins/
 ADD /bin/linux/amd64/data-* /


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrade all dockerfiles to photon 5

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Testing
make all

```
go test ./pkg/... -timeout=300s
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/apis/backupdriver/v1alpha1        [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/apis/datamover/v1alpha1   [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/backupdriver      [no test files]
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/backuprepository  (cached)
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/builder   [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/buildinfo [no test files]
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/cmd       (cached)
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/cmd/backupdriver  [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/cmd/backupdriver/cli/install      [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/cmd/backupdriver/cli/server       [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/cmd/datamgr       [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/cmd/datamgr/cli/install   [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/cmd/datamgr/cli/server    [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/common/config     [no test files]
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/common/vsphere    (cached)
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/constants [no test files]
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/controller        (cached)
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/dataMover [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned     [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/fake        [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/scheme      [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/typed/backupdriver/v1alpha1 [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/typed/backupdriver/v1alpha1/fake    [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/typed/datamover/v1alpha1    [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/typed/datamover/v1alpha1/fake       [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/crds    [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/informers/externalversions      [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/informers/externalversions/backupdriver [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/informers/externalversions/backupdriver/v1alpha1        [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/informers/externalversions/datamover    [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/informers/externalversions/datamover/v1alpha1   [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/informers/externalversions/internalinterfaces   [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/listers/backupdriver/v1alpha1   [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/listers/datamover/v1alpha1      [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/install   [no test files]
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/ivd       (cached)
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/paravirt  (cached)
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/plugin    [no test files]
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/plugin/util       (cached)
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/snapshotUtils     (cached)
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/snapshotmgr       (cached)
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/test      [no test files]
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/utils     (cached)
Success!


```


**Does this PR introduce a user-facing change?**:
```release-note
Photon 5 Upgrade
```
