### PR TITLE
Remove metrics support

### DIFF
--- a/pkg/cmd/backupdriver/cli/server/server.go
+++ b/pkg/cmd/backupdriver/cli/server/server.go
@@ -73,7 +73,6 @@ func NewCommand(f client.Factory) *cobra.Command {
 	var (
 		logLevelFlag = logging.LogLevelFlag(logrus.InfoLevel)
 		config       = serverConfig{
-			metricsAddress:     cmd.DefaultMetricsAddress,
 			clientQPS:          cmd.DefaultClientQPS,
 			clientBurst:        cmd.DefaultClientBurst,
 			profilerAddress:    cmd.DefaultProfilerAddress,
@@ -127,7 +126,6 @@ func NewCommand(f client.Factory) *cobra.Command {
 	// Common flags
 	command.Flags().Var(logLevelFlag, "log-level", fmt.Sprintf("the level at which to log. Valid values are %s.", strings.Join(logLevelFlag.AllowedValues(), ", ")))
 	command.Flags().Var(config.formatFlag, "log-format", fmt.Sprintf("the format for log output. Valid values are %s.", strings.Join(config.formatFlag.AllowedValues(), ", ")))
-	command.Flags().StringVar(&config.metricsAddress, "metrics-address", config.metricsAddress, "the address to expose prometheus metrics")
 	command.Flags().Float32Var(&config.clientQPS, "client-qps", config.clientQPS, "maximum number of requests per second by the server to the Kubernetes API once the burst limit has been reached")
 	command.Flags().IntVar(&config.clientBurst, "client-burst", config.clientBurst, "maximum number of requests by the server to the Kubernetes API in a short period of time")
 	command.Flags().StringVar(&config.profilerAddress, "profiler-address", config.profilerAddress, "the address to expose the pprof profiler")
@@ -312,7 +310,6 @@ func newServer(f client.Factory, config serverConfig, logger *logrus.Logger) (*s
 
 	s := &server{
 		namespace:                      f.Namespace(),
-		metricsAddress:                 config.metricsAddress,
 		kubeClient:                     kubeClient,
 		backupdriverClient:             backupdriverClient,
 		datamoverClient:                datamoverClient,

--- a/pkg/cmd/constants.go
+++ b/pkg/cmd/constants.go
@@ -17,9 +17,6 @@ limitations under the License.
 package cmd
 
 const (
-	// the port where prometheus metrics are exposed
-	DefaultMetricsAddress = ":8085"
-
 	// server's client default qps and burst
 	DefaultClientQPS   float32 = 100.0
 	DefaultClientBurst int     = 100

--- a/pkg/cmd/datamgr/cli/server/server.go
+++ b/pkg/cmd/datamgr/cli/server/server.go
@@ -54,7 +54,6 @@ import (
 )
 
 type serverConfig struct {
-	metricsAddress     string
 	clientQPS          float32
 	clientBurst        int
 	profilerAddress    string
@@ -71,7 +70,6 @@ func NewCommand(f client.Factory) *cobra.Command {
 	var (
 		logLevelFlag = logging.LogLevelFlag(logrus.InfoLevel)
 		config       = serverConfig{
-			metricsAddress:     cmd.DefaultMetricsAddress,
 			clientQPS:          cmd.DefaultClientQPS,
 			clientBurst:        cmd.DefaultClientBurst,
 			profilerAddress:    cmd.DefaultProfilerAddress,
@@ -122,7 +120,6 @@ func NewCommand(f client.Factory) *cobra.Command {
 	// Common flags
 	command.Flags().Var(logLevelFlag, "log-level", fmt.Sprintf("the level at which to log. Valid values are %s.", strings.Join(logLevelFlag.AllowedValues(), ", ")))
 	command.Flags().Var(config.formatFlag, "log-format", fmt.Sprintf("the format for log output. Valid values are %s.", strings.Join(config.formatFlag.AllowedValues(), ", ")))
-	command.Flags().StringVar(&config.metricsAddress, "metrics-address", config.metricsAddress, "the address to expose prometheus metrics")
 	command.Flags().Float32Var(&config.clientQPS, "client-qps", config.clientQPS, "maximum number of requests per second by the server to the Kubernetes API once the burst limit has been reached")
 	command.Flags().IntVar(&config.clientBurst, "client-burst", config.clientBurst, "maximum number of requests by the server to the Kubernetes API in a short period of time")
 	command.Flags().StringVar(&config.profilerAddress, "profiler-address", config.profilerAddress, "the address to expose the pprof profiler")
@@ -287,7 +284,6 @@ func newServer(f client.Factory, config serverConfig, logger *logrus.Logger) (*s
 
 	s := &server{
 		namespace:             f.Namespace(),
-		metricsAddress:        config.metricsAddress,
 		kubeClient:            kubeClient,
 		pluginClient:          pluginClient,
 		pluginInformerFactory: pluginInformers.NewSharedInformerFactoryWithOptions(pluginClient, constants.ResyncPeriod, pluginInformers.WithNamespace(f.Namespace())),


### PR DESCRIPTION
**What this PR does / why we need it**:
The default metrics port is causing issue during velero installation. This change removes metrics support. This is safe since metrics are not being reported in the repo.


**Which issue(s) this PR fixes**:
Fixes # PR 3471190

**Special notes for your reviewer**:
None

**Testing**:
```
make all
❯ make all
making: datamgr
/Library/Developer/CommandLineTools/usr/bin/make build BIN=data-manager-for-plugin VERSION=topic/deepakkinni/remove_met_add_v1-80def43-13.Jan.2025.11.28.48
skip copying astrolabe as it is not available at /Users/dkinni/go/src/github.com/vmware-tanzu/astrolabe
building: _output/bin/linux/amd64/data-manager-for-plugin
/Library/Developer/CommandLineTools/usr/bin/make shell CMD="-c '\
                GOOS=linux \
                GOARCH=amd64 \
                REGISTRY=dpcpinternal \
                VERSION=topic/deepakkinni/remove_met_add_v1-80def43-13.Jan.2025.11.28.48 \
                PKG=github.com/vmware-tanzu/velero-plugin-for-vsphere \
                BIN=data-manager-for-plugin \
                GIT_SHA=80def4348cd892dd2444753ead789f2b4b40b0a4 \
                GIT_DIRTY=\" M pkg/cmd/backupdriver/cli/server/server.go  M pkg/cmd/constants.go  M pkg/cmd/datamgr/cli/server/server.go\" \
                OUTPUT_DIR=/output/linux/amd64 \
                GO111MODULE=on \
                GOFLAGS=-mod=readonly \
                ./hack/build.sh'"
running docker: shell
docker run \
                --platform linux/amd64 \
                -e GOFLAGS \
                -i -t \
                --rm \
                -u $(id -u):$(id -g) \
                -v $(pwd)/.libs/vmware-vix-disklib-distrib:/usr/local/vmware-vix-disklib-distrib:delegated \
                -v $(pwd)/.go/pkg:/go/pkg:delegated \
                -v $(pwd)/.go/src:/go/src:delegated \
                -v $(pwd)/.go/std:/go/std:delegated \
                -v $(pwd):/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere:delegated \
                -v "$(pwd)/_output/bin:/output:delegated" \
                -v $(pwd)/.go/std/linux/amd64:/usr/local/go/pkg/linux/amd64_static:delegated \
                -v "$(pwd)/.go/go-build:/.cache/go-build:delegated" \
                -e CGO_ENABLED=1 \
                -e GOPATH=/go \
                -w /go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere \
                golang:1.18 \
                /bin/sh -c '    GOOS=linux      GOARCH=amd64    REGISTRY=dpcpinternal   VERSION=topic/deepakkinni/remove_met_add_v1-80def43-13.Jan.2025.11.28.48        PKG=github.com/vmware-tanzu/velero-plugin-for-vsphere   BIN=data-manager-for-plugin     GIT_SHA=80def4348cd892dd2444753ead789f2b4b40b0a4       GIT_DIRTY=" M pkg/cmd/backupdriver/cli/server/server.go  M pkg/cmd/constants.go  M pkg/cmd/datamgr/cli/server/server.go"         OUTPUT_DIR=/output/linux/amd64  GO111MODULE=on  GOFLAGS=-mod=readonly   ./hack/build.sh'
making: backup-driver
/Library/Developer/CommandLineTools/usr/bin/make build BIN=backup-driver VERSION=topic/deepakkinni/remove_met_add_v1-80def43-13.Jan.2025.11.28.48
skip copying astrolabe as it is not available at /Users/dkinni/go/src/github.com/vmware-tanzu/astrolabe
building: _output/bin/linux/amd64/backup-driver
/Library/Developer/CommandLineTools/usr/bin/make shell CMD="-c '\
                GOOS=linux \
                GOARCH=amd64 \
                REGISTRY=dpcpinternal \
                VERSION=topic/deepakkinni/remove_met_add_v1-80def43-13.Jan.2025.11.28.48 \
                PKG=github.com/vmware-tanzu/velero-plugin-for-vsphere \
                BIN=backup-driver \
                GIT_SHA=80def4348cd892dd2444753ead789f2b4b40b0a4 \
                GIT_DIRTY=\" M pkg/cmd/backupdriver/cli/server/server.go  M pkg/cmd/constants.go  M pkg/cmd/datamgr/cli/server/server.go\" \
                OUTPUT_DIR=/output/linux/amd64 \
                GO111MODULE=on \
                GOFLAGS=-mod=readonly \
                ./hack/build.sh'"
running docker: shell
docker run \
                --platform linux/amd64 \
                -e GOFLAGS \
                -i -t \
                --rm \
                -u $(id -u):$(id -g) \
                -v $(pwd)/.libs/vmware-vix-disklib-distrib:/usr/local/vmware-vix-disklib-distrib:delegated \
                -v $(pwd)/.go/pkg:/go/pkg:delegated \
                -v $(pwd)/.go/src:/go/src:delegated \
                -v $(pwd)/.go/std:/go/std:delegated \
                -v $(pwd):/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere:delegated \
                -v "$(pwd)/_output/bin:/output:delegated" \
                -v $(pwd)/.go/std/linux/amd64:/usr/local/go/pkg/linux/amd64_static:delegated \
                -v "$(pwd)/.go/go-build:/.cache/go-build:delegated" \
                -e CGO_ENABLED=1 \
                -e GOPATH=/go \
                -w /go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere \
                golang:1.18 \
                /bin/sh -c '    GOOS=linux      GOARCH=amd64    REGISTRY=dpcpinternal   VERSION=topic/deepakkinni/remove_met_add_v1-80def43-13.Jan.2025.11.28.48        PKG=github.com/vmware-tanzu/velero-plugin-for-vsphere   BIN=backup-driver       GIT_SHA=80def4348cd892dd2444753ead789f2b4b40b0a4        GIT_DIRTY=" M pkg/cmd/backupdriver/cli/server/server.go  M pkg/cmd/constants.go  M pkg/cmd/datamgr/cli/server/server.go"        OUTPUT_DIR=/output/linux/amd64  GO111MODULE=on  GOFLAGS=-mod=readonly   ./hack/build.sh'
making: plugin
/Library/Developer/CommandLineTools/usr/bin/make build BIN=velero-plugin-for-vsphere VERSION=topic/deepakkinni/remove_met_add_v1-80def43-13.Jan.2025.11.28.48
skip copying astrolabe as it is not available at /Users/dkinni/go/src/github.com/vmware-tanzu/astrolabe
building: _output/bin/linux/amd64/velero-plugin-for-vsphere
/Library/Developer/CommandLineTools/usr/bin/make shell CMD="-c '\
                GOOS=linux \
                GOARCH=amd64 \
                REGISTRY=dpcpinternal \
                VERSION=topic/deepakkinni/remove_met_add_v1-80def43-13.Jan.2025.11.28.48 \
                PKG=github.com/vmware-tanzu/velero-plugin-for-vsphere \
                BIN=velero-plugin-for-vsphere \
                GIT_SHA=80def4348cd892dd2444753ead789f2b4b40b0a4 \
                GIT_DIRTY=\" M pkg/cmd/backupdriver/cli/server/server.go  M pkg/cmd/constants.go  M pkg/cmd/datamgr/cli/server/server.go\" \
                OUTPUT_DIR=/output/linux/amd64 \
                GO111MODULE=on \
                GOFLAGS=-mod=readonly \
                ./hack/build.sh'"
running docker: shell
docker run \
                --platform linux/amd64 \
                -e GOFLAGS \
                -i -t \
                --rm \
                -u $(id -u):$(id -g) \
                -v $(pwd)/.libs/vmware-vix-disklib-distrib:/usr/local/vmware-vix-disklib-distrib:delegated \
                -v $(pwd)/.go/pkg:/go/pkg:delegated \
                -v $(pwd)/.go/src:/go/src:delegated \
                -v $(pwd)/.go/std:/go/std:delegated \
                -v $(pwd):/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere:delegated \
                -v "$(pwd)/_output/bin:/output:delegated" \
                -v $(pwd)/.go/std/linux/amd64:/usr/local/go/pkg/linux/amd64_static:delegated \
                -v "$(pwd)/.go/go-build:/.cache/go-build:delegated" \
                -e CGO_ENABLED=1 \
                -e GOPATH=/go \
                -w /go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere \
                golang:1.18 \
                /bin/sh -c '    GOOS=linux      GOARCH=amd64    REGISTRY=dpcpinternal   VERSION=topic/deepakkinni/remove_met_add_v1-80def43-13.Jan.2025.11.28.48        PKG=github.com/vmware-tanzu/velero-plugin-for-vsphere   BIN=velero-plugin-for-vsphere   GIT_SHA=80def4348cd892dd2444753ead789f2b4b40b0a4       GIT_DIRTY=" M pkg/cmd/backupdriver/cli/server/server.go  M pkg/cmd/constants.go  M pkg/cmd/datamgr/cli/server/server.go"         OUTPUT_DIR=/output/linux/amd64  GO111MODULE=on  GOFLAGS=-mod=readonly   ./hack/build.sh'
making: vsphere-astrolabe
/Library/Developer/CommandLineTools/usr/bin/make build BIN=vsphere-astrolabe VERSION=topic/deepakkinni/remove_met_add_v1-80def43-13.Jan.2025.11.28.48
skip copying astrolabe as it is not available at /Users/dkinni/go/src/github.com/vmware-tanzu/astrolabe
building: _output/bin/linux/amd64/vsphere-astrolabe
/Library/Developer/CommandLineTools/usr/bin/make shell CMD="-c '\
                GOOS=linux \
                GOARCH=amd64 \
                REGISTRY=dpcpinternal \
                VERSION=topic/deepakkinni/remove_met_add_v1-80def43-13.Jan.2025.11.28.48 \
                PKG=github.com/vmware-tanzu/velero-plugin-for-vsphere \
                BIN=vsphere-astrolabe \
                GIT_SHA=80def4348cd892dd2444753ead789f2b4b40b0a4 \
                GIT_DIRTY=\" M pkg/cmd/backupdriver/cli/server/server.go  M pkg/cmd/constants.go  M pkg/cmd/datamgr/cli/server/server.go\" \
                OUTPUT_DIR=/output/linux/amd64 \
                GO111MODULE=on \
                GOFLAGS=-mod=readonly \
                ./hack/build.sh'"
running docker: shell
docker run \
                --platform linux/amd64 \
                -e GOFLAGS \
                -i -t \
                --rm \
                -u $(id -u):$(id -g) \
                -v $(pwd)/.libs/vmware-vix-disklib-distrib:/usr/local/vmware-vix-disklib-distrib:delegated \
                -v $(pwd)/.go/pkg:/go/pkg:delegated \
                -v $(pwd)/.go/src:/go/src:delegated \
                -v $(pwd)/.go/std:/go/std:delegated \
                -v $(pwd):/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere:delegated \
                -v "$(pwd)/_output/bin:/output:delegated" \
                -v $(pwd)/.go/std/linux/amd64:/usr/local/go/pkg/linux/amd64_static:delegated \
                -v "$(pwd)/.go/go-build:/.cache/go-build:delegated" \
                -e CGO_ENABLED=1 \
                -e GOPATH=/go \
                -w /go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere \
                golang:1.18 \
                /bin/sh -c '    GOOS=linux      GOARCH=amd64    REGISTRY=dpcpinternal   VERSION=topic/deepakkinni/remove_met_add_v1-80def43-13.Jan.2025.11.28.48        PKG=github.com/vmware-tanzu/velero-plugin-for-vsphere   BIN=vsphere-astrolabe   GIT_SHA=80def4348cd892dd2444753ead789f2b4b40b0a4        GIT_DIRTY=" M pkg/cmd/backupdriver/cli/server/server.go  M pkg/cmd/constants.go  M pkg/cmd/datamgr/cli/server/server.go"        OUTPUT_DIR=/output/linux/amd64  GO111MODULE=on  GOFLAGS=-mod=readonly   ./hack/build.sh'

```
Unit Test
```
❯ make test
running docker: shell
docker run \
                --platform linux/amd64 \
                -e GOFLAGS \
                -i -t \
                --rm \
                -u $(id -u):$(id -g) \
                -v $(pwd)/.libs/vmware-vix-disklib-distrib:/usr/local/vmware-vix-disklib-distrib:delegated \
                -v $(pwd)/.go/pkg:/go/pkg:delegated \
                -v $(pwd)/.go/src:/go/src:delegated \
                -v $(pwd)/.go/std:/go/std:delegated \
                -v $(pwd):/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere:delegated \
                -v "$(pwd)/_output/bin:/output:delegated" \
                -v $(pwd)/.go/std/linux/amd64:/usr/local/go/pkg/linux/amd64_static:delegated \
                -v "$(pwd)/.go/go-build:/.cache/go-build:delegated" \
                -e CGO_ENABLED=1 \
                -e GOPATH=/go \
                -w /go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere \
                golang:1.18 \
                /bin/sh -c '     VDDK_LIBS=github.com/vmware-tanzu/velero-plugin-for-vsphere/.libs/vmware-vix-disklib-distrib/lib64      TARGETS=./pkg/...      TIMEOUT=300s      VERBOSE=      DISABLE_CACHE=      RUN_SINGLE_CASE=      hack/test.sh'
Running tests: ./pkg/...
go test ./pkg/... -timeout=300s
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/apis/backupdriver/v1alpha1        [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/apis/datamover/v1alpha1   [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/backupdriver      [no test files]
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/backuprepository  0.178s
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/builder   [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/buildinfo [no test files]
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/cmd       0.154s
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/cmd/backupdriver  [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/cmd/backupdriver/cli/install      [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/cmd/backupdriver/cli/server       [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/cmd/datamgr       [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/cmd/datamgr/cli/install   [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/cmd/datamgr/cli/server    [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/common/config     [no test files]
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/common/vsphere    0.052s
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/constants [no test files]
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/controller        0.205s
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/dataMover [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned     [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/fake        [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/scheme      [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/typed/backupdriver/v1alpha1 [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/typed/backupdriver/v1alpha1/fake    [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/typed/datamover/v1alpha1    [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/typed/datamover/v1alpha1/fake       [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/crds    [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/informers/externalversions      [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/informers/externalversions/backupdriver [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/informers/externalversions/backupdriver/v1alpha1        [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/informers/externalversions/datamover    [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/informers/externalversions/datamover/v1alpha1   [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/informers/externalversions/internalinterfaces   [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/listers/backupdriver/v1alpha1   [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/listers/datamover/v1alpha1      [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/install   [no test files]
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/ivd       0.145s
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/paravirt  0.128s
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/plugin    [no test files]
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/plugin/util       0.067s
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/snapshotUtils     0.078s
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/snapshotmgr       0.068s
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/test      [no test files]
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/utils     0.063s
Success!


```

**Does this PR introduce a user-facing change?**:
NONE
```release-note

```
