### PR TITLE
Remove metrics port from backup-driver deployment

### DIFF
--- a/deployment/create-deployment-for-backupdriver-guest.yaml
+++ b/deployment/create-deployment-for-backupdriver-guest.yaml
@@ -31,10 +31,6 @@ spec:
     type: RollingUpdate
   template:
     metadata:
-      annotations:
-        prometheus.io/path: /metrics
-        prometheus.io/port: "8085"
-        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         component: velero
@@ -55,10 +51,6 @@ spec:
         image: dpcpinternal/backup-driver:<backup-driver image tag>
         imagePullPolicy: IfNotPresent
         name: backup-driver
-        ports:
-        - containerPort: 8085
-          name: metrics
-          protocol: TCP
         resources: {}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File

--- a/deployment/create-deployment-for-backupdriver.yaml
+++ b/deployment/create-deployment-for-backupdriver.yaml
@@ -31,10 +31,6 @@ spec:
     type: RollingUpdate
   template:
     metadata:
-      annotations:
-        prometheus.io/path: /metrics
-        prometheus.io/port: "8085"
-        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         component: velero
@@ -55,10 +51,6 @@ spec:
         image: dpcpinternal/backup-driver:<backup-driver image tag>
         imagePullPolicy: IfNotPresent
         name: backup-driver
-        ports:
-        - containerPort: 8085
-          name: metrics
-          protocol: TCP
         resources: {}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File

--- a/deployment/create-deployment-for-plugin.yaml
+++ b/deployment/create-deployment-for-plugin.yaml
@@ -42,10 +42,6 @@ spec:
     type: RollingUpdate
   template:
     metadata:
-      annotations:
-        prometheus.io/path: /metrics
-        prometheus.io/port: "8085"
-        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         component: velero
@@ -72,10 +68,6 @@ spec:
         image: gcr.io/heptio-images/velero:v1.1.0
         imagePullPolicy: IfNotPresent
         name: velero
-        ports:
-        - containerPort: 8085
-          name: metrics
-          protocol: TCP
         resources: {}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File

--- a/pkg/install/deployment.go
+++ b/pkg/install/deployment.go
@@ -96,7 +96,6 @@ func Deployment(namespace string, opts ...podTemplateOption) *appsv1.Deployment 
 						{
 							Name:            "backup-driver",
 							Image:           c.image,
-							Ports:           containerPorts(),
 							ImagePullPolicy: pullPolicy,
 							Command: []string{
 								"/backup-driver",

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -67,17 +67,17 @@ var CRDsList = []string{
 
 // DefaultImage is the default image to use for the Velero deployment and restic daemonset containers.
 var (
-	DefaultDatamgrImage          = imageRegistry() + "/" + constants.DataManagerForPlugin + ":" + imageVersion()
-	DefaultDatamgrPodCPURequest  = "0"
-	DefaultDatamgrPodMemRequest  = "0"
-	DefaultDatamgrPodCPULimit    = "0"
-	DefaultDatamgrPodMemLimit    = "0"
+	DefaultDatamgrImage         = imageRegistry() + "/" + constants.DataManagerForPlugin + ":" + imageVersion()
+	DefaultDatamgrPodCPURequest = "0"
+	DefaultDatamgrPodMemRequest = "0"
+	DefaultDatamgrPodCPULimit   = "0"
+	DefaultDatamgrPodMemLimit   = "0"
 
-	DefaultBackupDriverImage          = imageRegistry() + "/" + constants.BackupDriverForPlugin + ":" + imageVersion()
-	DefaultBackupDriverPodCPURequest  = "0"
-	DefaultBackupDriverPodMemRequest  = "0"
-	DefaultBackupDriverPodCPULimit    = "0"
-	DefaultBackupDriverPodMemLimit    = "0"
+	DefaultBackupDriverImage         = imageRegistry() + "/" + constants.BackupDriverForPlugin + ":" + imageVersion()
+	DefaultBackupDriverPodCPURequest = "0"
+	DefaultBackupDriverPodMemRequest = "0"
+	DefaultBackupDriverPodCPULimit   = "0"
+	DefaultBackupDriverPodMemLimit   = "0"
 )
 
 type PodOptions struct {
@@ -92,7 +92,7 @@ type PodOptions struct {
 	SecretAdd      bool
 	MasterAffinity bool
 	HostNetwork    bool
-	Features	   []string
+	Features       []string
 }
 
 // Use "latest" if the build process didn't supply a version
@@ -121,15 +121,6 @@ func objectMeta(namespace, name string) metav1.ObjectMeta {
 		Name:      name,
 		Namespace: namespace,
 		Labels:    labels(),
-	}
-}
-
-func containerPorts() []corev1.ContainerPort {
-	return []corev1.ContainerPort{
-		{
-			Name:          "metrics",
-			ContainerPort: 8085,
-		},
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes metrics port from backup-driver deployment spec.

**Which issue(s) this PR fixes**:
Fixes # PR 3471190

**Special notes for your reviewer**:
None

**Testing**:
```
❯ make test
running docker: shell
docker run \
                --platform linux/amd64 \
                -e GOFLAGS \
                -i -t \
                --rm \
                -u $(id -u):$(id -g) \
                -v $(pwd)/.libs/vmware-vix-disklib-distrib:/usr/local/vmware-vix-disklib-distrib:delegated \
                -v $(pwd)/.go/pkg:/go/pkg:delegated \
                -v $(pwd)/.go/src:/go/src:delegated \
                -v $(pwd)/.go/std:/go/std:delegated \
                -v $(pwd):/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere:delegated \
                -v "$(pwd)/_output/bin:/output:delegated" \
                -v $(pwd)/.go/std/linux/amd64:/usr/local/go/pkg/linux/amd64_static:delegated \
                -v "$(pwd)/.go/go-build:/.cache/go-build:delegated" \
                -e CGO_ENABLED=1 \
                -e GOPATH=/go \
                -w /go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere \
                golang:1.18 \
                /bin/sh -c '     VDDK_LIBS=github.com/vmware-tanzu/velero-plugin-for-vsphere/.libs/vmware-vix-disklib-distrib/lib64      TARGETS=./pkg/...      TIMEOUT=300s      VERBOSE=      DISABLE_CACHE=      RUN_SINGLE_CASE=      hack/test.sh'
Running tests: ./pkg/...
go test ./pkg/... -timeout=300s
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/apis/backupdriver/v1alpha1        [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/apis/datamover/v1alpha1   [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/backupdriver      [no test files]
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/backuprepository  (cached)
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/builder   [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/buildinfo [no test files]
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/cmd       0.085s
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/cmd/backupdriver  [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/cmd/backupdriver/cli/install      [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/cmd/backupdriver/cli/server       [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/cmd/datamgr       [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/cmd/datamgr/cli/install   [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/cmd/datamgr/cli/server    [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/common/config     [no test files]
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/common/vsphere    (cached)
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/constants [no test files]
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/controller        (cached)
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/dataMover [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned     [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/fake        [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/scheme      [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/typed/backupdriver/v1alpha1 [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/typed/backupdriver/v1alpha1/fake    [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/typed/datamover/v1alpha1    [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/clientset/versioned/typed/datamover/v1alpha1/fake       [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/crds    [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/informers/externalversions      [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/informers/externalversions/backupdriver [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/informers/externalversions/backupdriver/v1alpha1        [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/informers/externalversions/datamover    [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/informers/externalversions/datamover/v1alpha1   [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/informers/externalversions/internalinterfaces   [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/listers/backupdriver/v1alpha1   [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/generated/listers/datamover/v1alpha1      [no test files]
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/install   [no test files]
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/ivd       (cached)
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/paravirt  (cached)
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/plugin    [no test files]
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/plugin/util       (cached)
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/snapshotUtils     (cached)
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/snapshotmgr       (cached)
?       github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/test      [no test files]
ok      github.com/vmware-tanzu/velero-plugin-for-vsphere/pkg/utils     (cached)
Success!


❯ REGISTRY=cns-docker-dev-local.usw5.packages.broadcom.com/dkinni VERSION=rem_metric_port_v1 make container
making: datamgr
/Library/Developer/CommandLineTools/usr/bin/make build BIN=data-manager-for-plugin VERSION=rem_metric_port_v1
skip copying astrolabe as it is not available at /Users/dkinni/go/src/github.com/vmware-tanzu/astrolabe
building: _output/bin/linux/amd64/data-manager-for-plugin
/Library/Developer/CommandLineTools/usr/bin/make shell CMD="-c '\
                GOOS=linux \
                GOARCH=amd64 \
                REGISTRY=cns-docker-dev-local.usw5.packages.broadcom.com/dkinni \
                VERSION=rem_metric_port_v1 \
                PKG=github.com/vmware-tanzu/velero-plugin-for-vsphere \
                BIN=data-manager-for-plugin \
                GIT_SHA=0d8dd16add9baf258847b8853e982c1c9c234994 \
                GIT_DIRTY=\"\" \
                OUTPUT_DIR=/output/linux/amd64 \
                GO111MODULE=on \
                GOFLAGS=-mod=readonly \
                ./hack/build.sh'"
running docker: shell
docker run \
                --platform linux/amd64 \
                -e GOFLAGS \
                -i -t \
                --rm \
                -u $(id -u):$(id -g) \
                -v $(pwd)/.libs/vmware-vix-disklib-distrib:/usr/local/vmware-vix-disklib-distrib:delegated \
                -v $(pwd)/.go/pkg:/go/pkg:delegated \
                -v $(pwd)/.go/src:/go/src:delegated \
                -v $(pwd)/.go/std:/go/std:delegated \
                -v $(pwd):/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere:delegated \
                -v "$(pwd)/_output/bin:/output:delegated" \
                -v $(pwd)/.go/std/linux/amd64:/usr/local/go/pkg/linux/amd64_static:delegated \
                -v "$(pwd)/.go/go-build:/.cache/go-build:delegated" \
                -e CGO_ENABLED=1 \
                -e GOPATH=/go \
                -w /go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere \
                golang:1.18 \
                /bin/sh -c '    GOOS=linux      GOARCH=amd64    REGISTRY=cns-docker-dev-local.usw5.packages.broadcom.com/dkinni         VERSION=rem_metric_port_v1      PKG=github.com/vmware-tanzu/velero-plugin-for-vsphere   BIN=data-manager-for-plugin     GIT_SHA=0d8dd16add9baf258847b8853e982c1c9c234994       GIT_DIRTY=""     OUTPUT_DIR=/output/linux/amd64  GO111MODULE=on  GOFLAGS=-mod=readonly   ./hack/build.sh'
making: backup-driver
/Library/Developer/CommandLineTools/usr/bin/make build BIN=backup-driver VERSION=rem_metric_port_v1
skip copying astrolabe as it is not available at /Users/dkinni/go/src/github.com/vmware-tanzu/astrolabe
building: _output/bin/linux/amd64/backup-driver
/Library/Developer/CommandLineTools/usr/bin/make shell CMD="-c '\
                GOOS=linux \
                GOARCH=amd64 \
                REGISTRY=cns-docker-dev-local.usw5.packages.broadcom.com/dkinni \
                VERSION=rem_metric_port_v1 \
                PKG=github.com/vmware-tanzu/velero-plugin-for-vsphere \
                BIN=backup-driver \
                GIT_SHA=0d8dd16add9baf258847b8853e982c1c9c234994 \
                GIT_DIRTY=\"\" \
                OUTPUT_DIR=/output/linux/amd64 \
                GO111MODULE=on \
                GOFLAGS=-mod=readonly \
                ./hack/build.sh'"
running docker: shell
docker run \
                --platform linux/amd64 \
                -e GOFLAGS \
                -i -t \
                --rm \
                -u $(id -u):$(id -g) \
                -v $(pwd)/.libs/vmware-vix-disklib-distrib:/usr/local/vmware-vix-disklib-distrib:delegated \
                -v $(pwd)/.go/pkg:/go/pkg:delegated \
                -v $(pwd)/.go/src:/go/src:delegated \
                -v $(pwd)/.go/std:/go/std:delegated \
                -v $(pwd):/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere:delegated \
                -v "$(pwd)/_output/bin:/output:delegated" \
                -v $(pwd)/.go/std/linux/amd64:/usr/local/go/pkg/linux/amd64_static:delegated \
                -v "$(pwd)/.go/go-build:/.cache/go-build:delegated" \
                -e CGO_ENABLED=1 \
                -e GOPATH=/go \
                -w /go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere \
                golang:1.18 \
                /bin/sh -c '    GOOS=linux      GOARCH=amd64    REGISTRY=cns-docker-dev-local.usw5.packages.broadcom.com/dkinni         VERSION=rem_metric_port_v1      PKG=github.com/vmware-tanzu/velero-plugin-for-vsphere   BIN=backup-driver       GIT_SHA=0d8dd16add9baf258847b8853e982c1c9c234994        GIT_DIRTY=""    OUTPUT_DIR=/output/linux/amd64  GO111MODULE=on  GOFLAGS=-mod=readonly   ./hack/build.sh'
making: plugin
/Library/Developer/CommandLineTools/usr/bin/make build BIN=velero-plugin-for-vsphere VERSION=rem_metric_port_v1
skip copying astrolabe as it is not available at /Users/dkinni/go/src/github.com/vmware-tanzu/astrolabe
building: _output/bin/linux/amd64/velero-plugin-for-vsphere
/Library/Developer/CommandLineTools/usr/bin/make shell CMD="-c '\
                GOOS=linux \
                GOARCH=amd64 \
                REGISTRY=cns-docker-dev-local.usw5.packages.broadcom.com/dkinni \
                VERSION=rem_metric_port_v1 \
                PKG=github.com/vmware-tanzu/velero-plugin-for-vsphere \
                BIN=velero-plugin-for-vsphere \
                GIT_SHA=0d8dd16add9baf258847b8853e982c1c9c234994 \
                GIT_DIRTY=\"\" \
                OUTPUT_DIR=/output/linux/amd64 \
                GO111MODULE=on \
                GOFLAGS=-mod=readonly \
                ./hack/build.sh'"
running docker: shell
docker run \
                --platform linux/amd64 \
                -e GOFLAGS \
                -i -t \
                --rm \
                -u $(id -u):$(id -g) \
                -v $(pwd)/.libs/vmware-vix-disklib-distrib:/usr/local/vmware-vix-disklib-distrib:delegated \
                -v $(pwd)/.go/pkg:/go/pkg:delegated \
                -v $(pwd)/.go/src:/go/src:delegated \
                -v $(pwd)/.go/std:/go/std:delegated \
                -v $(pwd):/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere:delegated \
                -v "$(pwd)/_output/bin:/output:delegated" \
                -v $(pwd)/.go/std/linux/amd64:/usr/local/go/pkg/linux/amd64_static:delegated \
                -v "$(pwd)/.go/go-build:/.cache/go-build:delegated" \
                -e CGO_ENABLED=1 \
                -e GOPATH=/go \
                -w /go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere \
                golang:1.18 \
                /bin/sh -c '    GOOS=linux      GOARCH=amd64    REGISTRY=cns-docker-dev-local.usw5.packages.broadcom.com/dkinni         VERSION=rem_metric_port_v1      PKG=github.com/vmware-tanzu/velero-plugin-for-vsphere   BIN=velero-plugin-for-vsphere   GIT_SHA=0d8dd16add9baf258847b8853e982c1c9c234994       GIT_DIRTY=""     OUTPUT_DIR=/output/linux/amd64  GO111MODULE=on  GOFLAGS=-mod=readonly   ./hack/build.sh'
making: vsphere-astrolabe
/Library/Developer/CommandLineTools/usr/bin/make build BIN=vsphere-astrolabe VERSION=rem_metric_port_v1
skip copying astrolabe as it is not available at /Users/dkinni/go/src/github.com/vmware-tanzu/astrolabe
building: _output/bin/linux/amd64/vsphere-astrolabe
/Library/Developer/CommandLineTools/usr/bin/make shell CMD="-c '\
                GOOS=linux \
                GOARCH=amd64 \
                REGISTRY=cns-docker-dev-local.usw5.packages.broadcom.com/dkinni \
                VERSION=rem_metric_port_v1 \
                PKG=github.com/vmware-tanzu/velero-plugin-for-vsphere \
                BIN=vsphere-astrolabe \
                GIT_SHA=0d8dd16add9baf258847b8853e982c1c9c234994 \
                GIT_DIRTY=\"\" \
                OUTPUT_DIR=/output/linux/amd64 \
                GO111MODULE=on \
                GOFLAGS=-mod=readonly \
                ./hack/build.sh'"
running docker: shell
docker run \
                --platform linux/amd64 \
                -e GOFLAGS \
                -i -t \
                --rm \
                -u $(id -u):$(id -g) \
                -v $(pwd)/.libs/vmware-vix-disklib-distrib:/usr/local/vmware-vix-disklib-distrib:delegated \
                -v $(pwd)/.go/pkg:/go/pkg:delegated \
                -v $(pwd)/.go/src:/go/src:delegated \
                -v $(pwd)/.go/std:/go/std:delegated \
                -v $(pwd):/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere:delegated \
                -v "$(pwd)/_output/bin:/output:delegated" \
                -v $(pwd)/.go/std/linux/amd64:/usr/local/go/pkg/linux/amd64_static:delegated \
                -v "$(pwd)/.go/go-build:/.cache/go-build:delegated" \
                -e CGO_ENABLED=1 \
                -e GOPATH=/go \
                -w /go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere \
                golang:1.18 \
                /bin/sh -c '    GOOS=linux      GOARCH=amd64    REGISTRY=cns-docker-dev-local.usw5.packages.broadcom.com/dkinni         VERSION=rem_metric_port_v1      PKG=github.com/vmware-tanzu/velero-plugin-for-vsphere   BIN=vsphere-astrolabe   GIT_SHA=0d8dd16add9baf258847b8853e982c1c9c234994        GIT_DIRTY=""    OUTPUT_DIR=/output/linux/amd64  GO111MODULE=on  GOFLAGS=-mod=readonly   ./hack/build.sh'
cp $(pwd)/scripts/install.sh _output/bin/linux/amd64
/Library/Developer/CommandLineTools/usr/bin/make build-container IMAGE=cns-docker-dev-local.usw5.packages.broadcom.com/dkinni/velero-plugin-for-vsphere DOCKERFILE=Dockerfile-plugin VERSION=rem_metric_port_v1
mkdir -p _output/bin/linux/amd64/lib/vmware-vix-disklib/lib64
cp -R /Users/dkinni/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/.libs/vmware-vix-disklib-distrib/lib64/* _output/bin/linux/amd64/lib/vmware-vix-disklib/lib64
# Some of the libraries have the executable bit set and this causes plugin startup to fail
chmod 644 _output/bin/linux/amd64/lib/vmware-vix-disklib/lib64/*
container: cns-docker-dev-local.usw5.packages.broadcom.com/dkinni/velero-plugin-for-vsphere:rem_metric_port_v1
cp Dockerfile-plugin _output/bin/linux/amd64/Dockerfile-plugin
docker build --platform linux/amd64 -t cns-docker-dev-local.usw5.packages.broadcom.com/dkinni/velero-plugin-for-vsphere:rem_metric_port_v1 -f _output/bin/linux/amd64/Dockerfile-plugin _output
[+] Building 14.7s (14/14) FINISHED                                                                                                                                                                                                                                                                docker:desktop-linux
 => [internal] load build definition from Dockerfile-plugin                                                                                                                                                                                                                                                        0.0s
 => => transferring dockerfile: 1.03kB                                                                                                                                                                                                                                                                             0.0s
 => [internal] load metadata for docker.io/library/photon:5.0                                                                                                                                                                                                                                                      1.8s
 => [auth] library/photon:pull token for registry-1.docker.io                                                                                                                                                                                                                                                      0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                                                                                  0.0s
 => => transferring context: 2B                                                                                                                                                                                                                                                                                    0.0s
 => [1/8] FROM docker.io/library/photon:5.0@sha256:027f9eed364392f9abf8a60fea5e6883d7b4b6a66d09e822de10a734eb9bb6a0                                                                                                                                                                                                0.0s
 => => resolve docker.io/library/photon:5.0@sha256:027f9eed364392f9abf8a60fea5e6883d7b4b6a66d09e822de10a734eb9bb6a0                                                                                                                                                                                                0.0s
 => [internal] load build context                                                                                                                                                                                                                                                                                  3.1s
 => => transferring context: 311.96MB                                                                                                                                                                                                                                                                              3.0s
 => CACHED [2/8] RUN tdnf -y upgrade && tdnf clean all                                                                                                                                                                                                                                                             0.0s
 => [3/8] ADD /bin/linux/amd64/velero-* /plugins/                                                                                                                                                                                                                                                                  0.3s
 => [4/8] ADD /bin/linux/amd64/data-* /                                                                                                                                                                                                                                                                            0.2s
 => [5/8] ADD /bin/linux/amd64/backup-driver* /                                                                                                                                                                                                                                                                    0.1s
 => [6/8] COPY /bin/linux/amd64/install.sh /scripts/                                                                                                                                                                                                                                                               0.0s
 => [7/8] COPY /bin/linux/amd64/lib/vmware-vix-disklib/lib64/* /plugins/                                                                                                                                                                                                                                           0.2s
 => [8/8] RUN ["chmod", "+x", "/scripts/install.sh"]                                                                                                                                                                                                                                                               0.2s
 => exporting to image                                                                                                                                                                                                                                                                                             6.3s
 => => exporting layers                                                                                                                                                                                                                                                                                            4.3s
 => => exporting manifest sha256:e3c4430b36f6ffc3bf7d7e8efe843f37573690c8310882cfe575920aa687ef6a                                                                                                                                                                                                                  0.0s
 => => exporting config sha256:ae3999b70e0be3c53344d38acb4ea11f47c9f8cc9a2179af949f0b6e8236a100                                                                                                                                                                                                                    0.0s
 => => exporting attestation manifest sha256:ad58055746139fb1ca4a075045cacb5eefd8873afef97fab15326aba16b4bd40                                                                                                                                                                                                      0.0s
 => => exporting manifest list sha256:9e20b98c4673c3915f045e9e84f804f0981af4e368050f4c192c9c37605ba13b                                                                                                                                                                                                             0.0s
 => => naming to cns-docker-dev-local.usw5.packages.broadcom.com/dkinni/velero-plugin-for-vsphere:rem_metric_port_v1                                                                                                                                                                                               0.0s
 => => unpacking to cns-docker-dev-local.usw5.packages.broadcom.com/dkinni/velero-plugin-for-vsphere:rem_metric_port_v1                                                                                                                                                                                            1.9s

View build details: docker-desktop://dashboard/build/desktop-linux/desktop-linux/jqgqo3cgvr8714x5ptrlyfghr

What's next:
    View a summary of image vulnerabilities and recommendations → docker scout quickview 
/Library/Developer/CommandLineTools/usr/bin/make build-container BIN=data-manager-for-plugin IMAGE=cns-docker-dev-local.usw5.packages.broadcom.com/dkinni/data-manager-for-plugin DOCKERFILE=Dockerfile-datamgr VERSION=rem_metric_port_v1
mkdir -p _output/bin/linux/amd64/lib/vmware-vix-disklib/lib64
cp -R /Users/dkinni/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/.libs/vmware-vix-disklib-distrib/lib64/* _output/bin/linux/amd64/lib/vmware-vix-disklib/lib64
# Some of the libraries have the executable bit set and this causes plugin startup to fail
chmod 644 _output/bin/linux/amd64/lib/vmware-vix-disklib/lib64/*
container: cns-docker-dev-local.usw5.packages.broadcom.com/dkinni/data-manager-for-plugin:rem_metric_port_v1
cp Dockerfile-datamgr _output/bin/linux/amd64/Dockerfile-datamgr
docker build --platform linux/amd64 -t cns-docker-dev-local.usw5.packages.broadcom.com/dkinni/data-manager-for-plugin:rem_metric_port_v1 -f _output/bin/linux/amd64/Dockerfile-datamgr _output
[+] Building 7.1s (9/9) FINISHED                                                                                                                                                                                                                                                                   docker:desktop-linux
 => [internal] load build definition from Dockerfile-datamgr                                                                                                                                                                                                                                                       0.0s
 => => transferring dockerfile: 822B                                                                                                                                                                                                                                                                               0.0s
 => [internal] load metadata for docker.io/library/photon:5.0                                                                                                                                                                                                                                                      0.6s
 => [internal] load .dockerignore                                                                                                                                                                                                                                                                                  0.0s
 => => transferring context: 2B                                                                                                                                                                                                                                                                                    0.0s
 => [1/4] FROM docker.io/library/photon:5.0@sha256:027f9eed364392f9abf8a60fea5e6883d7b4b6a66d09e822de10a734eb9bb6a0                                                                                                                                                                                                0.0s
 => => resolve docker.io/library/photon:5.0@sha256:027f9eed364392f9abf8a60fea5e6883d7b4b6a66d09e822de10a734eb9bb6a0                                                                                                                                                                                                0.0s
 => [internal] load build context                                                                                                                                                                                                                                                                                  0.7s
 => => transferring context: 62.27MB                                                                                                                                                                                                                                                                               0.7s
 => CACHED [2/4] RUN tdnf -y upgrade && tdnf clean all                                                                                                                                                                                                                                                             0.0s
 => [3/4] ADD /bin/linux/amd64/data-* /datamgr                                                                                                                                                                                                                                                                     0.4s
 => [4/4] COPY /bin/linux/amd64/lib/vmware-vix-disklib/lib64/* /vddkLibs/                                                                                                                                                                                                                                          0.2s
 => exporting to image                                                                                                                                                                                                                                                                                             5.1s
 => => exporting layers                                                                                                                                                                                                                                                                                            4.2s
 => => exporting manifest sha256:ae5c3ecb263e6efae6f1c3ac4c1cff0058f7d668db43efa66372a91a020e832a                                                                                                                                                                                                                  0.0s
 => => exporting config sha256:16a77b40610eef13cadc16785ced826a90b5e2633c84cdd786bc12603ce63b71                                                                                                                                                                                                                    0.0s
 => => exporting attestation manifest sha256:15188b2ba57ef53cc2330c5a5ada9e5c0bd8ca8aaec2f7ace523904c2a126fd1                                                                                                                                                                                                      0.0s
 => => exporting manifest list sha256:8d50696d79e11183f5a2b676fbcb85e8beb0ef3d8a0cf77097a786e771522457                                                                                                                                                                                                             0.0s
 => => naming to cns-docker-dev-local.usw5.packages.broadcom.com/dkinni/data-manager-for-plugin:rem_metric_port_v1                                                                                                                                                                                                 0.0s
 => => unpacking to cns-docker-dev-local.usw5.packages.broadcom.com/dkinni/data-manager-for-plugin:rem_metric_port_v1                                                                                                                                                                                              0.9s

View build details: docker-desktop://dashboard/build/desktop-linux/desktop-linux/wjvxe8d8rlgcz2elt29elhkeh

What's next:
    View a summary of image vulnerabilities and recommendations → docker scout quickview 
/Library/Developer/CommandLineTools/usr/bin/make build-container BIN=backup-driver IMAGE=cns-docker-dev-local.usw5.packages.broadcom.com/dkinni/backup-driver DOCKERFILE=Dockerfile-backup-driver VERSION=rem_metric_port_v1
mkdir -p _output/bin/linux/amd64/lib/vmware-vix-disklib/lib64
cp -R /Users/dkinni/go/src/github.com/vmware-tanzu/velero-plugin-for-vsphere/.libs/vmware-vix-disklib-distrib/lib64/* _output/bin/linux/amd64/lib/vmware-vix-disklib/lib64
# Some of the libraries have the executable bit set and this causes plugin startup to fail
chmod 644 _output/bin/linux/amd64/lib/vmware-vix-disklib/lib64/*
container: cns-docker-dev-local.usw5.packages.broadcom.com/dkinni/backup-driver:rem_metric_port_v1
cp Dockerfile-backup-driver _output/bin/linux/amd64/Dockerfile-backup-driver
docker build --platform linux/amd64 -t cns-docker-dev-local.usw5.packages.broadcom.com/dkinni/backup-driver:rem_metric_port_v1 -f _output/bin/linux/amd64/Dockerfile-backup-driver _output
[+] Building 6.6s (9/9) FINISHED                                                                                                                                                                                                                                                                   docker:desktop-linux
 => [internal] load build definition from Dockerfile-backup-driver                                                                                                                                                                                                                                                 0.0s
 => => transferring dockerfile: 841B                                                                                                                                                                                                                                                                               0.0s
 => [internal] load metadata for docker.io/library/photon:5.0                                                                                                                                                                                                                                                      0.7s
 => [internal] load .dockerignore                                                                                                                                                                                                                                                                                  0.0s
 => => transferring context: 2B                                                                                                                                                                                                                                                                                    0.0s
 => [1/4] FROM docker.io/library/photon:5.0@sha256:027f9eed364392f9abf8a60fea5e6883d7b4b6a66d09e822de10a734eb9bb6a0                                                                                                                                                                                                0.0s
 => => resolve docker.io/library/photon:5.0@sha256:027f9eed364392f9abf8a60fea5e6883d7b4b6a66d09e822de10a734eb9bb6a0                                                                                                                                                                                                0.0s
 => [internal] load build context                                                                                                                                                                                                                                                                                  1.5s
 => => transferring context: 142.48MB                                                                                                                                                                                                                                                                              1.5s
 => CACHED [2/4] RUN tdnf -y upgrade && tdnf clean all                                                                                                                                                                                                                                                             0.0s
 => CACHED [3/4] COPY /bin/linux/amd64/lib/vmware-vix-disklib/lib64/* /vddkLibs/                                                                                                                                                                                                                                   0.0s
 => [4/4] ADD /bin/linux/amd64/backup-driver* /backup-driver                                                                                                                                                                                                                                                       0.6s
 => exporting to image                                                                                                                                                                                                                                                                                             3.7s
 => => exporting layers                                                                                                                                                                                                                                                                                            3.2s
 => => exporting manifest sha256:e16cdd933c58001b2a53eb18e4a297e5a203c7b885914a7ae0fb1dd2d1a60022                                                                                                                                                                                                                  0.0s
 => => exporting config sha256:b66fd99b4501373aca11f64e3ebb89e7c0a946ec46d3994077f3328bf516179f                                                                                                                                                                                                                    0.0s
 => => exporting attestation manifest sha256:bba2d19d47f1e63d66caaf45bd6129ee5711867c051a8040a5630d1156573508                                                                                                                                                                                                      0.0s
 => => exporting manifest list sha256:567f11e0d0a3c798e3f9b3d44f1e4ff5083c96a773233f5b0bf7f0d8959e805b                                                                                                                                                                                                             0.0s
 => => naming to cns-docker-dev-local.usw5.packages.broadcom.com/dkinni/backup-driver:rem_metric_port_v1                                                                                                                                                                                                           0.0s
 => => unpacking to cns-docker-dev-local.usw5.packages.broadcom.com/dkinni/backup-driver:rem_metric_port_v1 

```

Installed on Supervisor:
```
root@420eaa73f3809ee9cb625cd3af7f353a [ ~ ]# kubectl -n test-velero-service-404 get pods
NAME                             READY   STATUS    RESTARTS   AGE
backup-driver-6f8846bb75-hxspw   1/1     Running   0          25s
nginx-v1                         1/1     Running   0          79m
velero-555444675b-g72kf          1/1     Running   0          95s
```

**Does this PR introduce a user-facing change?**:
None
```release-note

```
